### PR TITLE
feat: Windows raw CreateProcessW backend — fd>=3 and independent executable()+commandline()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /target
 **/*.rs.bk
 
-# Cargo.lock IS committed (matches the repo convention; required for CI `--locked`).
-
-# agent scratch (specs/plans are force-added in git)
-.tmp/
-.superpowers/
+# Claude Code
+.claude/*.local.*
+CLAUDE.local.md

--- a/.tmp/claude/superpowers/plans/2026-07-18-plan12-windows-raw-backend.md
+++ b/.tmp/claude/superpowers/plans/2026-07-18-plan12-windows-raw-backend.md
@@ -1,0 +1,551 @@
+# Plan 12 — Windows raw `CreateProcessW` backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the two Windows-only `Unsupported` rejections `std::process` cannot express — `fd(n≥3)` and `executable()`+`commandline()` (plus the `executable()`-alone argv[0] degradation) — via a raw `CreateProcessW` backend on both the sync and async surfaces.
+
+**Architecture:** A `#[cfg(windows)]` raw spawn path, routed ONLY when the std path can't express the request (`executable()` set OR any fd ≥ 3). A process-handle enum (`ProcHandle` sync / `ProcSource` async) lets the raw child coexist with `SharedChild`/`tokio::process::Child`. EVERY raw spawn sets `STARTF_USESTDHANDLES` + `hStd*` (wires 0/1/2) and a `STARTUPINFOEX` `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` (scopes inheritance to exactly its own child ends); fd ≥ 3 additionally rides the MSVCRT `lpReserved2` fd-table. `lpApplicationName` is set independently of `lpCommandLine`, only when `executable()` is set. A crate-wide, poison-tolerant spawn mutex serializes the brief mark-inheritable→spawn window across raw AND std paths. Containment reuses `attach_job`; sync and async raw waits share one handle-based cancellable primitive.
+
+**Tech Stack:** Rust (MSRV 1.87). Existing `windows` 0.62 dep (add Threading/attribute-list/wait/`Win32_Storage_FileSystem` items). No new crate deps (a `which` evaluation is recorded in Task 3; a small local resolver is used). Existing `shared_child`, `tokio`, `libc`.
+
+## Global Constraints
+
+- Spec: `.tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md`.
+- **Windows is the PRIMARY runtime** (host is Windows 11): after each task run `cargo test --locked` and `cargo test --locked --features tokio` on the host. **Unix untouched** — after each task also run the WSL suite: `MSYS_NO_PATHCONV=1 wsl.exe -d Ubuntu-24.04 -- bash -lc 'cd /mnt/c/Users/bindreams/src/subprocess && export CARGO_TARGET_DIR=/tmp/sp-target && cargo test --locked --features tokio && cargo test --locked'`. Pipe long outputs to files under `.tmp/claude/`; never `| tail`.
+- **No-time-sync test discipline:** exits and wait-cancellation are proven by pipe EOF, an inspected `ExitStatus`, or an event-driven channel/`Notify` signal — never a sleep/poll/wall-clock. No arbitrary retry/loop caps. Tests never skip on a missing dependency: the one console-adjacent case is made deterministic via the `NUL` char device (no console provisioning needed).
+- **Routing invariant:** `needs_raw == (cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3))`. When false, the std/tokio path is byte-for-byte unchanged.
+- **Inheritance safety:** the raw path holds a crate-wide **poison-tolerant** spawn mutex (`crate::child::spawn::spawn_lock()`, `.lock().unwrap_or_else(|e| e.into_inner())`) across the mark-inheritable → `CreateProcessW` → **close-child-ends** window, and the child ends are closed BEFORE the guard is released on EVERY exit path (success and error). The std/tokio paths take the SAME lock around their `spawn()` call. Every raw spawn passes `bInheritHandles=TRUE` scoped by a `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` naming exactly its child ends. (Residual race vs. spawns outside this crate is documented, matching std's own residual.)
+- **`executable()` resolution rule (a deliberate, documented rule — NOT byte-parity with CreateProcessW's full 6-location search):** an absolute+existing `executable()` is used as-is; a bare/relative name is resolved against **[parent cwd, then each PATH dir]**, appending `.exe` when it has no extension, first hit wins. Only set on the raw path when `executable()` is set; the fd ≥ 3-only route leaves `lpApplicationName` NULL so `CreateProcessW` resolves `lpCommandLine`'s first token itself (matching std). `.bat`/`.cmd` programs are a loud `Unsupported` on the raw path too (`reject_batch_program`, CVE-2024-24576), checked BEFORE resolution.
+- **Loud, never silent:** DETECTABLE cases stay loud `Unsupported` and are tested — `Stdio::inherit()` on fd ≥ 3 (also hardened in `inherit_end`), chained merges, `.bat`/`.cmd`. An oversized fd-table (checked **analytically before allocation**, `> u16::MAX` bytes), any embedded-NUL in a program/arg/**cwd**/env string, and a `SetHandleInformation` failure are loud `Error`s. Every discarded FFI `Result` in a Drop/best-effort path carries a `log::debug!` (and `debug_assert!` only where a panic cannot poison a held lock).
+- **fd ≥ 3 is MSVC/UCRT-children faithful** (spec §divergence). For a non-MSVCRT child the handles are still inherited but that foreign CRT won't expose them as numbered fds — inherent, **documented**, NOT a detectable rejection.
+- **Unsafe hygiene:** every `unsafe` block carries a `// SAFETY:` note. All owned handles are RAII (`OwnedHandle`/`ChildEnd`/`ParentEnd`).
+- Before every commit: `cargo +stable fmt --check`; `cargo clippy --locked --features tokio --all-targets`; `cargo clippy --locked --all-targets`; `prek run --all-files` (docs LF; normalize before `git add`).
+- Single-line commit messages. Rust style: `foo.rs` + `foo/` modules; unit tests in sibling `*_tests.rs`.
+- Branch `azhukova/<issue#>`; never commit to `main`. Never `git add -A` — stage explicit paths; `git add -f` the plan/spec under `.tmp/claude/superpowers/`.
+
+---
+
+### Task 1: testbin fd-relay + argv0 + isatty report modes
+
+**Files:** Modify `testbin/main.rs`, `Cargo.toml` (windows-target `libc` for the testbin), `tests/raw_windows.rs` (new)
+
+**Interfaces (testbin CLI):** `read-fd <n>` (copy fd n → stdout); `write-fd <n> <text>`; `argv0-report` (`argv0=<argv[0]>` + `image=<current_exe()>`); `isatty-fd <n>` (`isatty=<0|1>` via `libc::isatty(n)`).
+
+- [ ] **Step 1: Read `testbin/main.rs`** to match its `args[1]` dispatch.
+
+- [ ] **Step 2: Write the failing test** — new `tests/raw_windows.rs`:
+
+```rust
+#![cfg(windows)]
+mod common;
+#[test]
+fn testbin_argv0_report_echoes_argv0() {
+    let out = std::process::Command::new(common::testbin())
+        .args(["subprocess_testbin", "argv0-report"]).output().expect("spawn");
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(s.contains("argv0=subprocess_testbin") && s.contains("image="), "got: {s}");
+}
+```
+
+- [ ] **Step 3: Run it, expect FAIL** — `cargo test --locked --test raw_windows testbin_argv0_report`.
+
+- [ ] **Step 4: Implement the modes** — CRT-fd → `File`:
+
+```rust
+#[cfg(windows)]
+fn file_from_fd(fd: i32) -> std::fs::File {
+    use std::os::windows::io::{FromRawHandle, RawHandle};
+    let h = unsafe { libc::get_osfhandle(fd) };
+    assert!(h != -1, "fd {fd} not wired into the CRT fd table");
+    unsafe { std::fs::File::from_raw_handle(h as RawHandle) }
+}
+#[cfg(unix)]
+fn file_from_fd(fd: i32) -> std::fs::File {
+    use std::os::fd::{FromRawFd, RawFd};
+    unsafe { std::fs::File::from_raw_fd(fd as RawFd) }
+}
+```
+
+`read-fd`=`io::copy(fd→stdout)`; `write-fd`=write; `argv0-report`=the two lines; `isatty-fd <n>`=`println!("isatty={}", unsafe { libc::isatty(n) })`. `std::mem::forget` each `File` after use.
+
+- [ ] **Step 5: Run tests, expect PASS**; then `cargo test --locked`.
+
+- [ ] **Step 6: Commit** — `git add testbin/main.rs Cargo.toml tests/raw_windows.rs && git commit -m "test: testbin fd-relay + argv0 + isatty modes for the raw backend"`
+
+---
+
+### Task 2: MSVCRT `lpReserved2` fd-table encoder + device classifier
+
+**Files:** Create `src/child/spawn/windows_raw.rs` (module root, `#[cfg(windows)]`), `src/child/spawn/windows_raw/crt_fds.rs` (+ `crt_fds_tests.rs`)
+
+**Interfaces:**
+- `enum FdKind { Pipe, File, CharDev }`; `pub(crate) fn classify(h: HANDLE) -> Result<FdKind, Error>` — `GetFileType`: `FILE_TYPE_PIPE→Pipe`, `FILE_TYPE_CHAR→CharDev`, `FILE_TYPE_DISK→File`; on `FILE_TYPE_UNKNOWN` inspect `GetLastError` — nonzero → `Error::Io`, `NO_ERROR` → `File`.
+- `pub(crate) struct FdTable { pub bytes: Vec<u8>, pub handles: Vec<HANDLE> }`; `pub(crate) fn encode(entries:&BTreeMap<Fd,(HANDLE,FdKind)>) -> FdTable`. `pub(crate) fn encoded_len(maxfd: i32) -> usize` computed with **overflow-safe** arithmetic — `usize::try_from(maxfd).ok().and_then(|m| m.checked_add(1)).and_then(|n| n.checked_mul(1 + size_of::<HANDLE>())).and_then(|x| x.checked_add(4)).unwrap_or(usize::MAX)` — so an `i32::MAX` fd or a 32-bit `usize` multiply saturates to `usize::MAX` and `table_fits` cleanly rejects (never a wrap-to-small that lets a giant `encode` allocation through). `pub(crate) fn table_fits(byte_len: usize) -> bool` (`<= u16::MAX`).
+
+- [ ] **Step 1: Write the failing tests** — `crt_fds_tests.rs` (layout + size-cap boundary + **`classify` on an invalid handle**):
+
+```rust
+use super::*;
+use std::collections::BTreeMap;
+use crate::stdio::Fd;
+const FOPEN: u8 = 0x01; const FPIPE: u8 = 0x08; const HSZ: usize = std::mem::size_of::<*mut core::ffi::c_void>();
+fn h(v: isize) -> windows::Win32::Foundation::HANDLE { windows::Win32::Foundation::HANDLE(v as _) }
+
+#[test]
+fn encodes_count_flags_and_handles_for_fd3() {
+    let mut m = BTreeMap::new();
+    for (n,v) in [(0i32,10isize),(1,11),(2,12)] { m.insert(Fd::from_raw(n),(h(v),FdKind::CharDev)); }
+    m.insert(Fd::from_raw(3),(h(99),FdKind::Pipe));
+    let t = encode(&m);
+    assert_eq!(&t.bytes[0..4], &4i32.to_le_bytes());
+    assert_eq!(t.bytes[4+3] & (FOPEN|FPIPE), FOPEN|FPIPE);
+    assert_eq!(t.bytes.len(), 4 + 4 + 4*HSZ);
+    assert_eq!(t.bytes.len(), encoded_len(3));
+    assert_eq!(t.handles.len(), 4);
+}
+#[test]
+fn interior_gap_is_invalid_handle_and_zero_flag() {
+    let mut m = BTreeMap::new();
+    m.insert(Fd::from_raw(3),(h(30),FdKind::Pipe)); m.insert(Fd::from_raw(5),(h(50),FdKind::File));
+    let t = encode(&m);
+    assert_eq!(&t.bytes[0..4], &6i32.to_le_bytes());
+    assert_eq!(t.bytes[4+4], 0);
+    let off = 4 + 6 + 4*HSZ;
+    assert_eq!(&t.bytes[off..off+HSZ], &(-1isize as usize).to_ne_bytes()[..]);
+    assert_eq!(t.handles.len(), 2);
+}
+#[test]
+fn cap_computed_len_boundary_and_overflow_safe() {
+    assert!(table_fits(encoded_len(10)));
+    // exact boundary: the largest maxfd whose encoded_len <= u16::MAX fits; the next does not.
+    let hsz = std::mem::size_of::<*mut core::ffi::c_void>();
+    let max_n = (u16::MAX as usize - 4) / (1 + hsz);       // N slots fit
+    assert!(table_fits(encoded_len((max_n - 1) as i32)));
+    assert!(!table_fits(encoded_len((max_n + 8) as i32)));
+    // overflow-safe: i32::MAX must saturate, not panic/wrap, and cleanly reject.
+    assert_eq!(encoded_len(i32::MAX), usize::MAX);
+    assert!(!table_fits(encoded_len(i32::MAX)));
+}
+#[test]
+fn classify_invalid_handle_is_error() {
+    // An invalid handle drives GetFileType -> FILE_TYPE_UNKNOWN with a nonzero GetLastError.
+    assert!(classify(windows::Win32::Foundation::INVALID_HANDLE_VALUE).is_err());
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked crt_fds`.
+
+- [ ] **Step 3: Implement.** `encode`: `N=maxfd+1`; present fd → flag `FOPEN|kind_bits`, handle + push to `handles`; absent → flag `0`, `INVALID_HANDLE_VALUE`. Flags `FOPEN=0x01,FPIPE=0x08,FDEV=0x40`. `classify` per interface. `encoded_len`/`table_fits` per interface (used by Task 5 to check the cap BEFORE `encode` allocates). Add `Fd::from_raw(i32)` to `src/stdio.rs` if absent.
+
+- [ ] **Step 4: Run, expect PASS** — `cargo test --locked crt_fds`.
+
+- [ ] **Step 5: Commit** — `git add src/child/spawn/windows_raw.rs src/child/spawn/windows_raw/ src/stdio.rs && git commit -m "feat: MSVCRT lpReserved2 fd-table encoder + GetFileType classifier + pre-alloc size cap"`
+
+---
+
+### Task 3: `executable()` resolution, env block, NUL guard
+
+**Files:** Create `src/child/spawn/windows_raw/resolve.rs` (+ `resolve_tests.rs`)
+
+**Interfaces:**
+- `pub(crate) fn resolve_executable_in(exe:&Path, base_cwd:&Path, path:Option<&OsStr>) -> Result<PathBuf, Error>` — the testable core (absolute+exists → as-is; else search `[base_cwd] ++ path`, appending `.exe` if no extension; `Error::Io(NotFound)` on miss) — and `pub(crate) fn resolve_executable(exe:&Path) -> Result<PathBuf, Error>` = the core with `std::env::current_dir()?` + `PATH`. **Tests drive the core with an explicit base dir — never `SetCurrentDirectory` (process-global; would race parallel tests).**
+- `pub(crate) fn build_env_block_from(base:&[(OsString,OsString)], ops:&[EnvOp]) -> Result<Option<Vec<u16>>, Error>` and `pub(crate) fn build_env_block(ops:&[EnvOp]) -> Result<Option<Vec<u16>>, Error>` (former seeded from `std::env::vars_os()`). `Ok(None)` when `ops` is empty (inherit); else the sorted, wide, double-NUL block; `Err` on embedded NUL. **Tests use `build_env_block_from` with a fixed base — never mutate global env.**
+- `pub(crate) fn ensure_no_nul_wide(s: &OsStr) -> Result<(), Error>` (`Error::Io(InvalidInput)`).
+
+**Dependency evaluation (recorded):** `which` v7 was evaluated but honors the full `PATHEXT` in `PATHEXT` order, diverging from what we want for `executable()` (a small `.exe`-appending cwd+PATH rule that keeps `.bat`/`.cmd` out of resolution so `reject_batch_program` owns that rejection). A minimal local resolver is used (evaluate-then-local pattern, cf. Plan 11 `kinfo`). No new dependency.
+
+- [ ] **Step 1: Write the failing tests** — `resolve_tests.rs` (base-cwd shadow via an explicit base dir; env via fixed base — no global-state mutation anywhere):
+
+```rust
+use super::*;
+use crate::command::EnvOp;
+use std::ffi::OsString;
+
+#[test]
+fn resolve_absolute_existing_is_returned_as_is() {
+    let me = std::env::current_exe().unwrap();
+    assert_eq!(resolve_executable(&me).unwrap(), me);
+}
+#[test]
+fn resolve_bare_name_prefers_base_cwd_over_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let shadow = dir.path().join("sp_shadow.exe");
+    std::fs::copy(std::env::current_exe().unwrap(), &shadow).unwrap();
+    // Explicit base dir — no process-global SetCurrentDirectory, so parallel tests can't race.
+    let got = resolve_executable_in(std::path::Path::new("sp_shadow"), dir.path(), None).unwrap();
+    assert_eq!(got.canonicalize().unwrap(), shadow.canonicalize().unwrap());
+}
+#[test]
+fn resolve_bare_name_appends_exe_from_path() {
+    let p = resolve_executable(std::path::Path::new("cmd")).unwrap();
+    assert!(p.is_absolute() && p.exists() && p.extension().is_some_and(|e| e.eq_ignore_ascii_case("exe")), "{p:?}");
+}
+#[test]
+fn empty_ops_inherit() { assert!(build_env_block(&[]).unwrap().is_none()); }
+#[test]
+fn set_sorts_ci_and_double_nul() {
+    let b = build_env_block_from(&[], &[EnvOp::Set("Zeta".into(),"1".into()), EnvOp::Set("alpha".into(),"2".into())]).unwrap().unwrap();
+    assert_eq!(&b[b.len()-2..], &[0u16,0u16]);
+    let s = String::from_utf16(&b).unwrap();
+    assert!(s.find("alpha=").unwrap() < s.find("Zeta=").unwrap(), "{s:?}");
+}
+#[test]
+fn remove_is_case_insensitive() {
+    let b = build_env_block_from(&[(OsString::from("SP_R"),OsString::from("x"))], &[EnvOp::Remove("sp_r".into())]).unwrap().unwrap();
+    assert!(!String::from_utf16(&b).unwrap().to_uppercase().contains("SP_R="));
+}
+#[test]
+fn clear_then_set_yields_only_the_set_var() {
+    let b = build_env_block_from(&[(OsString::from("PATH"),OsString::from("x"))], &[EnvOp::Clear, EnvOp::Set("ONLYME".into(),"1".into())]).unwrap().unwrap();
+    let s = String::from_utf16(&b).unwrap();
+    assert!(s.contains("ONLYME=1") && !s.to_uppercase().contains("PATH="));
+}
+#[test]
+fn embedded_nul_is_rejected() {
+    let e = build_env_block_from(&[], &[EnvOp::Set("K".into(), OsString::from("a\u{0}b"))]).unwrap_err();
+    assert!(matches!(e, crate::error::Error::Io(_)));
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked resolve_ set_ remove_ clear_ embedded_ empty_ops`.
+
+- [ ] **Step 3: Implement** per the interfaces (`resolve_executable` search `[current_dir()?] ++ PATH`; `build_env_block_from` seeds a `BTreeMap<upper(key),(key,val)>`, applies Set/Remove/Clear, `ensure_no_nul_wide` each, emits sorted `KEY=VAL\0` + trailing `\0`).
+
+- [ ] **Step 4: Run, expect PASS** — same filter.
+
+- [ ] **Step 5: Commit** — `git add src/child/spawn/windows_raw/ && git commit -m "feat: raw-path executable resolution + env block + NUL guard"`
+
+---
+
+### Task 4: sync backend enum + `RawChild` + poison-tolerant spawn lock + raw spawn (executable path)
+
+**Files:** Create `src/child/proc_handle.rs`; Modify `src/child.rs`, `src/child/spawn/windows_raw.rs`, `src/child/spawn.rs` (routing + `spawn_lock()` + wrap std spawn + harden `inherit_end`), `Cargo.toml`, `tests/raw_windows.rs`
+
+**Interfaces:**
+- `enum ProcHandle { Std(SharedChild), #[cfg(windows)] Raw(windows_raw::RawChild) }` + `wait`/`try_wait`/`kill`/`id`.
+- `struct RawChild { proc: OwnedHandle, pid: u32 }` + `wait`/`try_wait`/`kill`/`id`/`process_handle`.
+- `pub(crate) fn spawn_lock() -> std::sync::MutexGuard<'static,()>` over a crate `static SPAWN_MUTEX: Mutex<()>`, acquired **poison-tolerantly** (`.lock().unwrap_or_else(|e| e.into_inner())`) — held across the inheritable→spawn→close window on the raw path AND around `std_cmd.spawn()`/`tcmd.spawn()`.
+- `pub(crate) enum WaitOutcome { Exited, Cancelled }`; `pub(crate) fn wait_handle_or_cancel(proc: HANDLE, cancel: Option<HANDLE>) -> io::Result<WaitOutcome>`.
+- `pub(crate) fn create_process(app: Option<&[u16]>, cmdline:&mut Vec<u16>, si:&mut STARTUPINFOEXW, env:&Option<Vec<u16>>, cwd:&Option<Vec<u16>>, flags:u32) -> Result<(OwnedHandle,u32), Error>` (shared by sync/async; sets `si.StartupInfo.cb`; caller pre-fills `dwFlags`/`hStd*`/attribute list).
+- `pub(crate) fn spawn_raw(cmd:&Command, fds:BTreeMap<Fd,ResolvedStdio>, kill_on_drop:bool) -> Result<Child, Error>`.
+
+- [ ] **Step 1: Write the failing tests** (executable≠argv0; end-to-end embedded-NUL; batch rejection via a REAL `.bat`; embedded-NUL cwd):
+
+```rust
+#[test]
+fn executable_independent_of_argv0_on_windows() {
+    let exe = common::testbin();
+    let mut c = subprocess::Command::new();
+    c.executable(&exe).commandline("pretend-name argv0-report").stdout(subprocess::Stdio::pipe()).unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    assert!(s.contains("argv0=pretend-name") && s.to_lowercase().contains("testbin"), "{s}");
+}
+#[test]
+fn embedded_nul_in_commandline_is_rejected() {
+    let e = subprocess::Command::new().executable(common::testbin()).commandline("a\u{0}b").spawn().unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Io(_)), "{e:?}");
+}
+#[test]
+fn embedded_nul_in_cwd_is_rejected() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin()).commandline("x argv0-report").current_dir(std::path::PathBuf::from("a\u{0}b"));
+    assert!(matches!(c.spawn().unwrap_err(), subprocess::error::Error::Io(_)));
+}
+#[test]
+fn batch_script_via_executable_is_unsupported() {
+    let dir = tempfile::tempdir().unwrap();
+    let bat = dir.path().join("x.bat");
+    std::fs::write(&bat, b"@echo off\n").unwrap();
+    let e = subprocess::Command::new().executable(&bat).commandline("x.bat").spawn().unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported{..}), "{e:?}");
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked --features tokio --test raw_windows executable_independent embedded_nul batch_script_via_executable`.
+
+- [ ] **Step 3: Refactor `Child` onto `ProcHandle`** (pure refactor; forward the four methods + Drop). Add `spawn_lock()` (poison-tolerant) and wrap `std_cmd.spawn()` in `src/child/spawn.rs` with `let _g = spawn_lock();`. Run `cargo test --locked` + WSL → green.
+
+- [ ] **Step 4: Implement `wait_handle_or_cancel` + `RawChild`** — `wait_handle_or_cancel`: `Some(cancel)`→`WaitForMultipleObjects(&[proc,cancel],FALSE,INFINITE)` (idx0 `Exited`, idx1 `Cancelled`, `WAIT_FAILED`→Err); `None`→`WaitForSingleObject(proc,INFINITE)`. `RawChild::wait`=it with `None`+`GetExitCodeProcess`; `try_wait`=`WaitForSingleObject(h,0)`; `kill`=`TerminateProcess(h,1)` with an already-exited failure mapped to `Ok(())`.
+
+- [ ] **Step 5: Implement `spawn_raw`** — order: **reject-batch (before resolve)** → resolve → NUL-check (program, cwd, argv/commandline components) → resolve stdio → build STARTUPINFOEXW (`USESTDHANDLES`+`hStd*`+attr list) → spawn under the lock closing child ends on every path → teardown-symmetric identity/attach.
+
+```rust
+pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
+    // .bat/.cmd rejected on the raw program token BEFORE resolution (a bad/nonexistent path still errors loudly).
+    reject_batch_program(cmd)?;                                   // checks executable() ext, else commandline/argv[0] token
+    let image: Option<PathBuf> = cmd.executable_path().map(resolve::resolve_executable).transpose()?;
+    if let Some(p) = &image { resolve::ensure_no_nul_wide(p.as_os_str())?; }
+    if let Some(c) = cmd.cwd() { resolve::ensure_no_nul_wide(c.as_os_str())?; }
+    let app_name: Option<Vec<u16>> = image.as_ref().map(|p| to_wide_nul(p.as_os_str()));
+    let mut cmdline = raw_program_and_line(cmd)?;                 // each token ensure_no_nul_wide'd
+    cmdline.push(0);
+    let env_block = resolve::build_env_block(cmd.env_ops())?;     // Task 6 may add the contain marker
+    let cwd_w = cmd.cwd().map(|c| to_wide_nul(c.as_os_str()));
+
+    let slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR];             // Task 5 adds fd>=3
+    let (child_ends, parent_ends) = resolve_stdio(&fds, &slots, PipeOwnership::Owned)?;
+
+    // STARTUPINFOEXW: cb, STARTF_USESTDHANDLES + hStd* for 0/1/2, and an attribute list of exactly our
+    // child ends. hStd* wires the child's stdio; the HANDLE_LIST scopes inheritance AND backs
+    // EXTENDED_STARTUPINFO_PRESENT. (Task 5 adds fd>=3 handles to the list + lpReserved2.)
+    let mut si = STARTUPINFOEXW::default();
+    si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+    si.StartupInfo.dwFlags |= windows::Win32::System::Threading::STARTF_USESTDHANDLES;
+    si.StartupInfo.hStdInput  = HANDLE(child_ends[&Fd::STDIN ].as_raw_handle());
+    si.StartupInfo.hStdOutput = HANDLE(child_ends[&Fd::STDOUT].as_raw_handle());
+    si.StartupInfo.hStdError  = HANDLE(child_ends[&Fd::STDERR].as_raw_handle());
+    let all_handles: Vec<HANDLE> = child_ends.values().map(|e| HANDLE(e.as_raw_handle())).collect(); // 0/1/2, all distinct; Task 5 REPLACES with table.handles
+    let attr = build_attribute_list(&all_handles)?;              // Init/Update; Delete after spawn (both paths)
+    si.lpAttributeList = attr.ptr();
+    let contain_flags = 0u32;                                    // Task 6 sets this
+    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
+
+    // UNDER THE LOCK: mark listed child ends inheritable, spawn, then CLOSE child ends BEFORE the guard
+    // releases on EVERY path. `spawn_step` returns a Result WITHOUT `?`-ing past the close.
+    let (proc, pid) = {
+        let _guard = crate::child::spawn::spawn_lock();
+        let r = spawn_step(&all_handles, &app_name, &mut cmdline, &mut si, &env_block, &cwd_w, flags);
+        drop(child_ends);   // close inside the lock on success AND error
+        drop(attr);         // DeleteProcThreadAttributeList
+        r
+    }?;
+    // identity read + attach_or_fault(pid, proc.as_raw_handle(), prepared) BEFORE building Child, with the
+    // SAME kill+reap error-teardown arms as src/child/spawn.rs:121-162 (dropping the OwnedHandle alone
+    // neither kills nor reaps on Windows).
+    // Child::from_parts(ProcHandle::Raw(RawChild{proc,pid}), id, parent_ends, kill_on_drop, containment, attached)
+}
+// spawn_step: for h in all_handles { set_inherit(h,true)?; }  then create_process(...). Returns Result; the
+// caller drops child_ends+attr AFTER it returns (both arms) so no inheritable handle outlives the lock.
+```
+
+`create_process` (shared FFI; async reuses it):
+
+```rust
+use windows::Win32::System::Threading::{CreateProcessW, PROCESS_INFORMATION, PROCESS_CREATION_FLAGS,
+    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT};
+use windows::core::{PCWSTR, PWSTR};
+let mut pi = PROCESS_INFORMATION::default();
+let app = app.map_or(PCWSTR::null(), |w| PCWSTR(w.as_ptr()));
+let cwd = cwd.as_ref().map_or(PCWSTR::null(), |w| PCWSTR(w.as_ptr()));
+// SAFETY: pointers valid for the call; cmdline is a mutable NUL-terminated buffer CreateProcessW may edit.
+unsafe { CreateProcessW(app, Some(PWSTR(cmdline.as_mut_ptr())), None, None, true,
+    PROCESS_CREATION_FLAGS(flags), env.as_ref().map(|b| b.as_ptr() as *const _), cwd,
+    &si.StartupInfo, &mut pi) }.map_err(Error::Io)?;
+let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess.0 as _) };
+// SAFETY: hThread is owned + unneeded. Under the spawn lock, so log-only (a debug_assert!(false) here would
+// poison the lock and cascade to every future spawn).
+if let Err(e) = unsafe { windows::Win32::Foundation::CloseHandle(pi.hThread) } { log::debug!("CloseHandle(hThread): {e:?}"); }
+```
+
+`reject_batch_program`: extension check on `executable()` if set, else the commandline/argv[0] first token — reuse `reject_batch_script`'s logic. `raw_program_and_line`: `commandline()` → argv[0]=`first_token_wide`, full line; `argv` → `join_wide`; each token `ensure_no_nul_wide`; argv[0] is always the user's name.
+
+- [ ] **Step 6: Route + harden** in `src/child/spawn.rs`:
+
+```rust
+#[cfg(windows)]
+if cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3) {
+    return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
+}
+```
+
+Remove the old fd≥3 loop + the `build_from_commandline` executable rejection. **Harden `inherit_end`'s Windows arm (`src/child/spawn.rs:506-524`)** to reject fd ≥ 3 (mirror the Unix arm).
+
+- [ ] **Step 7: Run, expect PASS** — the four new tests; then `cargo test --locked` + `--features tokio`; then WSL both.
+
+- [ ] **Step 8: Commit** — `git add src/child.rs src/child/proc_handle.rs src/child/spawn.rs src/child/spawn/windows_raw.rs Cargo.toml tests/raw_windows.rs && git commit -m "feat: sync raw CreateProcessW backend — executable/argv0, USESTDHANDLES, poison-tolerant spawn lock"`
+
+---
+
+### Task 5: sync fd ≥ 3 (`lpReserved2` + HANDLE_LIST) + inherit guard + pre-alloc cap + device-class tests
+
+**Files:** Modify `src/child/spawn/windows_raw.rs`, `tests/raw_windows.rs`; consumes `crt_fds::{encode, classify, encoded_len, table_fits, FdKind}`.
+
+- [ ] **Step 1: Write the failing tests** — round-trip both directions; retained inherit rejection; **File→isatty=0** and **NUL(char-device)→isatty=1** (deterministic `classify` coverage, no console needed); **oversized-fd rejection**:
+
+```rust
+#[test] fn fd3_pipe_out_delivers_child_bytes() { /* write-fd 3 "hi-fd3"; parent read end == "hi-fd3" */ }
+#[test] fn fd3_pipe_in_feeds_child() { /* read-fd 3; write "ping3", drop write end (EOF); stdout == "ping3" */ }
+#[test]
+fn inherit_on_fd3_is_unsupported() {
+    let e = subprocess::Command::new().args(["subprocess_testbin","exit","0"])
+        .fd(3, subprocess::Stdio::inherit()).unwrap().spawn().unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported{..}), "{e:?}");
+}
+#[test]
+fn fd3_file_is_not_a_tty() { /* fd(3, Stdio::file(tempfile)); isatty-fd 3 -> "isatty=0" */ }
+#[test]
+fn fd3_nul_is_a_char_device() {
+    // NUL is FILE_TYPE_CHAR -> classify=CharDev -> FDEV -> child _isatty(3)==1. Deterministic, no console.
+    let mut c = subprocess::Command::new();
+    c.args(["subprocess_testbin","isatty-fd","3"]).fd(3, subprocess::Stdio::null()).unwrap()
+     .stdout(subprocess::Stdio::pipe()).unwrap();
+    let mut child = c.spawn().unwrap(); let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap(); child.wait().unwrap();
+    assert!(s.contains("isatty=1"), "NUL on fd3 is a char device: {s}");
+}
+#[test]
+fn oversized_fd_is_unsupported() {
+    let e = subprocess::Command::new().args(["subprocess_testbin","exit","0"])
+        .fd(70_000, subprocess::Stdio::null()).unwrap().spawn().unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported{..}), "{e:?}");
+}
+```
+
+(Adjust `Stdio::file`/`null`/accessor names to the real API from `src/stdio.rs`/`src/command.rs`.)
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked --features tokio --test raw_windows fd3_ inherit_on_fd3 oversized_fd`.
+
+- [ ] **Step 3: Extend `spawn_raw`.** BEFORE resolving stdio, reject each configured fd ≥ 3 whose `ResolvedStdio` is `Inherit` → `Error::Unsupported`. **Check the cap BEFORE allocating:** `let maxfd = fds.keys().map(|f| f.raw()).max().unwrap_or(2); if !crt_fds::table_fits(crt_fds::encoded_len(maxfd)) { return Err(Error::Unsupported{ detail:"fd table > 64KiB".into(), .. }); }` Then add fd ≥ 3 to the resolve slots; `classify(handle)?` each; `table = encode(0..=maxfd)`; `si.StartupInfo.cbReserved2 = table.bytes.len() as u16; lpReserved2 = table.bytes.as_ptr()` (kept alive past spawn). **Set `all_handles = table.handles`** — a SINGLE source that already covers 0/1/2 + fd ≥ 3 (each a distinct fresh dup from `resolve_stdio`, so no duplicate handle reaches the list), and whose 0/1/2 entries ARE the same handles wired into `hStd*`. Do NOT append to Task 4's 0/1/2 vector (that would duplicate 0/1/2). The attribute list built in Task 4 is now over this `all_handles`.
+
+- [ ] **Step 4: Run, expect PASS** — the new tests; full host + WSL suites.
+
+- [ ] **Step 5: Commit** — `git add src/child/spawn/windows_raw.rs tests/raw_windows.rs && git commit -m "feat: sync fd>=3 via lpReserved2 + HANDLE_LIST; inherit guard; pre-alloc cap; device-class tests"`
+
+---
+
+### Task 6: containment over the raw path (shared, mode-gated flag computation)
+
+**Files:** Modify `src/containment/dispatch.rs`, `src/child/spawn/windows_raw.rs`, `tests/raw_windows.rs`
+
+**Interfaces:** `#[cfg(windows)] pub(crate) fn windows_contain_setup(req:&ContainRequest, is_root:bool) -> WindowsContain` where `struct WindowsContain { creation_flags: u32, marker_env: bool }` — the decision inlined in `prepare` (dispatch.rs:276-288); **returns `{0,false}` when `req.mode` is `None`.** `prepare` (std path) calls it under its existing `if mode.is_some()` gate and applies as today.
+
+- [ ] **Step 1: Write the failing tests** — contained raw child in our job + `kill_tree` reaps (fd3 read to EOF, not payload-size-dependent); AND an **uncontained** raw child reports `Containment::None`:
+
+```rust
+#[test]
+fn contained_raw_child_is_in_our_job_and_kill_tree_reaps() {
+    let mut c = subprocess::Command::new();
+    c.args(["subprocess_testbin","write-fd","3","x"]).fd(3, subprocess::Stdio::pipe()).unwrap().contain();
+    let mut child = c.spawn().expect("contained raw spawn");
+    assert!(child.test_job_handle_contains_self());
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.fd_read_end(subprocess::Fd::from_raw(3)).unwrap(), &mut s).unwrap();
+    assert_eq!(s, "x");
+    child.kill_tree().expect("kill_tree");
+}
+#[test]
+fn uncontained_raw_child_has_no_containment() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin()).commandline("x argv0-report").stdout(subprocess::Stdio::pipe()).unwrap();
+    assert!(matches!(c.spawn().unwrap().containment(), subprocess::Containment::None));
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked --features tokio --test raw_windows contained_raw uncontained_raw`.
+
+- [ ] **Step 3: Refactor + wire.** (a) Extract `windows_contain_setup` from dispatch.rs:276-288 (`{0,false}` for `mode==None`); std `prepare` calls it under its `if mode.is_some()` gate + applies as today (full suite → std path unchanged). (b) In `spawn_raw`, **gated on `cmd.contain_request().mode.is_some()`**: compute `is_root` as `prepare` does, call `windows_contain_setup`, OR `creation_flags` into `flags`, when `marker_env` push `(NESTED_ENV,"1")` into the env ops feeding `build_env_block`, and call `clear_std_handle_inheritance()`. When `mode` is `None`, none of this runs. Then `attach_or_fault(pid, proc.as_raw_handle(), prepared)` (construct `Prepared{mode,is_root,..}`). `attach_job` resumes the CREATE_SUSPENDED child via Toolhelp — unchanged.
+
+- [ ] **Step 4: Run, expect PASS** — both tests; full host + WSL suites.
+
+- [ ] **Step 5: Commit** — `git add src/containment/dispatch.rs src/child/spawn/windows_raw.rs tests/raw_windows.rs && git commit -m "feat: containment over the sync raw backend — shared mode-gated flag computation"`
+
+---
+
+### Task 7: async backend enum + `RawAsyncChild` + async raw spawn (executable path)
+
+Mirror Task 4 for tokio. Async wait reuses the shared `wait_handle_or_cancel` on the OWNED handle (no foreign pid-reopen), with **`Arc`-owned handles** so a dropped wait future or dropped child never closes a parked-on handle.
+
+**Files:** Create `src/tokio/child/proc_source.rs`, `src/tokio/spawn/windows_raw.rs`; Modify `src/tokio/child.rs`, `src/tokio/child/pump.rs`, `src/tokio/child/graceful.rs`, `src/tokio/spawn.rs` (routing + `spawn_lock` around `tcmd.spawn()`), `src/wait/windows.rs` (generalize the watcher core to a `HANDLE`); Create `tests/raw_windows_async.rs`
+
+**Interfaces:**
+- `enum ProcSource { Tokio(::tokio::process::Child), #[cfg(windows)] Raw(windows_raw::RawAsyncChild) }` + `id`, `#[cfg(windows)] raw_handle`, `async fn wait(&mut self)`, `try_wait`, `start_kill`, stdin/stdout/stderr (Tokio arm).
+- `struct RawAsyncChild { proc: Arc<OwnedHandle>, pid: u32, exited: Option<ExitStatus> }`. `wait(&mut self)`: return cached `exited` if set; else create a cancel event (`Arc<OwnedHandle>`), clone `proc`+`cancel` Arcs into `spawn_blocking(move || wait_handle_or_cancel(HANDLE(proc.as_raw_handle()), Some(HANDLE(cancel.as_raw_handle()))))`, hold a `CancelGuard(Arc<cancel>)` in the future that `SetEvent`s on drop (`log::debug!` on failure — Drop can't propagate). The `Arc`s keep both handles alive until the blocking task returns. Await the `JoinHandle`; a `JoinError` (task panic / runtime shutdown) → `Error::Io(other("wait task failed"))`. On `Exited` → `GetExitCodeProcess`, cache `exited`. `try_wait` = zero-timeout poll; `start_kill` = `TerminateProcess`.
+- A `#[cfg(test)]` **per-instance** observable seam: `RawAsyncChild` carries an optional observer (`started` + `outcome` senders) injected by a test-only spawn variant (`spawn_with_wait_observer`), NOT a process-global free function — a global seam would let a parallel tokio test's `wait()` fire into this test's channels. The blocking closure signals "started" and sends its `WaitOutcome` on THAT child's channels only, so the test observes exactly the child under test — deterministic, event-driven.
+- `src/wait/windows.rs`'s watcher core is refactored to take a `HANDLE` (+ cancel event); the foreign caller opens the handle, the raw async path passes its owned handle.
+
+- [ ] **Step 1: Write the failing async tests** — executable≠argv0, AND a **cancellation** test that (a) polls the wait to parking and (b) observes the `Cancelled` outcome:
+
+```rust
+#![cfg(all(windows, feature = "tokio"))]
+mod common;
+#[tokio::test]
+async fn async_executable_independent_of_argv0() { /* mirror the sync test with AsyncReadExt */ }
+
+#[tokio::test]
+async fn async_wait_drop_cancels_and_child_stays_waitable() {
+    // testbin blocks until stdin EOF. Install a test observable, START wait() as a task so it PARKS
+    // (await the closure's "started" signal), then abort/drop it and AWAIT the "cancelled" signal —
+    // no wall-clock. Then close stdin (EOF) and prove a fresh wait() still resolves.
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (outcome_tx, outcome_rx) = tokio::sync::oneshot::channel();
+    let mut c = subprocess::tokio::Command::new();
+    c.args(["subprocess_testbin","read-fd","0"]).stdin(subprocess::Stdio::pipe()).unwrap();
+    // test-only spawn variant injects the observer into THIS child only (no process-global seam).
+    let mut child = c.spawn_with_wait_observer(started_tx, outcome_tx).unwrap();
+    let task = tokio::spawn(async move { let _ = child.wait().await; });
+    started_rx.await.unwrap();          // THIS child's blocking wait has parked
+    task.abort();                       // drop the in-flight wait future -> CancelGuard fires SetEvent
+    assert_eq!(outcome_rx.await.unwrap(), WaitOutcome::Cancelled);   // observed on THIS child, event-driven
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`Unsupported` / missing hook) — `cargo test --locked --features tokio --test raw_windows_async async_executable async_wait_drop_cancels`.
+
+- [ ] **Step 3: Introduce `ProcSource`** as a pure refactor (Tokio arm only): update `child.rs`, `pump.rs`, `graceful.rs`; expose `ProcSource::wait(&mut self)`. Full tokio suite host + WSL → green.
+
+- [ ] **Step 4: Generalize the watcher + implement `RawAsyncChild`** per the interface (Arc-owned handles; `CancelGuard`; `JoinError` mapping; the `#[cfg(test)]` observable). Refactor `src/wait/windows.rs`'s blocking core to take a `HANDLE`.
+
+- [ ] **Step 5: Implement async `spawn_raw`** — reuse `create_process`, the STARTUPINFOEXW/USESTDHANDLES/HANDLE_LIST build, and the lock/close discipline (child ends closed before the guard releases); piped std ends via the tokio overlapped-pipe machinery; identity read BEFORE any await; `attach_or_fault(...)` **with the SAME kill+reap error-teardown arms as the sync-raw/std spawn**. Route with the SAME predicate; `spawn_lock()` around the raw window and `tcmd.spawn()`.
+
+- [ ] **Step 6: Run, expect PASS** — the async tests; full tokio host + WSL suites.
+
+- [ ] **Step 7: Commit** — `git add src/tokio/ src/wait/windows.rs tests/raw_windows_async.rs && git commit -m "feat: async raw CreateProcessW backend — executable/argv0; Arc-owned cancellable async wait"`
+
+---
+
+### Task 8: async fd ≥ 3 + containment parity
+
+**Files:** Modify `src/tokio/spawn/windows_raw.rs`, `src/tokio/child.rs` (Windows fd ≥ 3 async parent-end accessors — mirror the Unix Plan-10 surface), `tests/raw_windows_async.rs`; consumes `create_process` + `crt_fds`.
+
+- [ ] **Step 1: Write the failing tests** — async fd-3 round-trip both directions (exit proven by pipe EOF) + a contained-async twin (`test_job_handle_contains_self`).
+
+- [ ] **Step 2: Run, expect FAIL** — `cargo test --locked --features tokio --test raw_windows_async async_fd3_ async_contained`.
+
+- [ ] **Step 3: Implement** — fd ≥ 3 child ends into `create_process` (same `lpReserved2`/HANDLE_LIST/pre-alloc-cap/inherit-guard/lock path); surface Windows fd ≥ 3 parent ends as tokio async pipe ends (owned by the async raw path, like the Plan-10 merge-target overlapped pairs); containment via `windows_contain_setup` (mode-gated); **SAME kill+reap teardown arms**.
+
+- [ ] **Step 4: Run, expect PASS** — full tokio host + WSL suites.
+
+- [ ] **Step 5: Commit** — `git add src/tokio/ tests/raw_windows_async.rs && git commit -m "feat: async fd>=3 + contained raw backend parity (tokio, Windows)"`
+
+---
+
+### Task 9: retire the rejections, refresh docs/error text, spec/TODO, end-to-end flips
+
+**Files:** Modify `src/command.rs`, `src/child/spawn.rs` + `src/tokio/spawn.rs` (residual `Plan 4` text), `src/child/spawn.rs` `inherit_end` message, `TODO.md`, the design spec (mark landed), `tests/spawn_io.rs` / `tests/tokio_io.rs`.
+
+- [ ] **Step 1: Grep** `rg -n "Plan 4|raw backend" src tests` — each hit removed or reworded (no future-backend promise). Resolve every hit.
+
+- [ ] **Step 2: Flip the `Unsupported` tests to END-TO-END** — not `spawn().is_ok()`: `executable()+commandline()` reads back `argv0-report` (argv[0] from commandline, image = executable); fd ≥ 3 round-trips bytes. Keep `Unsupported` for retained cases (inherit-on-fd ≥ 3, chained merge, `.bat`/`.cmd`).
+
+- [ ] **Step 3: Run the FULL matrix** — host `cargo test --locked` + `--features tokio`; WSL both; `cargo +stable fmt --check`; `cargo clippy --locked --features tokio --all-targets` + `--all-targets`; `prek run --all-files`. All green/clean.
+
+- [ ] **Step 4: Docs** — `command.rs` platform notes: supported behavior + MSVC/UCRT-only fd ≥ 3 caveat + the `executable()` cwd+PATH resolution rule + retained limits + inherent non-MSVCRT note. Normalize docs to LF.
+
+- [ ] **Step 5: Commit** — `git add src tests TODO.md Cargo.toml Cargo.lock && git add -f .tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md .tmp/claude/superpowers/plans/2026-07-18-plan12-windows-raw-backend.md && git commit -m "feat: retire the Windows fd>=3 / executable+commandline Unsupported paths; docs + spec/TODO"` (`.gitignore` was already committed at branch start; `CLAUDE.local.md` is gitignored/untracked — do NOT add it)
+
+---
+
+## Self-Review
+
+**Spec coverage:** §1 → Tasks 4/7. §2 → Task 4 (+5/6). §3 + classify → Task 2, wired 5/8. §4 → Task 3. §5 → Task 6 (+8). §6 + shared wait → Task 4. §7 → Task 7. §8 routing → 4/7. §9 features → 3/4. Deferrals retained loud → 4/5/9. **Covered.**
+
+**Round-3 must_fix dispositions (all FIXED):** async cancel test unpolled/unobservable (4077a20c, 4671b42d) → the test spawns the wait as a task, awaits a "started" park signal, aborts it, and awaits an observed `Cancelled` outcome via a `#[cfg(test)]` seam (Task 7). resolver parity overclaim (2972f846) → parity claim dropped; the cwd+PATH+`.exe` rule is stated as deliberate (Global Constraints, Task 3). missing USESTDHANDLES/hStd*/cb (67ff57ac) → set explicitly in `spawn_raw` (Task 4). CharDev/classify coverage (1b1c6059, 2fb2b893) → deterministic `NUL`→CharDev→isatty=1 test + `classify` invalid-handle unit test (Tasks 5/2). lock-release-before-close race (277c09bf) → `spawn_step` returns a Result and child ends+attr are dropped BEFORE the guard on both arms (Task 4). cwd NUL (14cd19d6) → `ensure_no_nul_wide(cwd)` + test (Task 4). cap-after-alloc (c44613d7) → `encoded_len`/`table_fits` checked before `encode` (Tasks 2/5). mutex poison cascade (d196d5af) → poison-tolerant `spawn_lock` + the in-lock `CloseHandle(hThread)` is log-only, not `debug_assert!(false)` (Task 4). JoinError (a003e2b0) → mapped to `Error::Io` (Task 7). batch ordering/test (6e58395b) → `reject_batch_program` runs before resolution; the test uses a REAL temp `.bat` (Task 4). Dropped-but-tightened: the embedded-NUL assertion pins `Error::Io`.
+
+**Round-4 must_fix dispositions.** Fixed in-plan: `encoded_len` overflow-safe (702cf004, Task 2 + boundary/overflow test); HANDLE_LIST single-sourced from `table.handles`, no 0/1/2 duplication (8fe02265, Tasks 4/5); per-instance async observer, not a global seam (6ee52540, 2a35c875, Task 7); `resolve_executable_in` explicit base dir, no global-cwd mutation in tests (aa2a98ce, Task 3). Resolved during implementation under the mandatory **code-mode** review (they need real code / empirical Windows behavior, not a plan edit): extract `needs_raw`, `build_raw_spawn_plan`, and `teardown_on_attach_failure` as named shared sync/async functions (62577a91, 3c6cf898, eee6d001 — the DRY structure emerges when writing the shared FFI, and the plan already names `create_process`/`crt_fds`/`resolve`/`windows_contain_setup` as shared); `RawChild::kill`/`start_kill` disposition — `TerminateProcess` on a handle we still hold succeeds even post-exit, so map errors normally rather than special-casing "already exited" (2363b09b — verify against real error codes when the code runs); `GetExitCodeProcess` failure → `Error::Io` and `CancelGuard` `SetEvent` failure → `log::error!` (aebc0dce, 1c270906); drop Task 5's redundant inherit-fd≥3 pre-check now that `inherit_end`'s Windows arm is the single hardened source (e9ec04ef); add tests exercising the poison-tolerant lock after a held-lock panic and the `JoinError`→`Error::Io` mapping (8868a744, e4938b15) and a `record-the-raw-FFI-approach` evaluation note (ed8ef289) during Task 4/7 implementation. These are exactly the class the code-mode panel verifies against compiled, tested code.
+
+**Conciseness cuts applied (verified present):** the accepted cuts (create_process/spawn_raw comment trims, the `argv0-report` block trailing comment, the round-2-dispositions verbosity, the `std::mem::forget` phrasing, the batch/USESTDHANDLES inline notes) are gone; the CharDev-hedge cut is NOT applied as a mere trim — it is resolved substantively (the `NUL` deterministic test) per must_fix 1b1c6059.
+
+**Type consistency:** `ProcHandle`/`ProcSource` sets consistent; `RawChild{proc:OwnedHandle,pid}` / `RawAsyncChild{proc:Arc<OwnedHandle>,pid,exited}`; `crt_fds::{encode,classify,encoded_len,table_fits,FdTable,FdKind}` 2↔5↔8; `resolve::{resolve_executable,build_env_block,build_env_block_from,ensure_no_nul_wide}` 3↔4; `wait_handle_or_cancel`/`WaitOutcome` 4↔7; `spawn_lock` 4↔7; `create_process` 4↔7; `windows_contain_setup`/`WindowsContain` std↔raw.
+
+## Recorded decisions
+- Scope = sync + async in one plan (user, 2026-07-18).
+- Routing = hybrid, raw only when needed.
+- `executable()` bare-name resolution = a deliberate cwd+PATH+`.exe` rule (NOT full CreateProcessW-search parity; documented).
+- fd ≥ 3 = `lpReserved2` numbered fds, MSVC/UCRT-faithful; non-MSVCRT inherent+documented (spec §144).
+- Deferred (user-agreed): chained merges, inherit-on-fd ≥ 3 — retained as loud `Unsupported`.
+- Inheritance safety via a poison-tolerant crate spawn mutex + always-on USESTDHANDLES/HANDLE_LIST; child ends closed before the guard releases on every path.
+- Shared handle-based wait; async uses Arc-owned handles + observable cancel-on-drop.
+- Workflow: issue → branch `azhukova/<issue#>` → PR → CI.

--- a/.tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md
+++ b/.tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md
@@ -1,5 +1,10 @@
 # Plan 12 — Windows raw `CreateProcessW` backend (fd ≥ 3 + independent `executable`/`commandline`)
 
+> **Status: LANDED** (2026-07-19, branch `azhukova/4`). All 9 tasks implemented and reviewed;
+> the two Windows-only `Unsupported` rejections (`fd >= 3`, `executable()` + `commandline()`) are
+> lifted on both the sync and async surfaces. Retained design limits: chained merges,
+> `Stdio::inherit()` on `fd >= 3`, and `fd >= 3` for non-MSVCRT children.
+
 Fulfils the deferred "Plan 4" spawn-engine item (`TODO.md:66`): a raw `CreateProcessW`
 backend that lifts the two Windows-only `Unsupported` rejections `std::process` cannot
 express — `fd(n)` for n ≥ 3, and `executable()` set alongside `commandline()` (and the

--- a/.tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md
+++ b/.tmp/claude/superpowers/specs/2026-07-18-plan12-windows-raw-backend-design.md
@@ -1,0 +1,216 @@
+# Plan 12 — Windows raw `CreateProcessW` backend (fd ≥ 3 + independent `executable`/`commandline`)
+
+Fulfils the deferred "Plan 4" spawn-engine item (`TODO.md:66`): a raw `CreateProcessW`
+backend that lifts the two Windows-only `Unsupported` rejections `std::process` cannot
+express — `fd(n)` for n ≥ 3, and `executable()` set alongside `commandline()` (and the
+sibling `executable()`-alone argv[0] degradation). Delivered on BOTH the sync and async
+surfaces in one plan, preserving the feature-equivalence invariant.
+
+## Scope
+
+**In:** (1) a raw `CreateProcessW` spawn path on Windows, **routed only when the std path
+cannot express the request** — `executable()` is set, OR any `fd(n)` with n ≥ 3 is
+configured — and otherwise left entirely on the existing std/tokio path (the 11 landed
+plans' green tests are untouched by construction); (2) `fd ≥ 3` inheritance via the MSVCRT
+`lpReserved2` fd-table smuggle so the child CRT sees numbered descriptors, with
+inheritance scoped by `STARTUPINFOEX` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`
+(**MSVC/UCRT children only**, per spec §divergence line 144); (3) independent
+`lpApplicationName` / `lpCommandLine` so `executable()` + `commandline()` (and
+`executable()` + argv) load the intended file while the child's argv[0] is the user's
+intended name; (4) a process-handle abstraction so the raw child coexists with
+`SharedChild` (sync) / `tokio::process::Child` (async); (5) raw-path program resolution
+(PATH + PATHEXT) and environment-block construction, since `CreateProcessW` PATH-searches
+neither a non-NULL `lpApplicationName` nor inherits env when we must apply env ops;
+(6) containment/lifecycle integration (the raw path sets `CREATE_SUSPENDED` itself; the
+existing `attach_job` Toolhelp-resume is reused unchanged); (7) async raw wait on the
+existing Windows event-cancellable death-watch primitive; (8) flip the four `Unsupported`
+rejection sites, update their error text, and mirror the test suite sync↔async.
+
+**Out (kept `Unsupported`, agreed with user 2026-07-18):**
+(a) **chained merges** (`merge → merge`) — the two-pass `resolve_stdio` still rejects them;
+(b) **`Stdio::inherit()` on fd ≥ 3** — semantically undefined on Windows (the parent has no
+fd ≥ 3), stays a loud `Unsupported`, not a silent drop;
+(c) **non-MSVCRT children for fd ≥ 3** — the `lpReserved2` table is a CRT-private contract;
+a child linking a foreign/no CRT cannot be served and this is documented as inherent, not a
+bug. The Unix path, elevation, PTY, and \*BSD are unchanged (`TODO.md`).
+
+## Architecture
+
+### 1. Process-handle abstraction (`src/child.rs`, `src/tokio/child.rs`)
+
+The sole structural cost. `SharedChild::new` requires a `std::process::Child`; a raw
+`HANDLE` is neither that nor a `tokio::process::Child`. Introduce a thin backend enum whose
+methods forward to the active arm, keeping every downstream call site (wait/kill/id/
+containment/Drop) source-compatible:
+
+- **Sync** — `Child.shared: SharedChild` becomes `Child.proc: ProcHandle`:
+  `enum ProcHandle { Std(SharedChild), #[cfg(windows)] Raw(windows_raw::RawChild) }`
+  forwarding `wait` / `try_wait` / `kill` / `id` and, on Windows, the raw process handle the
+  containment attach + `kill_tree` backstop + `test_job_handle_contains_self` need (today via
+  `AsRawHandle`; the `Raw` arm exposes it directly, no `OpenProcess`-by-pid round trip).
+- **Async** — `Child.child: tokio::process::Child` becomes
+  `enum ProcSource { Tokio(tokio::process::Child), #[cfg(windows)] Raw(RawAsyncChild) }`,
+  forwarding `id` / `raw_handle` / `wait().await` / `try_wait` / `start_kill` and the
+  stdin/stdout/stderr piped-end takers (the `Raw` arm holds our own overlapped ends).
+
+On Unix the enum is a single-arm passthrough (zero behavior change; `#[cfg(windows)]` gates
+the `Raw` variant so no Unix code sees it).
+
+### 2. Raw spawn core (`src/child/spawn/windows_raw.rs`, new)
+
+A `#[cfg(windows)]` module owning the `CreateProcessW` call, driven from a resolved
+`Command`. Inputs it assembles:
+
+- **`lpApplicationName`** — the resolved absolute executable path (§4). Set for EVERY raw
+  spawn (research-brief line 131: always emit an explicit `lpApplicationName`; never let the
+  OS parse the exe from the command line — that is the BatBadBut vector).
+- **`lpCommandLine`** — built with the existing `quote::windows::join_wide`, argv[0] = the
+  user's intended name (from `argv[0]`, or `first_token_wide(commandline)`), argv[1..]
+  quoted. Mutable buffer (`CreateProcessW` may write to it).
+- **`STARTUPINFOEXW`** — `STARTF_USESTDHANDLES` with `hStdInput/Output/Error` = the resolved
+  0/1/2 child ends; `lpAttributeList` carries a single
+  `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` naming EXACTLY {0,1,2 handles} ∪ {fd ≥ 3 handles}
+  (§3), so `bInheritHandles = TRUE` leaks nothing else (research-brief line 188: unscoped
+  inheritance leaks cross-child pipe ends → hangs).
+- **`cbReserved2`/`lpReserved2`** — the MSVCRT fd table (§3) when any fd ≥ 3 is present.
+- **`lpEnvironment`** (§4) + `CREATE_UNICODE_ENVIRONMENT`; **`lpCurrentDirectory`** = cwd.
+- **`dwCreationFlags`** — `CREATE_UNICODE_ENVIRONMENT`, plus the containment flags (§5)
+  folded in here rather than via std's `creation_flags`.
+
+Handle hygiene: set `HANDLE_FLAG_INHERIT` on every listed child end immediately before
+spawn; the parent keeps its own ends non-inheritable. Stdio child ends are produced by the
+UNCHANGED `resolve_stdio` core (`PipeOwnership::Owned` sync / `Deferred`-equivalent async) —
+the raw path reuses the same pipe/file/null/merge resolution, only the final wiring to the
+OS differs. `PROCESS_INFORMATION` yields the process handle, thread handle, and pid.
+
+### 3. fd ≥ 3 MSVCRT fd-table (`src/child/spawn/windows_raw/crt_fds.rs`, new)
+
+The `lpReserved2` blob is the CRT's private inherited-fd table (prior art: CPython
+`subprocess`/`_winapi`, libuv `process.c`, the `thaum` reference impl). Layout:
+
+```
+int   count;                 // number of fds, table covers fd 0..count-1
+char  flags[count];          // per-fd CRT flags
+HANDLE handles[count];       // per-fd OS handle (INVALID_HANDLE_VALUE for a gap)
+```
+
+We emit a table covering fd `0..=N` where `N` is the highest configured descriptor, so it
+includes 0/1/2 (same handles as `STARTF_USESTDHANDLES`, belt-and-suspenders for CRTs that
+read the table for 0/1/2) and each configured fd ≥ 3. Any interior slot the user did not
+configure (e.g. fd 3 and fd 5 set but not fd 4) gets `INVALID_HANDLE_VALUE` + a zero flag
+byte, so the child CRT treats it as closed. Per-fd flag byte =
+`FOPEN | (FPIPE if a pipe | FDEV if a char device | 0)` (no `FTEXT` — binary). All listed
+handles are also in the `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` (§2), the only mechanism that
+actually makes them inheritable under scoped inheritance. `cbReserved2 = sizeof(int) +
+count*(1 + sizeof(HANDLE))`. Confined to the raw path; a foreign-CRT child is the documented
+non-goal (Out §c).
+
+### 4. Program resolution + environment block (`src/child/spawn/windows_raw/resolve.rs`, new)
+
+- **Program resolution** — `CreateProcessW` does not PATH-search a non-NULL
+  `lpApplicationName`, so the raw path must resolve a bare program name to an absolute path
+  itself (std does this internally but never exposes the result). **Dependency evaluation
+  (to confirm in the plan):** prefer the `which` crate (maintained, handles Windows PATHEXT +
+  `App Paths`) over a hand-rolled search, per the add-a-dependency rule; validate against
+  `std::process` parity with a test that resolves the same bare name both ways. If `which`'s
+  search order diverges from std in a way a test catches, fall back to a minimal
+  PATH+PATHEXT+cwd resolver and record the decline.
+- **Environment block** — when env ops are present we build the `CREATE_UNICODE_ENVIRONMENT`
+  block ourselves: start from the parent env, apply `Set`/`Remove`/`Clear` (case-insensitive
+  keys, Windows semantics), sort case-insensitively, wide-encode, `\0`-separate,
+  double-`\0`-terminate. No maintained crate exposes exactly std's block construction; this
+  is a faithful local build (documented layout). When no env ops are present, pass NULL
+  (inherit parent env) — the common case stays allocation-free.
+
+### 5. Containment / lifecycle integration
+
+The Windows containment mechanism is unchanged — only who sets the creation flags moves. For
+a contained raw spawn, `windows_raw` folds `CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP`
+into `dwCreationFlags` itself (the std path's `containment::prepare` → `set_root_flags`
+mutates a `std::process::Command`, which the raw path does not use). Post-spawn,
+`attach_job(proc_handle)` is reused VERBATIM: it assigns the job and resumes via the Toolhelp
+thread walk keyed on pid. (The raw path also holds `PROCESS_INFORMATION.hThread` and COULD
+resume it directly, but reusing `attach_job` unchanged keeps one resume path and one set of
+tests; the thread handle is simply closed after `attach_job` returns.) `require_contained`,
+`Attached`, `disarm`, `kill_tree`, `terminate_tree`, and the Drop teardown are untouched.
+
+### 6. `RawChild` lifecycle (sync, in `windows_raw.rs`)
+
+Owns `OwnedHandle` (process) + pid. `wait` = `WaitForSingleObject(INFINITE)` then
+`GetExitCodeProcess` → `ExitStatus` (via `ExitStatusExt`); `try_wait` = `WaitForSingleObject(0)`
+`WAIT_TIMEOUT` → `None`; `kill` = `TerminateProcess`, mapping the already-exited error to
+`Ok(())` for parity with `std`/`shared_child`; `id` = the pid. Thread-safe waiting is
+inherent on Windows (many threads may wait one handle; exit code is idempotent), so
+`RawChild` does NOT need `shared_child` — it is used through `&self` like the `Std` arm.
+`Drop` requires nothing beyond closing the handle (the existing `Child::drop` orchestrates
+kill+reap through the enum).
+
+### 7. `RawAsyncChild` (async, `src/tokio/spawn/windows_raw.rs`, new)
+
+The hard half. Holds the process `OwnedHandle` + pid + our overlapped parent ends. `wait`/
+`try_wait` reuse the SAME Windows death-watch primitive the async foreign `Process` already
+uses (`src/tokio/wait.rs` + `src/wait/windows.rs` — the "event-cancellable blocking wait, no
+pollable process handle" noted in `TODO.md:83`): a cancellation-safe `wait().await` over the
+handle, `try_wait` a zero-timeout poll. `start_kill`/`kill` = `TerminateProcess`. The spawn
+itself is synchronous (raw `CreateProcessW`, then identity read + `attach_job` before any
+await — mirroring the existing async spawn's "identity before await" ordering), so no reactor
+interaction occurs until the first `wait`. Stdio for the async raw path reuses the existing
+overlapped-pipe machinery (`src/tokio/stdio.rs`) for parent ends; fd ≥ 3 async parent ends
+mirror the Unix fd ≥ 3 accessor surface already shipped in Plan 10.
+
+### 8. Routing predicate (`src/child/spawn.rs`, `src/tokio/spawn.rs`)
+
+A single `#[cfg(windows)]` predicate, evaluated after `fds` is taken:
+`needs_raw = cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3)`.
+When false → the existing std/tokio path, byte-for-byte. When true → the raw path. The four
+current rejection sites (`child/spawn.rs:29`, `:279`; `tokio/spawn.rs:34`; and the
+`build_from_commandline` Windows arm) are replaced by this branch. `Stdio::inherit()` on
+fd ≥ 3 (Out §b) is still rejected inside `resolve_stdio`/`inherit_end` — reached only if the
+user pairs inherit with an fd ≥ 3 slot, and it stays loud.
+
+### 9. Cargo / `windows` crate features
+
+Add to the existing `windows` dependency (already `0.62`): `CreateProcessW`,
+`STARTUPINFOEXW`, `PROC_THREAD_ATTRIBUTE_LIST` +
+`InitializeProcThreadAttributeList`/`UpdateProcThreadAttribute`/`DeleteProcThreadAttributeList`,
+`GetExitCodeProcess`, `WaitForSingleObject`, `PROCESS_INFORMATION` — most live under
+`Win32_System_Threading` (already enabled); enable any missing sibling feature (e.g.
+`Win32_Storage_FileSystem` for `HANDLE_FLAG_INHERIT`/`SetHandleInformation` if not already
+in scope). New crate dep: `which` (Windows-target, gated), pending the §4 parity check.
+
+## Testing (TDD, sync ↔ async mirrored)
+
+Every behavior is written test-first; each new integration test has a sync and a tokio twin.
+
+- **fd ≥ 3 round-trip** — configure `fd(3, pipe)` (both directions) to a CRT child
+  (`subprocess_testbin` gains a mode that reads/writes fd 3 via the CRT), assert the bytes
+  cross. Exit proven by pipe EOF; no sleeps/polls/wall-clock (per the standing prohibition).
+- **fd ≥ 3 to a file / null** — child writes fd 4 to a temp file; parent reads it back.
+- **`executable()` ≠ argv[0]** — load one helper while argv[0] is a different name; the child
+  reports its argv[0] and its own image path; assert they differ as configured. Covers
+  `executable()` + `commandline()`, `executable()` + argv, and `executable()`-alone (the
+  latter proving the pre-existing Windows argv[0] degradation is lifted).
+- **Rejection flips** — the former `Unsupported` cases now succeed; the RETAINED rejections
+  (chained merge, inherit-on-fd ≥ 3) still return `Unsupported` with updated text (no stale
+  "raw backend (Plan 4)" wording).
+- **Containment over the raw path** — a contained raw spawn is in our job
+  (`test_job_handle_contains_self`), and `kill_tree` tears down an fd ≥ 3-wired tree.
+- **Parity / no-regression** — the std path is unchanged when `needs_raw` is false (existing
+  suite); a `which`-vs-std program-resolution parity test; run the full suite on Windows
+  (host) and WSL (Unix untouched) before the branch CI.
+
+## Recorded decisions
+
+- **Scope = sync + async in one plan** (user, 2026-07-18) — preserves the feature-equivalence
+  invariant rather than shipping a divergent surface.
+- **Routing = hybrid, raw only when needed** — industry convergence (CPython/Go/libuv all
+  fall to a raw path only when the common path can't express the request); minimises blast
+  radius against 11 plans of green tests. Not punted to the user (decision-style: evidence,
+  not a menu).
+- **fd ≥ 3 semantic = `lpReserved2` numbered fds, MSVC/UCRT-only** — already settled by
+  `specs/2026-06-20-subprocess-design.md:144`; this plan implements, it does not re-decide.
+- **Deferred (user-agreed, 2026-07-18):** chained merges and inherit-on-fd ≥ 3 stay
+  `Unsupported`; non-MSVCRT fd ≥ 3 is an inherent non-goal, documented not tracked-as-bug.
+- **Workflow (CLAUDE.local.md):** GitHub issue → branch `azhukova/<issue#>` → PR → CI green;
+  the issue/branch/PR (people-alerting) are batched for explicit user OK after design +
+  implementation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ getrandom = { version = "0.4", features = ["std"] }
 libc = "0.2"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Threading",
     "Win32_System_JobObjects",
     "Win32_System_Console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ shared_child = { version = "1", features = ["timeout"] }
 log = "0.4"
 # `macros` is required by the library, not only tests: `communicate` uses `tokio::try_join!`,
 # which is gated behind tokio's `macros` feature. `net` is solely for `AsyncFd` (the
-# reactor-native death-watch); `time` solely for the grace bound on it.
-tokio = { version = "1", optional = true, features = ["process", "rt", "io-util", "macros", "net", "time"] }
+# reactor-native death-watch); `time` solely for the grace bound on it. `sync` backs the
+# per-instance wait observer (a `#[cfg(test)]` oneshot seam) the raw async backend is tested with.
+tokio = { version = "1", optional = true, features = ["process", "rt", "io-util", "macros", "net", "sync", "time"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ tempfile = "3"
 # Unpredictable merge-target pipe names (std parity: std randomizes its anon-pipe names).
 # `std` for the `io::Error` conversion.
 getrandom = { version = "0.4", features = ["std"] }
+# `get_osfhandle`/`isatty`: the testbin maps CRT fds to OS handles and classifies devices.
+libc = "0.2"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_System_Threading",

--- a/TODO.md
+++ b/TODO.md
@@ -61,9 +61,11 @@ To run the live test in CI:
 - [ ] Settle license line for the ported qodana shlex (Apache-2.0, user-authored) — attribution header / NOTICE.
 - [ ] Re-validate own-containment vs `process-wrap` dependency, and `cgroups-rs` vs thin direct cgroup-fs impl.
 
-## Spawn engine (from Plan 4)
+## Spawn engine (from Plan 4, delivered in Plan 12)
 
-- [ ] (Plan 4) Implement raw backend (CreateProcess/execve) to support independent `executable` + `commandline` on Windows — std has no stable API to set `lpApplicationName` independently of `lpCommandLine`, so the std-only backend forces `argv[0]` to equal the executable when both are set.
+- [x] (Plan 12) Raw `CreateProcessW` backend (sync + async) supporting independent `executable` + `commandline` and `fd >= 3` on Windows — `lpApplicationName` set independently of `lpCommandLine`, argv[0] preserved, and `fd >= 3` smuggled via the MSVCRT `lpReserved2` fd-table.
+
+Retained deferrals (agreed with user; permanent design limits, not bugs): chained merges (`merge -> merge`), `Stdio::inherit()` on `fd >= 3` (no defined parent stream), and `fd >= 3` for non-MSVCRT children (the `lpReserved2` table is a CRT-private contract — inherent).
 
 ## Lifecycle / graceful shutdown (from Plan 5)
 

--- a/prek.toml
+++ b/prek.toml
@@ -2,7 +2,9 @@
 # See https://prek.j178.dev for more information.
 #:schema https://www.schemastore.org/prek.json
 
-exclude = "^target/"
+# `.tmp/` is agent scratch (plans/specs/reports force-added only for record) — not
+# source to be linted/reformatted, same rationale as `target/`.
+exclude = "^(target|\\.tmp)/"
 default_install_hook_types = ["pre-commit", "commit-msg"]
 
 # Local hooks ==========================================================================================================

--- a/src/child.rs
+++ b/src/child.rs
@@ -3,8 +3,6 @@
 use std::collections::BTreeMap;
 use std::io::{PipeReader, PipeWriter};
 
-use shared_child::SharedChild;
-
 use crate::command::Command;
 use crate::containment::Containment;
 use crate::error::Error;
@@ -16,6 +14,10 @@ pub(crate) mod pump;
 
 #[path = "child/spawn.rs"]
 pub(crate) mod spawn;
+
+#[path = "child/proc_handle.rs"]
+pub(crate) mod proc_handle;
+use proc_handle::ProcHandle;
 
 #[path = "child/lifecycle.rs"]
 mod lifecycle;
@@ -33,7 +35,7 @@ pub(crate) enum ParentEnd {
 /// A spawned child process the crate owns.
 #[derive(Debug)]
 pub struct Child {
-    shared: SharedChild,
+    proc: ProcHandle,
     /// Stable identity resolved immediately after spawn.
     id: ProcessId,
     pipes: BTreeMap<Fd, ParentEnd>,
@@ -44,7 +46,7 @@ pub struct Child {
 
 impl Child {
     pub(crate) fn from_parts(
-        shared: SharedChild,
+        proc: ProcHandle,
         id: ProcessId,
         pipes: BTreeMap<Fd, ParentEnd>,
         kill_on_drop: bool,
@@ -52,7 +54,7 @@ impl Child {
         attached: crate::containment::Attached,
     ) -> Child {
         Child {
-            shared,
+            proc,
             id,
             pipes,
             kill_on_drop,
@@ -86,19 +88,19 @@ impl Child {
 
     /// Block until the child exits, returning its status.
     pub fn wait(&self) -> Result<std::process::ExitStatus, Error> {
-        self.shared.wait().map_err(Error::Io)
+        self.proc.wait().map_err(Error::Io)
     }
 
     /// Return the exit status if the child has already exited.
     pub fn try_wait(&self) -> Result<Option<std::process::ExitStatus>, Error> {
-        self.shared.try_wait().map_err(Error::Io)
+        self.proc.try_wait().map_err(Error::Io)
     }
 
     /// Hard-kill the process. Returns `Ok(())` if already dead.
     pub fn kill(&self) -> Result<(), Error> {
-        // shared_child delegates to std::process::Child::kill, which returns
-        // Ok(()) for an already-exited child on all platforms.
-        self.shared.kill().map_err(Error::Io)
+        // Both backends return Ok(()) for an already-exited child (std delegates to
+        // std::process::Child::kill; the raw path maps an already-dead TerminateProcess to Ok).
+        self.proc.kill().map_err(Error::Io)
     }
 
     /// Hard-kill the contained tree. Requires an actionable containment mechanism
@@ -110,7 +112,7 @@ impl Child {
         // Backstop for the TreeWalk mechanism: its hard_kill kills the root by identity,
         // which no-ops if `ProcessId::of` transiently fails to resolve the root — this
         // handle-based kill covers that, so its failure is contract-relevant.
-        let backstop = self.shared.kill().map_err(Error::Io);
+        let backstop = self.proc.kill().map_err(Error::Io);
         if let (Err(group), Err(bs)) = (&group_result, &backstop) {
             log::debug!("kill_tree handle backstop also failed ({bs}); surfacing the group error: {group}");
         }
@@ -125,7 +127,7 @@ impl Child {
     /// unsignaled; `kill_tree` is the guaranteed hard teardown.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
-        self.attached.terminate(self.shared.id())
+        self.attached.terminate(self.proc.id())
     }
 
     /// Take the parent's write end of the child's stdin pipe, if configured.
@@ -205,10 +207,10 @@ impl Child {
             return false;
         };
 
-        // Open the child process by PID; shared_child doesn't expose its handle.
+        // Open the child process by PID; the backend doesn't expose its handle.
         // SAFETY: standard Win32 call; handle closed below.
         let process_handle = unsafe {
-            match OpenProcess(PROCESS_QUERY_INFORMATION, false, self.shared.id()) {
+            match OpenProcess(PROCESS_QUERY_INFORMATION, false, self.proc.id()) {
                 Ok(h) => h,
                 Err(_) => return false,
             }
@@ -233,8 +235,8 @@ impl Drop for Child {
         // Hard-kill the contained tree (if any) then also the direct child, then reap.
         // Order matters on Unix: kill BEFORE wait (reaping frees the PID).
         let _ = self.attached.hard_kill();
-        let _ = self.shared.kill();
-        let _ = self.shared.wait();
+        let _ = self.proc.kill();
+        let _ = self.proc.wait();
     }
 }
 

--- a/src/child.rs
+++ b/src/child.rs
@@ -191,39 +191,12 @@ impl Child {
         take_reader(&mut self.pipes, fd)
     }
 
-    /// Test-only: return whether this child is inside our Job Object.
-    /// Uses `IsProcessInJob` against the handle we hold (not "any job").
-    /// Exposed outside `cfg(test)` so integration tests (separate compilation unit) can call it.
+    /// Test-only: return whether this child is inside our Job Object (via `IsProcessInJob` against
+    /// the handle we hold, not "any job"). Exposed outside `cfg(test)` so integration tests (a
+    /// separate compilation unit) can call it.
     #[cfg(windows)]
     pub fn test_job_handle_contains_self(&self) -> bool {
-        use crate::containment::Attached;
-        use windows::Win32::System::JobObjects::IsProcessInJob;
-        use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_INFORMATION};
-
-        let Attached::JobObject(ref job) = self.attached else {
-            return false;
-        };
-        let Some(job_handle) = job.as_handle() else {
-            return false;
-        };
-
-        // Open the child process by PID; the backend doesn't expose its handle.
-        // SAFETY: standard Win32 call; handle closed below.
-        let process_handle = unsafe {
-            match OpenProcess(PROCESS_QUERY_INFORMATION, false, self.proc.id()) {
-                Ok(h) => h,
-                Err(_) => return false,
-            }
-        };
-
-        let mut in_job = windows::core::BOOL(0);
-        // SAFETY: both handles are valid for the duration of the call.
-        let ok = unsafe { IsProcessInJob(process_handle, Some(job_handle), &mut in_job) };
-        // SAFETY: process_handle was opened above and must be closed.
-        unsafe {
-            let _ = windows::Win32::Foundation::CloseHandle(process_handle);
-        }
-        ok.is_ok() && in_job.as_bool()
+        crate::containment::windows::job_contains_pid(&self.attached, self.proc.id())
     }
 }
 

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -1,5 +1,5 @@
 //! `Child` graceful shutdown — the soft-then-hard escalation trio. A submodule of `child`
-//! so it can reach `Child`'s private `shared`/`id`.
+//! so it can reach `Child`'s private `proc`/`id`.
 
 use std::process::ExitStatus;
 use std::time::Duration;
@@ -40,7 +40,7 @@ impl Child {
                 id = self.id.pid()
             );
         }
-        self.shared.kill().map_err(Error::Io)?; // escalate; an Err returns HERE, subsuming any watch Err (deliberate — mirrors kill_tree's both-fail disposition)
+        self.proc.kill().map_err(Error::Io)?; // escalate; an Err returns HERE, subsuming any watch Err (deliberate — mirrors kill_tree's both-fail disposition)
         let status = self.wait()?;
         watch?;
         Ok(status)

--- a/src/child/lifecycle.rs
+++ b/src/child/lifecycle.rs
@@ -1,5 +1,5 @@
 //! `Child` bounded waits. A submodule of `child` so it can reach `Child`'s private
-//! `shared`.
+//! `proc` handle.
 
 use std::process::ExitStatus;
 use std::time::{Duration, Instant};
@@ -34,6 +34,6 @@ impl Child {
     /// Like [`wait_timeout`](Child::wait_timeout) but against an absolute `deadline`
     /// (at or before now behaves like [`try_wait`](Child::try_wait)).
     pub fn wait_deadline(&self, deadline: Instant) -> Result<Option<ExitStatus>, Error> {
-        self.shared.wait_deadline(deadline).map_err(Error::Io)
+        self.proc.wait_deadline(deadline).map_err(Error::Io)
     }
 }

--- a/src/child/proc_handle.rs
+++ b/src/child/proc_handle.rs
@@ -1,0 +1,70 @@
+//! Backend-agnostic owned-process handle. A `Child` holds one of these and
+//! forwards its wait/kill/identity operations to whichever backend spawned it:
+//! the std path's [`SharedChild`], or (Windows only) the raw `CreateProcessW`
+//! child [`RawChild`]. Keeping the fan-out here lets `Child` stay backend-blind.
+
+use std::io;
+use std::process::ExitStatus;
+use std::time::Instant;
+
+use shared_child::SharedChild;
+
+#[cfg(windows)]
+use super::spawn::windows_raw::RawChild;
+
+/// The process backend behind an owned [`Child`](super::Child).
+#[derive(Debug)]
+pub(crate) enum ProcHandle {
+    /// std-spawned child, adopted into `shared_child` for concurrent wait/kill.
+    Std(SharedChild),
+    /// Raw `CreateProcessW` child owning the process handle directly.
+    #[cfg(windows)]
+    Raw(RawChild),
+}
+
+impl ProcHandle {
+    /// Block until the child exits.
+    pub(crate) fn wait(&self) -> io::Result<ExitStatus> {
+        match self {
+            ProcHandle::Std(s) => s.wait(),
+            #[cfg(windows)]
+            ProcHandle::Raw(r) => r.wait(),
+        }
+    }
+
+    /// The exit status if the child has already exited, else `None`.
+    pub(crate) fn try_wait(&self) -> io::Result<Option<ExitStatus>> {
+        match self {
+            ProcHandle::Std(s) => s.try_wait(),
+            #[cfg(windows)]
+            ProcHandle::Raw(r) => r.try_wait(),
+        }
+    }
+
+    /// Block until the child exits or `deadline` passes (`Ok(None)` at expiry).
+    pub(crate) fn wait_deadline(&self, deadline: Instant) -> io::Result<Option<ExitStatus>> {
+        match self {
+            ProcHandle::Std(s) => s.wait_deadline(deadline),
+            #[cfg(windows)]
+            ProcHandle::Raw(r) => r.wait_deadline(deadline),
+        }
+    }
+
+    /// Hard-kill the process (already-exited is success).
+    pub(crate) fn kill(&self) -> io::Result<()> {
+        match self {
+            ProcHandle::Std(s) => s.kill(),
+            #[cfg(windows)]
+            ProcHandle::Raw(r) => r.kill(),
+        }
+    }
+
+    /// The OS process id.
+    pub(crate) fn id(&self) -> u32 {
+        match self {
+            ProcHandle::Std(s) => s.id(),
+            #[cfg(windows)]
+            ProcHandle::Raw(r) => r.id(),
+        }
+    }
+}

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -230,10 +230,11 @@ fn resolve_program(cmd: &Command, fallback: std::ffi::OsString) -> std::ffi::OsS
 // Program + the trailing args (argv mode). `executable` overrides the loaded
 // file; argv[0] is the conventional program name otherwise.
 //
-// POSIX only: when `executable` is set and argv is non-empty, the user's
-// argv[0] is preserved via `CommandExt::arg0` (set on the caller's std_cmd).
-// On Windows std has no `arg0`; argv[0] silently becomes the executable path
-// (documented limitation lifted in Plan 4's raw backend).
+// POSIX: when `executable` is set and argv is non-empty, the user's argv[0] is
+// preserved via `CommandExt::arg0` (set on the caller's std_cmd). On Windows a
+// set `executable` never reaches this std path — it routes to the raw
+// `CreateProcessW` backend, which preserves argv[0] independently of the loaded
+// image (argv[0] no longer degrades to the executable path).
 fn resolve_program_argv<'a>(
     cmd: &'a Command,
     argv: &'a [std::ffi::OsString],
@@ -275,7 +276,7 @@ fn build_from_commandline(cmd: &Command, line: &std::ffi::OsString) -> Result<st
 }
 
 #[cfg(windows)]
-fn build_from_commandline(cmd: &Command, line: &std::ffi::OsString) -> Result<std::process::Command, Error> {
+fn build_from_commandline(_cmd: &Command, line: &std::ffi::OsString) -> Result<std::process::Command, Error> {
     use std::os::windows::ffi::{OsStrExt, OsStringExt};
     use std::os::windows::process::CommandExt;
     // Windows is command-line-native. CRITICAL: std::process always PREPENDS a
@@ -284,23 +285,10 @@ fn build_from_commandline(cmd: &Command, line: &std::ffi::OsString) -> Result<st
     // passing the whole line would duplicate the program token in the child's
     // argv. We split the first token off with first_token_and_rest_wide.
     //
-    // Limitation: std has no stable API to set lpApplicationName independently
-    // of lpCommandLine. So when executable() is set alongside a commandline(),
-    // we explicitly reject the combination rather than silently doing the wrong
-    // thing (the child's argv[0] would come from the commandline, but the file
-    // loaded would be executable — a confusing mismatch). The raw backend
-    // (Plan 4) removes this limitation via direct CreateProcess.
-    // TODO(plan4): implement raw backend to support independent executable + commandline on Windows
-    if cmd.executable_path().is_some() {
-        return Err(Error::Unsupported {
-            op: "spawn with executable() and commandline() both set".into(),
-            platform: "windows",
-            detail: "std::process has no API to set the loaded file independently of \
-                     the command line string; use the argv() builder or wait for the \
-                     raw backend (Plan 4)"
-                .into(),
-        });
-    }
+    // This std path is only reached for a commandline() WITHOUT executable(): a set
+    // executable() routes to the raw `CreateProcessW` backend (which sets
+    // lpApplicationName independently of lpCommandLine) before `build_std_command`
+    // is ever called, on both the sync and async spawn paths.
     let wide: Vec<u16> = line.encode_wide().collect();
     let (first, rest) = crate::quote::windows::first_token_and_rest_wide(&wide)
         .ok_or_else(|| Error::Io(std::io::Error::other("empty command line")))?;
@@ -377,7 +365,8 @@ pub(crate) fn resolve_stdio(
     pipe: PipeOwnership,
 ) -> Result<ResolvedStdioEnds, Error> {
     // Reject merge-targeting-a-merge: the two-pass algorithm resolves only one level of
-    // indirection. Transitive chaining needs a fixpoint loop and is deferred to the raw backend.
+    // indirection. Transitive chaining (a fixpoint loop) is an unsupported design limit — redirect
+    // to a concrete slot (pipe/file/null/inherit) instead.
     for &slot in slots {
         if let Some(ResolvedStdio::Merge(target)) = fds.get(&slot) {
             if matches!(fds.get(target), Some(ResolvedStdio::Merge(_))) {
@@ -494,8 +483,9 @@ fn file_end(f: &std::fs::File) -> Result<ChildEnd, Error> {
 fn inherit_end(slot: Fd) -> Result<ChildEnd, Error> {
     // Duplicate the parent's matching std stream. Bind the stream to a variable
     // before borrowing its descriptor (a temporary would be dropped while borrowed).
-    // For n>=3, Stdio::inherit() has no defined parent stream to dup — reject it
-    // explicitly. (The raw backend, Plan 4, can open arbitrary parent fds by number.)
+    // For n>=3, Stdio::inherit() has no defined parent stream to dup — a design limit
+    // kept as a loud Unsupported on every path (the raw backend routes here too), never a
+    // silent drop.
     #[cfg(unix)]
     {
         use std::os::fd::AsFd;
@@ -517,7 +507,7 @@ fn inherit_end(slot: Fd) -> Result<ChildEnd, Error> {
                     op: format!("Stdio::inherit() on {other}"),
                     platform: "unix",
                     detail: "inherit on fd >= 3 has no defined parent stream; \
-                             use pipe/file/null, or the raw backend (Plan 4)"
+                             use pipe/file/null instead"
                         .into(),
                 })
             }
@@ -540,14 +530,14 @@ fn inherit_end(slot: Fd) -> Result<ChildEnd, Error> {
                 let s = std::io::stderr();
                 s.as_handle().try_clone_to_owned()
             }
-            // fd >= 3 has no defined parent std stream to dup (mirrors the Unix arm). The raw
-            // backend opens arbitrary parent handles by number in Task 5.
+            // fd >= 3 has no defined parent std stream to dup (mirrors the Unix arm). Retained design
+            // limit: the raw backend routes fd >= 3 inherit through here and rejects it too.
             other => {
                 return Err(Error::Unsupported {
                     op: format!("Stdio::inherit() on {other}"),
                     platform: "windows",
                     detail: "inherit on fd >= 3 has no defined parent stream; \
-                             use pipe/file/null, or the raw backend (Plan 12)"
+                             use pipe/file/null instead"
                         .into(),
                 })
             }

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -24,22 +24,25 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let kill_on_drop = cmd.kill_on_drop_flag();
 
     // Windows routing. The raw `CreateProcessW` backend (Plan 12) owns the cases std cannot
-    // express: an `executable()` loaded independently of argv[0]. It is used only for an
-    // UNCONTAINED child with std-only descriptors — containment on the raw path is Task 6 and
-    // fd >= 3 wiring is Task 5, so those stay on the paths that already handle (or reject) them.
+    // express: an `executable()` loaded independently of argv[0], and arbitrary descriptors
+    // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It is used only for an UNCONTAINED child —
+    // containment on the raw path is Task 6, so a CONTAINED fd >= 3 stays rejected below until then.
     #[cfg(windows)]
     {
         let has_high_fd = fds.keys().any(|slot| slot.raw() >= 3);
-        if cmd.executable_path().is_some() && cmd.contain_request().mode.is_none() && !has_high_fd {
+        if (cmd.executable_path().is_some() || has_high_fd) && cmd.contain_request().mode.is_none() {
             return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
         }
-        // fd >= 3 has no std wiring on Windows (the raw fd-table path lands in Task 5).
+        // Reaching here with a high fd means the child is CONTAINED (an uncontained one routed to
+        // the raw backend above). Containment over the raw backend is not yet wired (Task 6).
         if has_high_fd {
             let slot = fds.keys().find(|s| s.raw() >= 3).expect("has_high_fd");
             return Err(Error::Unsupported {
                 op: format!("{slot}"),
                 platform: std::env::consts::OS,
-                detail: "arbitrary descriptors (>= 3) require the raw backend (Plan 12)".into(),
+                detail: "arbitrary descriptors (>= 3) under containment require the raw backend's \
+                         containment wiring (Plan 12 Task 6)"
+                    .into(),
             });
         }
     }

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -25,25 +25,13 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
 
     // Windows routing. The raw `CreateProcessW` backend (Plan 12) owns the cases std cannot
     // express: an `executable()` loaded independently of argv[0], and arbitrary descriptors
-    // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It is used only for an UNCONTAINED child —
-    // containment on the raw path is Task 6, so a CONTAINED fd >= 3 stays rejected below until then.
+    // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It handles both uncontained and CONTAINED
+    // children (Task 6 wired containment — Job Object / TreeWalk — into the raw path).
     #[cfg(windows)]
     {
         let has_high_fd = fds.keys().any(|slot| slot.raw() >= 3);
-        if (cmd.executable_path().is_some() || has_high_fd) && cmd.contain_request().mode.is_none() {
+        if cmd.executable_path().is_some() || has_high_fd {
             return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
-        }
-        // Reaching here with a high fd means the child is CONTAINED (an uncontained one routed to
-        // the raw backend above). Containment over the raw backend is not yet wired (Task 6).
-        if has_high_fd {
-            let slot = fds.keys().find(|s| s.raw() >= 3).expect("has_high_fd");
-            return Err(Error::Unsupported {
-                op: format!("{slot}"),
-                platform: std::env::consts::OS,
-                detail: "arbitrary descriptors (>= 3) under containment require the raw backend's \
-                         containment wiring (Plan 12 Task 6)"
-                    .into(),
-            });
         }
     }
     let mut std_cmd = build_std_command(cmd)?;
@@ -54,9 +42,9 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let std_slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR];
     let all_slots: Vec<Fd> = {
         // Yield 0/1/2 first (even unconfigured, for inherit defaulting), then any
-        // configured n>=3. The n>=3 collection is Unix-only: on Windows the fd>=3
-        // rejection above guarantees `fds` holds no fd>=3, so the push is dead code
-        // there — cfg-gate it to make that explicit.
+        // configured n>=3. The n>=3 collection is Unix-only: on Windows the routing
+        // above (any fd>=3 goes to the raw backend) guarantees `fds` holds no fd>=3,
+        // so the push is dead code there — cfg-gate it to make that explicit.
         #[cfg_attr(not(unix), allow(unused_mut))]
         let mut v: Vec<Fd> = std_slots.to_vec();
         #[cfg(unix)]

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -6,6 +6,7 @@ use std::process::Stdio as StdStdio;
 
 use shared_child::SharedChild;
 
+use crate::child::proc_handle::ProcHandle;
 use crate::child::{Child, ParentEnd};
 use crate::command::{Command, CommandInput, EnvOp};
 use crate::error::Error;
@@ -22,15 +23,23 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let fds = std::mem::take(cmd.fds_mut());
     let kill_on_drop = cmd.kill_on_drop_flag();
 
-    // On Windows, fd >= 3 is unsupported in this plan (no MSVCRT fd-table wiring).
-    // On Unix, arbitrary fds are handled below via command-fds.
+    // Windows routing. The raw `CreateProcessW` backend (Plan 12) owns the cases std cannot
+    // express: an `executable()` loaded independently of argv[0]. It is used only for an
+    // UNCONTAINED child with std-only descriptors — containment on the raw path is Task 6 and
+    // fd >= 3 wiring is Task 5, so those stay on the paths that already handle (or reject) them.
     #[cfg(windows)]
-    for slot in fds.keys() {
-        if slot.raw() >= 3 {
+    {
+        let has_high_fd = fds.keys().any(|slot| slot.raw() >= 3);
+        if cmd.executable_path().is_some() && cmd.contain_request().mode.is_none() && !has_high_fd {
+            return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
+        }
+        // fd >= 3 has no std wiring on Windows (the raw fd-table path lands in Task 5).
+        if has_high_fd {
+            let slot = fds.keys().find(|s| s.raw() >= 3).expect("has_high_fd");
             return Err(Error::Unsupported {
                 op: format!("{slot}"),
                 platform: std::env::consts::OS,
-                detail: "arbitrary descriptors (>= 3) require the raw backend (Plan 4)".into(),
+                detail: "arbitrary descriptors (>= 3) require the raw backend (Plan 12)".into(),
             });
         }
     }
@@ -109,8 +118,13 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         }
     }
 
-    // We own the std Child so containment can job-assign + resume it (Task 5).
-    let mut child = std_cmd.spawn().map_err(Error::Io)?;
+    // We own the std Child so containment can job-assign + resume it (Task 5). Serialize the
+    // spawn against the raw backend's inheritable-handle window via the shared spawn lock: std's
+    // own handle-inheritance marking must not overlap a raw spawn on another thread.
+    let mut child = {
+        let _guard = spawn_lock();
+        std_cmd.spawn().map_err(Error::Io)?
+    };
     // Phase 2 (after spawn, before adopt): attach the mechanism (job/cgroup/...).
     // `prepared` is consumed here: Linux cgroup leaf ownership moves to Attached::Cgroup.
     #[cfg(windows)]
@@ -166,13 +180,23 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let shared = SharedChild::new(child).map_err(Error::Io)?;
 
     Ok(Child::from_parts(
-        shared,
+        ProcHandle::Std(shared),
         id,
         parent_ends,
         kill_on_drop,
         containment,
         attached,
     ))
+}
+
+/// Serializes spawns against the process-global inheritable-handle window: on Windows both the std
+/// path and the raw `CreateProcessW` backend must mark child-side handles inheritable, spawn, then
+/// un-mark/close without a concurrent spawn inheriting them. Held across that window on both paths.
+/// **Poison-tolerant:** a panic mid-spawn must not wedge every future spawn, so a poisoned lock is
+/// recovered rather than propagated (the guarded data is unit — there is no invariant to protect).
+pub(crate) fn spawn_lock() -> std::sync::MutexGuard<'static, ()> {
+    static SPAWN_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    SPAWN_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 pub(crate) fn build_std_command(cmd: &Command) -> Result<std::process::Command, Error> {
@@ -296,7 +320,13 @@ fn build_from_commandline(cmd: &Command, line: &std::ffi::OsString) -> Result<st
 }
 
 fn reject_batch_script(std_cmd: &std::process::Command) -> Result<(), Error> {
-    let prog = std::path::Path::new(std_cmd.get_program());
+    reject_batch_path(std::path::Path::new(std_cmd.get_program()))
+}
+
+/// Reject a `.bat`/`.cmd` program by its path extension. Shared by the std path
+/// (`reject_batch_script`) and the raw backend (`windows_raw::reject_batch_program`): cmd.exe
+/// batch escaping is a distinct, unimplemented vector (CVE-2024-24576 / BatBadBut).
+pub(crate) fn reject_batch_path(prog: &std::path::Path) -> Result<(), Error> {
     if let Some(ext) = prog.extension() {
         let ext = ext.to_string_lossy().to_ascii_lowercase();
         if ext == "bat" || ext == "cmd" {
@@ -515,9 +545,20 @@ fn inherit_end(slot: Fd) -> Result<ChildEnd, Error> {
                 let s = std::io::stdout();
                 s.as_handle().try_clone_to_owned()
             }
-            _ => {
+            Fd::STDERR => {
                 let s = std::io::stderr();
                 s.as_handle().try_clone_to_owned()
+            }
+            // fd >= 3 has no defined parent std stream to dup (mirrors the Unix arm). The raw
+            // backend opens arbitrary parent handles by number in Task 5.
+            other => {
+                return Err(Error::Unsupported {
+                    op: format!("Stdio::inherit() on {other}"),
+                    platform: "windows",
+                    detail: "inherit on fd >= 3 has no defined parent stream; \
+                             use pipe/file/null, or the raw backend (Plan 12)"
+                        .into(),
+                })
             }
         };
         owned.map_err(Error::Io)
@@ -621,7 +662,7 @@ pub(crate) mod fault {
 // `foo.rs` + `foo/` module convention (mirroring `child.rs`'s `child/spawn.rs`).
 #[cfg(windows)]
 #[path = "spawn/windows_raw.rs"]
-mod windows_raw;
+pub(crate) mod windows_raw;
 
 #[cfg(test)]
 #[path = "spawn_tests.rs"]

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -615,6 +615,14 @@ pub(crate) mod fault {
     }
 }
 
+// Windows raw `CreateProcessW` spawn backend (Plan 12). The MSVCRT fd-table
+// encoder + device classifier (`crt_fds`) lands first; the spawn path that
+// consumes it follows in later tasks. Explicit `#[path]` per the repo's
+// `foo.rs` + `foo/` module convention (mirroring `child.rs`'s `child/spawn.rs`).
+#[cfg(windows)]
+#[path = "spawn/windows_raw.rs"]
+mod windows_raw;
+
 #[cfg(test)]
 #[path = "spawn_tests.rs"]
 mod spawn_tests;

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -414,8 +414,9 @@ pub(crate) fn resolve_stdio(
                 return Err(Error::Unsupported {
                     op: format!("async merge {slot} -> {target} (piped)"),
                     platform: std::env::consts::OS,
-                    detail: "merging into a piped target needs an async parent end (not yet built); \
-                             merge into file/null/inherit, or capture separately"
+                    detail: "merging into a piped target with a deferred (tokio-owned) pipe end needs \
+                             the merge target resolved first; merge into file/null/inherit, or capture \
+                             separately"
                         .into(),
                 });
             }

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -1,0 +1,10 @@
+//! Windows raw `CreateProcessW` spawn backend (Plan 12).
+//!
+//! Lands incrementally. This root currently exposes only the MSVCRT
+//! `lpReserved2` fd-table encoder plus a `GetFileType` device classifier
+//! (`crt_fds`); the sync/async spawn paths that consume them arrive in later
+//! tasks.
+#![allow(dead_code)] // the fd-table API is consumed by the Task 5+ spawn paths; not yet wired to a production caller
+
+#[path = "windows_raw/crt_fds.rs"]
+mod crt_fds;

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -1,13 +1,286 @@
 //! Windows raw `CreateProcessW` spawn backend (Plan 12).
 //!
-//! Lands incrementally. This root currently exposes only the MSVCRT
-//! `lpReserved2` fd-table encoder plus a `GetFileType` device classifier
-//! (`crt_fds`); the sync/async spawn paths that consume them arrive in later
-//! tasks.
-#![allow(dead_code)] // the fd-table API is consumed by the Task 5+ spawn paths; not yet wired to a production caller
+//! [`spawn_raw`] is the sync entry point: it loads an `executable()` file
+//! independently of argv[0] (the case std cannot express on Windows), wiring the
+//! child's std handles via `STARTUPINFOEXW` + a scoped `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
+//! The process-handle + FFI primitives live in [`proc`]; program/env/NUL
+//! resolution in [`resolve`]; the MSVCRT fd-table encoder (for fd >= 3, Task 5)
+//! in [`crt_fds`].
 
 #[path = "windows_raw/crt_fds.rs"]
+#[allow(dead_code)] // the fd-table encoder is consumed by the Task 5 fd>=3 spawn path; no caller yet
 mod crt_fds;
 
 #[path = "windows_raw/resolve.rs"]
 mod resolve;
+
+#[path = "windows_raw/proc.rs"]
+mod proc;
+
+pub(crate) use proc::RawChild;
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::io::{AsRawHandle, OwnedHandle};
+use std::path::PathBuf;
+
+use windows::Win32::Foundation::{SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT};
+use windows::Win32::System::Threading::{
+    DeleteProcThreadAttributeList, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
+    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
+    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+};
+
+use crate::child::proc_handle::ProcHandle;
+use crate::child::spawn::{
+    attach_or_fault, reject_batch_path, resolve_identity, resolve_stdio, spawn_lock, ChildEnd, PipeOwnership,
+};
+use crate::child::Child;
+use crate::command::{Command, CommandInput};
+use crate::error::Error;
+use crate::stdio::{Fd, ResolvedStdio};
+
+/// Spawn `cmd` via raw `CreateProcessW`. Task 4 scope: an UNCONTAINED child with std-only
+/// descriptors (0/1/2). fd >= 3 (Task 5) and containment (Task 6) leave their marked seams below.
+pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
+    // .bat/.cmd rejected on the raw program token BEFORE resolution, so a bad/nonexistent batch
+    // path still errors loudly (CVE-2024-24576) rather than surfacing as a spawn failure.
+    reject_batch_program(cmd)?;
+
+    let image: Option<PathBuf> = cmd.executable_path().map(resolve::resolve_executable).transpose()?;
+    if let Some(p) = &image {
+        resolve::ensure_no_nul_wide(p.as_os_str())?;
+    }
+    if let Some(c) = cmd.cwd() {
+        resolve::ensure_no_nul_wide(c.as_os_str())?;
+    }
+    let app_name: Option<Vec<u16>> = image.as_ref().map(|p| to_wide_nul(p.as_os_str()));
+    let mut cmdline = raw_program_and_line(cmd)?; // each token NUL-checked
+    cmdline.push(0);
+    let env_block = resolve::build_env_block(cmd.env_ops())?; // Task 6 may add the contain marker
+    let cwd_w = cmd.cwd().map(|c| to_wide_nul(c.as_os_str()));
+
+    let slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR]; // Task 5 adds fd >= 3
+    let (child_ends, parent_ends) = resolve_stdio(&fds, &slots, PipeOwnership::Owned)?;
+
+    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2, plus an attribute list of exactly
+    // our child ends. hStd* wires the child's stdio; the HANDLE_LIST scopes inheritance to those
+    // handles AND backs EXTENDED_STARTUPINFO_PRESENT. (Task 5 adds fd >= 3 handles + lpReserved2.)
+    let mut si = STARTUPINFOEXW::default();
+    si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+    si.StartupInfo.hStdInput = child_handle(&child_ends, Fd::STDIN);
+    si.StartupInfo.hStdOutput = child_handle(&child_ends, Fd::STDOUT);
+    si.StartupInfo.hStdError = child_handle(&child_ends, Fd::STDERR);
+    // 0/1/2 child-end handles, all distinct (each slot is its own dup). Task 5 REPLACES this with
+    // `crt_fds` `table.handles` (0/1/2 plus fd >= 3).
+    let all_handles: Vec<HANDLE> = slots.iter().map(|s| child_handle(&child_ends, *s)).collect();
+    let attr = AttributeList::build(&all_handles)?;
+    si.lpAttributeList = attr.as_ptr();
+    let contain_flags = 0u32; // Task 6 sets this (uncontained here)
+    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
+
+    // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
+    // the attribute list BEFORE the guard releases on EVERY path. An early `?` here would drop the
+    // inner-scope guard before `child_ends`/`attr` (Rust drops inner locals first), leaving
+    // inheritable handles exposed to a concurrent spawn — so compute a Result and drop explicitly.
+    let spawned = {
+        let _guard = spawn_lock();
+        let r = spawn_step(
+            &all_handles,
+            app_name.as_deref(),
+            &mut cmdline,
+            &mut si,
+            &env_block,
+            &cwd_w,
+            flags,
+        );
+        drop(child_ends); // close the child ends inside the lock, on success AND error
+        drop(attr); // DeleteProcThreadAttributeList before the guard releases
+        r
+    };
+    let (proc, pid) = spawned?;
+
+    // Identity read + attach BEFORE building `Child`, with the SAME kill+reap teardown as the std
+    // path (dropping the OwnedHandle alone neither kills nor reaps on Windows). Uncontained in
+    // Task 4: build the `mode: None` Prepared directly — `prepare` returns exactly this and would
+    // otherwise need a std `Command` we do not have.
+    let prepared = crate::containment::Prepared {
+        mode: None,
+        is_root: false,
+    };
+    let raw_handle = proc.as_raw_handle();
+    let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {
+        Ok(v) => v,
+        Err(e) => {
+            raw_spawn_teardown(proc, pid);
+            return Err(e);
+        }
+    };
+    let id = match resolve_identity(pid) {
+        Some(id) => id,
+        None => {
+            raw_spawn_teardown(proc, pid);
+            return Err(Error::Io(std::io::Error::other(
+                "spawned child vanished before its identity could be read",
+            )));
+        }
+    };
+
+    Ok(Child::from_parts(
+        ProcHandle::Raw(RawChild::new(proc, pid)),
+        id,
+        parent_ends,
+        kill_on_drop,
+        containment,
+        attached,
+    ))
+}
+
+/// Mark each listed handle inheritable, then spawn. Returns a Result WITHOUT `?`-ing so the caller
+/// can close the child ends + attribute list before releasing the spawn lock on either arm.
+fn spawn_step(
+    handles: &[HANDLE],
+    app: Option<&[u16]>,
+    cmdline: &mut [u16],
+    si: &mut STARTUPINFOEXW,
+    env: &Option<Vec<u16>>,
+    cwd: &Option<Vec<u16>>,
+    flags: u32,
+) -> Result<(OwnedHandle, u32), Error> {
+    for &h in handles {
+        set_inherit(h)?;
+    }
+    proc::create_process(app, cmdline, si, env, cwd, flags)
+}
+
+/// Kill + reap a just-spawned child whose post-spawn attach/identity read failed, so a failed spawn
+/// never leaks a running/zombie process (mirrors the std path's teardown).
+fn raw_spawn_teardown(proc: OwnedHandle, pid: u32) {
+    let rc = RawChild::new(proc, pid);
+    let _ = rc.kill();
+    if let Err(_e) = rc.wait() {
+        debug_assert!(false, "raw spawn teardown failed to reap child: {_e}");
+    }
+}
+
+fn child_handle(ends: &BTreeMap<Fd, ChildEnd>, slot: Fd) -> HANDLE {
+    // resolve_stdio with the 0/1/2 slot list always resolves all three (None -> inherit).
+    HANDLE(ends[&slot].as_raw_handle())
+}
+
+/// Mark `h` inheritable (`bInheritHandles` + the HANDLE_LIST require it).
+fn set_inherit(h: HANDLE) -> Result<(), Error> {
+    // SAFETY: `h` is a live child-end handle we own; SetHandleInformation only toggles its flags.
+    unsafe { SetHandleInformation(h, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }.map_err(|e| Error::Io(e.into()))
+}
+
+fn to_wide_nul(s: &OsStr) -> Vec<u16> {
+    s.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+/// Reject a `.bat`/`.cmd` program by the token that determines the loaded image: `executable()` if
+/// set, else the argv[0] / command-line first token. Runs before resolution.
+fn reject_batch_program(cmd: &Command) -> Result<(), Error> {
+    let token = cmd.executable_path().map(PathBuf::from).or_else(|| program_token(cmd));
+    if let Some(prog) = token {
+        reject_batch_path(&prog)?;
+    }
+    Ok(())
+}
+
+/// The program token (argv[0] / command-line first token) when `executable()` is unset.
+fn program_token(cmd: &Command) -> Option<PathBuf> {
+    match cmd.input() {
+        CommandInput::Empty => None,
+        CommandInput::Argv(argv) => argv.first().map(PathBuf::from),
+        CommandInput::CommandLine(line) => {
+            let wide: Vec<u16> = line.encode_wide().collect();
+            crate::quote::windows::first_token_wide(&wide).map(|t| PathBuf::from(OsString::from_wide(&t)))
+        }
+    }
+}
+
+/// Build the child's command line. argv[0] is always the user's name (independent of the loaded
+/// `executable()`); each token is NUL-checked. `commandline()` is passed through verbatim (the OS
+/// parses argv[0] as its first token); `argv` is joined via the MSVCRT quoter.
+fn raw_program_and_line(cmd: &Command) -> Result<Vec<u16>, Error> {
+    match cmd.input() {
+        CommandInput::Empty => {
+            // executable() alone, no argv/commandline: the OS uses lpApplicationName as argv[0].
+            if cmd.executable_path().is_some() {
+                Ok(Vec::new())
+            } else {
+                Err(Error::Io(std::io::Error::other("no program specified")))
+            }
+        }
+        CommandInput::Argv(argv) => {
+            if argv.is_empty() && cmd.executable_path().is_none() {
+                return Err(Error::Io(std::io::Error::other("empty argv")));
+            }
+            let mut wides: Vec<Vec<u16>> = Vec::with_capacity(argv.len());
+            for a in argv {
+                resolve::ensure_no_nul_wide(a)?;
+                wides.push(a.encode_wide().collect());
+            }
+            let refs: Vec<&[u16]> = wides.iter().map(Vec::as_slice).collect();
+            Ok(crate::quote::windows::join_wide(&refs))
+        }
+        CommandInput::CommandLine(line) => {
+            resolve::ensure_no_nul_wide(line)?;
+            Ok(line.encode_wide().collect())
+        }
+    }
+}
+
+/// RAII owner of a `PROC_THREAD_ATTRIBUTE_LIST` carrying a HANDLE_LIST. Deletes the list on drop.
+/// The handle array it references must outlive the list (per `UpdateProcThreadAttribute`): callers
+/// keep `all_handles` alive across both `CreateProcessW` and this drop.
+struct AttributeList {
+    _buf: Vec<u8>,
+    list: LPPROC_THREAD_ATTRIBUTE_LIST,
+}
+
+impl AttributeList {
+    fn build(handles: &[HANDLE]) -> Result<AttributeList, Error> {
+        let mut size: usize = 0;
+        // Sizing call: returns ERROR_INSUFFICIENT_BUFFER and writes the required byte count.
+        // SAFETY: the null-list form is the documented way to query the buffer size.
+        let _ = unsafe { InitializeProcThreadAttributeList(None, 1, None, &mut size) };
+        let mut buf: Vec<u8> = vec![0u8; size];
+        let list = LPPROC_THREAD_ATTRIBUTE_LIST(buf.as_mut_ptr().cast());
+        // SAFETY: `buf` is `size` bytes, matching the queried requirement; count = 1 (one attribute).
+        unsafe { InitializeProcThreadAttributeList(Some(list), 1, None, &mut size) }
+            .map_err(|e| Error::Io(e.into()))?;
+        // SAFETY: `list` is initialized; the HANDLE_LIST attribute takes an array of `handles.len()`
+        // HANDLEs by pointer (not copied), which the caller keeps alive until this list is deleted.
+        let update = unsafe {
+            UpdateProcThreadAttribute(
+                list,
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+                Some(handles.as_ptr().cast()),
+                std::mem::size_of_val(handles),
+                None,
+                None,
+            )
+        };
+        if let Err(e) = update {
+            // SAFETY: `list` was initialized above; delete it before `buf` drops.
+            unsafe { DeleteProcThreadAttributeList(list) };
+            return Err(Error::Io(e.into()));
+        }
+        Ok(AttributeList { _buf: buf, list })
+    }
+
+    fn as_ptr(&self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.list
+    }
+}
+
+impl Drop for AttributeList {
+    fn drop(&mut self) {
+        // SAFETY: `list` was initialized in `build`; Delete is its paired teardown.
+        unsafe { DeleteProcThreadAttributeList(self.list) };
+    }
+}

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -8,7 +8,6 @@
 //! in [`crt_fds`].
 
 #[path = "windows_raw/crt_fds.rs"]
-#[allow(dead_code)] // the fd-table encoder is consumed by the Task 5 fd>=3 spawn path; no caller yet
 mod crt_fds;
 
 #[path = "windows_raw/resolve.rs"]
@@ -41,8 +40,9 @@ use crate::command::{Command, CommandInput};
 use crate::error::Error;
 use crate::stdio::{Fd, ResolvedStdio};
 
-/// Spawn `cmd` via raw `CreateProcessW`. Task 4 scope: an UNCONTAINED child with std-only
-/// descriptors (0/1/2). fd >= 3 (Task 5) and containment (Task 6) leave their marked seams below.
+/// Spawn `cmd` via raw `CreateProcessW`. Handles an UNCONTAINED child with descriptors 0/1/2 plus
+/// arbitrary fd >= 3 (wired through the MSVCRT `lpReserved2` table). Containment (Task 6) leaves its
+/// marked seam below.
 pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
     // .bat/.cmd rejected on the raw program token BEFORE resolution, so a bad/nonexistent batch
     // path still errors loudly (CVE-2024-24576) rather than surfacing as a spawn failure.
@@ -61,21 +61,49 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let env_block = resolve::build_env_block(cmd.env_ops())?; // Task 6 may add the contain marker
     let cwd_w = cmd.cwd().map(|c| to_wide_nul(c.as_os_str()));
 
-    let slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR]; // Task 5 adds fd >= 3
+    // Cap the MSVCRT fd-table to the WORD-sized `cbReserved2` field BEFORE allocating anything
+    // (`encoded_len` is overflow-safe). `maxfd` is the largest configured slot; 0/1/2 always
+    // resolve, so the `2` floor covers an empty/low map.
+    let maxfd = fds.keys().map(|f| f.raw()).max().unwrap_or(2);
+    if !crt_fds::table_fits(crt_fds::encoded_len(maxfd)) {
+        return Err(Error::Unsupported {
+            op: format!("fd {maxfd}"),
+            platform: "windows",
+            detail: "descriptor table exceeds the 64KiB cbReserved2 limit".into(),
+        });
+    }
+
+    // Resolve 0/1/2 (always) plus any configured fd >= 3. `resolve_stdio` rejects inherit on fd >= 3.
+    let slots: Vec<Fd> = {
+        let mut v = vec![Fd::STDIN, Fd::STDOUT, Fd::STDERR];
+        v.extend(fds.keys().copied().filter(|f| f.raw() >= 3));
+        v
+    };
     let (child_ends, parent_ends) = resolve_stdio(&fds, &slots, PipeOwnership::Owned)?;
 
-    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2, plus an attribute list of exactly
-    // our child ends. hStd* wires the child's stdio; the HANDLE_LIST scopes inheritance to those
-    // handles AND backs EXTENDED_STARTUPINFO_PRESENT. (Task 5 adds fd >= 3 handles + lpReserved2.)
+    // Classify each resolved child end (0/1/2 + fd >= 3) for its CRT device flags, then encode the
+    // dense 0..=maxfd MSVCRT fd-table the child CRT reads back from `lpReserved2`.
+    let mut entries: BTreeMap<Fd, (HANDLE, crt_fds::FdKind)> = BTreeMap::new();
+    for (&slot, end) in &child_ends {
+        let h = HANDLE(end.as_raw_handle());
+        entries.insert(slot, (h, crt_fds::classify(h)?));
+    }
+    let table = crt_fds::encode(&entries);
+
+    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2; `lpReserved2` carries the fd-table so
+    // the child CRT recovers fd >= 3; the HANDLE_LIST scopes inheritance AND backs
+    // EXTENDED_STARTUPINFO_PRESENT. The table (`bytes`) is kept alive until after CreateProcessW.
     let mut si = STARTUPINFOEXW::default();
     si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     si.StartupInfo.hStdInput = child_handle(&child_ends, Fd::STDIN);
     si.StartupInfo.hStdOutput = child_handle(&child_ends, Fd::STDOUT);
     si.StartupInfo.hStdError = child_handle(&child_ends, Fd::STDERR);
-    // 0/1/2 child-end handles, all distinct (each slot is its own dup). Task 5 REPLACES this with
-    // `crt_fds` `table.handles` (0/1/2 plus fd >= 3).
-    let all_handles: Vec<HANDLE> = slots.iter().map(|s| child_handle(&child_ends, *s)).collect();
-    let attr = AttributeList::build(&all_handles)?;
+    si.StartupInfo.cbReserved2 = table.bytes.len() as u16; // fits: capped above
+    si.StartupInfo.lpReserved2 = table.bytes.as_ptr() as *mut u8;
+    // SINGLE handle source: `table.handles` is 0/1/2 + fd >= 3, each a distinct fresh dup from
+    // `resolve_stdio` (its 0/1/2 entries ARE the hStd* handles), so no duplicate reaches the list.
+    let all_handles: &[HANDLE] = &table.handles;
+    let attr = AttributeList::build(all_handles)?;
     si.lpAttributeList = attr.as_ptr();
     let contain_flags = 0u32; // Task 6 sets this (uncontained here)
     let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
@@ -87,7 +115,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let spawned = {
         let _guard = spawn_lock();
         let r = spawn_step(
-            &all_handles,
+            all_handles,
             app_name.as_deref(),
             &mut cmdline,
             &mut si,

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -94,17 +94,8 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     };
     let cwd_w = cmd.cwd().map(|c| to_wide_nul(c.as_os_str()));
 
-    // Cap the MSVCRT fd-table to the WORD-sized `cbReserved2` field BEFORE allocating anything
-    // (`encoded_len` is overflow-safe). `maxfd` is the largest configured slot; 0/1/2 always
-    // resolve, so the `2` floor covers an empty/low map.
-    let maxfd = fds.keys().map(|f| f.raw()).max().unwrap_or(2);
-    if !crt_fds::table_fits(crt_fds::encoded_len(maxfd)) {
-        return Err(Error::Unsupported {
-            op: format!("fd {maxfd}"),
-            platform: "windows",
-            detail: "descriptor table exceeds the 64KiB cbReserved2 limit".into(),
-        });
-    }
+    // Cap the MSVCRT fd-table to the WORD-sized `cbReserved2` field BEFORE allocating anything.
+    ensure_fd_table_fits(&fds)?;
 
     // Resolve 0/1/2 (always) plus any configured fd >= 3. `resolve_stdio` rejects inherit on fd >= 3.
     let slots: Vec<Fd> = {
@@ -114,14 +105,9 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     };
     let (child_ends, parent_ends) = resolve_stdio(&fds, &slots, PipeOwnership::Owned)?;
 
-    // Classify each resolved child end (0/1/2 + fd >= 3) for its CRT device flags, then encode the
-    // dense 0..=maxfd MSVCRT fd-table the child CRT reads back from `lpReserved2`.
-    let mut entries: BTreeMap<Fd, (HANDLE, crt_fds::FdKind)> = BTreeMap::new();
-    for (&slot, end) in &child_ends {
-        let h = HANDLE(end.as_raw_handle());
-        entries.insert(slot, (h, crt_fds::classify(h)?));
-    }
-    let table = crt_fds::encode(&entries);
+    // Classify each resolved child end (0/1/2 + fd >= 3) and encode the dense 0..=maxfd MSVCRT
+    // fd-table the child CRT reads back from `lpReserved2`.
+    let table = build_fd_table(&child_ends)?;
 
     // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2; `lpReserved2` carries the fd-table so
     // the child CRT recovers fd >= 3; the HANDLE_LIST scopes inheritance AND backs
@@ -195,6 +181,36 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
         containment,
         attached,
     ))
+}
+
+/// Reject a descriptor set whose dense MSVCRT fd-table would exceed the WORD-sized `cbReserved2`
+/// field, BEFORE any allocation (`encoded_len` is overflow-safe). `maxfd` is the largest configured
+/// slot; 0/1/2 always resolve, so the `2` floor covers an empty/low map. `pub(crate)`: shared with
+/// the async raw backend, which caps the same table.
+pub(crate) fn ensure_fd_table_fits(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<(), Error> {
+    let maxfd = fds.keys().map(|f| f.raw()).max().unwrap_or(2);
+    if !crt_fds::table_fits(crt_fds::encoded_len(maxfd)) {
+        return Err(Error::Unsupported {
+            op: format!("fd {maxfd}"),
+            platform: "windows",
+            detail: "descriptor table exceeds the 64KiB cbReserved2 limit".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Classify each resolved child end (0/1/2 + fd >= 3) for its CRT device flags, then encode the
+/// dense `0..=maxfd` MSVCRT fd-table the child CRT reads back from `lpReserved2`. The returned
+/// `handles` is the SINGLE inheritance source (0/1/2 + fd >= 3, each a distinct fresh dup), so no
+/// duplicate reaches the HANDLE_LIST. `pub(crate)`: shared with the async raw backend, which builds
+/// the identical table. Gate the caller on [`ensure_fd_table_fits`] first.
+pub(crate) fn build_fd_table(child_ends: &BTreeMap<Fd, ChildEnd>) -> Result<crt_fds::FdTable, Error> {
+    let mut entries: BTreeMap<Fd, (HANDLE, crt_fds::FdKind)> = BTreeMap::new();
+    for (&slot, end) in child_ends {
+        let h = HANDLE(end.as_raw_handle());
+        entries.insert(slot, (h, crt_fds::classify(h)?));
+    }
+    Ok(crt_fds::encode(&entries))
 }
 
 /// Mark each listed handle inheritable, then spawn. Returns a Result WITHOUT `?`-ing so the caller

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -8,3 +8,6 @@
 
 #[path = "windows_raw/crt_fds.rs"]
 mod crt_fds;
+
+#[path = "windows_raw/resolve.rs"]
+mod resolve;

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -10,13 +10,21 @@
 #[path = "windows_raw/crt_fds.rs"]
 mod crt_fds;
 
+// `pub(crate)`: the async raw backend (`crate::tokio::spawn::windows_raw`) reuses program/env/NUL
+// resolution verbatim.
 #[path = "windows_raw/resolve.rs"]
-mod resolve;
+pub(crate) mod resolve;
 
 #[path = "windows_raw/proc.rs"]
 mod proc;
 
 pub(crate) use proc::RawChild;
+// Additional seams the async raw backend reuses (Task 7): the cancellable handle wait + its
+// outcome, and the exit-status reader. The sync path uses these only inside `proc`, so the
+// re-export is tokio-only. (`create_process` is reached through the shared `spawn_step`, so it
+// needs no re-export.)
+#[cfg(feature = "tokio")]
+pub(crate) use proc::{exit_status, wait_handle_or_cancel, WaitOutcome};
 
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
@@ -191,7 +199,8 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
 
 /// Mark each listed handle inheritable, then spawn. Returns a Result WITHOUT `?`-ing so the caller
 /// can close the child ends + attribute list before releasing the spawn lock on either arm.
-fn spawn_step(
+/// `pub(crate)`: the async raw backend reuses the inheritable-mark + `create_process` window.
+pub(crate) fn spawn_step(
     handles: &[HANDLE],
     app: Option<&[u16]>,
     cmdline: &mut [u16],
@@ -207,8 +216,9 @@ fn spawn_step(
 }
 
 /// Kill + reap a just-spawned child whose post-spawn attach/identity read failed, so a failed spawn
-/// never leaks a running/zombie process (mirrors the std path's teardown).
-fn raw_spawn_teardown(proc: OwnedHandle, pid: u32) {
+/// never leaks a running/zombie process (mirrors the std path's teardown). `pub(crate)`: the async
+/// raw backend shares the identical error-teardown.
+pub(crate) fn raw_spawn_teardown(proc: OwnedHandle, pid: u32) {
     let rc = RawChild::new(proc, pid);
     let _ = rc.kill();
     if let Err(_e) = rc.wait() {
@@ -227,13 +237,14 @@ fn set_inherit(h: HANDLE) -> Result<(), Error> {
     unsafe { SetHandleInformation(h, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }.map_err(|e| Error::Io(e.into()))
 }
 
-fn to_wide_nul(s: &OsStr) -> Vec<u16> {
+pub(crate) fn to_wide_nul(s: &OsStr) -> Vec<u16> {
     s.encode_wide().chain(std::iter::once(0)).collect()
 }
 
 /// Reject a `.bat`/`.cmd` program by the token that determines the loaded image: `executable()` if
-/// set, else the argv[0] / command-line first token. Runs before resolution.
-fn reject_batch_program(cmd: &Command) -> Result<(), Error> {
+/// set, else the argv[0] / command-line first token. Runs before resolution. `pub(crate)`: shared
+/// with the async raw backend.
+pub(crate) fn reject_batch_program(cmd: &Command) -> Result<(), Error> {
     let token = cmd.executable_path().map(PathBuf::from).or_else(|| program_token(cmd));
     if let Some(prog) = token {
         reject_batch_path(&prog)?;
@@ -255,8 +266,9 @@ fn program_token(cmd: &Command) -> Option<PathBuf> {
 
 /// Build the child's command line. argv[0] is always the user's name (independent of the loaded
 /// `executable()`); each token is NUL-checked. `commandline()` is passed through verbatim (the OS
-/// parses argv[0] as its first token); `argv` is joined via the MSVCRT quoter.
-fn raw_program_and_line(cmd: &Command) -> Result<Vec<u16>, Error> {
+/// parses argv[0] as its first token); `argv` is joined via the MSVCRT quoter. `pub(crate)`: shared
+/// with the async raw backend.
+pub(crate) fn raw_program_and_line(cmd: &Command) -> Result<Vec<u16>, Error> {
     match cmd.input() {
         CommandInput::Empty => {
             // executable() alone, no argv/commandline: the OS uses lpApplicationName as argv[0].
@@ -287,14 +299,15 @@ fn raw_program_and_line(cmd: &Command) -> Result<Vec<u16>, Error> {
 
 /// RAII owner of a `PROC_THREAD_ATTRIBUTE_LIST` carrying a HANDLE_LIST. Deletes the list on drop.
 /// The handle array it references must outlive the list (per `UpdateProcThreadAttribute`): callers
-/// keep `all_handles` alive across both `CreateProcessW` and this drop.
-struct AttributeList {
+/// keep `all_handles` alive across both `CreateProcessW` and this drop. `pub(crate)`: the async raw
+/// backend builds the identical scoped inheritance list.
+pub(crate) struct AttributeList {
     _buf: Vec<u8>,
     list: LPPROC_THREAD_ATTRIBUTE_LIST,
 }
 
 impl AttributeList {
-    fn build(handles: &[HANDLE]) -> Result<AttributeList, Error> {
+    pub(crate) fn build(handles: &[HANDLE]) -> Result<AttributeList, Error> {
         let mut size: usize = 0;
         // Sizing call: returns ERROR_INSUFFICIENT_BUFFER and writes the required byte count.
         // SAFETY: the null-list form is the documented way to query the buffer size.
@@ -325,7 +338,7 @@ impl AttributeList {
         Ok(AttributeList { _buf: buf, list })
     }
 
-    fn as_ptr(&self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+    pub(crate) fn as_ptr(&self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
         self.list
     }
 }

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -36,13 +36,12 @@ use crate::child::spawn::{
     attach_or_fault, reject_batch_path, resolve_identity, resolve_stdio, spawn_lock, ChildEnd, PipeOwnership,
 };
 use crate::child::Child;
-use crate::command::{Command, CommandInput};
+use crate::command::{Command, CommandInput, EnvOp};
 use crate::error::Error;
 use crate::stdio::{Fd, ResolvedStdio};
 
-/// Spawn `cmd` via raw `CreateProcessW`. Handles an UNCONTAINED child with descriptors 0/1/2 plus
-/// arbitrary fd >= 3 (wired through the MSVCRT `lpReserved2` table). Containment (Task 6) leaves its
-/// marked seam below.
+/// Spawn `cmd` via raw `CreateProcessW`. Handles descriptors 0/1/2 plus arbitrary fd >= 3 (wired
+/// through the MSVCRT `lpReserved2` table), contained (Job Object / TreeWalk) or uncontained.
 pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
     // .bat/.cmd rejected on the raw program token BEFORE resolution, so a bad/nonexistent batch
     // path still errors loudly (CVE-2024-24576) rather than surfacing as a spawn failure.
@@ -58,7 +57,33 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let app_name: Option<Vec<u16>> = image.as_ref().map(|p| to_wide_nul(p.as_os_str()));
     let mut cmdline = raw_program_and_line(cmd)?; // each token NUL-checked
     cmdline.push(0);
-    let env_block = resolve::build_env_block(cmd.env_ops())?; // Task 6 may add the contain marker
+
+    // Containment: mirror `prepare`'s pre-spawn decision on the raw path. An uncontained spawn keeps
+    // the defaults (`contain_flags` 0, a `mode: None`/`is_root: false` `Prepared`); a Strongest root
+    // spawns CREATE_SUSPENDED and is job-assigned + resumed in `attach_or_fault`.
+    let req = cmd.contain_request();
+    let (contain_flags, is_root, marker_env) = if req.mode.is_some() {
+        let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
+        let is_root = !crate::containment::dispatch::is_nested(marker_present);
+        crate::containment::windows::clear_std_handle_inheritance();
+        let setup = crate::containment::dispatch::windows_contain_setup(&req, is_root);
+        (setup.creation_flags, is_root, setup.marker_env)
+    } else {
+        (0u32, false, false)
+    };
+
+    // Append the inherited root marker AFTER the user's env ops so it survives a user `env_clear()`
+    // (mirrors the std path setting the marker after the user's env).
+    let env_block = if marker_env {
+        let mut ops = cmd.env_ops().to_vec();
+        ops.push(EnvOp::Set(
+            OsString::from(crate::containment::NESTED_ENV),
+            OsString::from("1"),
+        ));
+        resolve::build_env_block(&ops)?
+    } else {
+        resolve::build_env_block(cmd.env_ops())?
+    };
     let cwd_w = cmd.cwd().map(|c| to_wide_nul(c.as_os_str()));
 
     // Cap the MSVCRT fd-table to the WORD-sized `cbReserved2` field BEFORE allocating anything
@@ -105,7 +130,6 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let all_handles: &[HANDLE] = &table.handles;
     let attr = AttributeList::build(all_handles)?;
     si.lpAttributeList = attr.as_ptr();
-    let contain_flags = 0u32; // Task 6 sets this (uncontained here)
     let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
 
     // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
@@ -130,12 +154,12 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let (proc, pid) = spawned?;
 
     // Identity read + attach BEFORE building `Child`, with the SAME kill+reap teardown as the std
-    // path (dropping the OwnedHandle alone neither kills nor reaps on Windows). Uncontained in
-    // Task 4: build the `mode: None` Prepared directly — `prepare` returns exactly this and would
-    // otherwise need a std `Command` we do not have.
+    // path (dropping the OwnedHandle alone neither kills nor reaps on Windows). The `Prepared`
+    // carries the REAL mode + is_root computed above, so `attach_or_fault` assigns the Job Object
+    // (Strongest root) or the TreeWalk/Delegated mechanism exactly as the std path does.
     let prepared = crate::containment::Prepared {
-        mode: None,
-        is_root: false,
+        mode: req.mode,
+        is_root,
     };
     let raw_handle = proc.as_raw_handle();
     let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {

--- a/src/child/spawn/windows_raw/crt_fds.rs
+++ b/src/child/spawn/windows_raw/crt_fds.rs
@@ -1,0 +1,155 @@
+//! MSVCRT `lpReserved2` fd-table encoder + a `GetFileType` device classifier.
+//!
+//! The child CRT recovers inherited descriptors n>=3 from
+//! `STARTUPINFO.lpReserved2`: a little-endian `i32` slot count, then `count`
+//! per-slot flag bytes, then `count` pointer-sized native-endian OS handles. A
+//! present slot carries `FOPEN` OR-ed with a device-kind bit; an interior gap
+//! carries a zero flag and `INVALID_HANDLE_VALUE`. See the CRT `ioinfo`/`osfile`
+//! layout that `__acrt_get_std_handle`/`_pipe` and friends read back.
+
+use std::collections::BTreeMap;
+
+use windows::Win32::Foundation::{GetLastError, SetLastError, HANDLE, INVALID_HANDLE_VALUE, NO_ERROR};
+use windows::Win32::Storage::FileSystem::{GetFileType, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE};
+
+use crate::error::Error;
+use crate::stdio::Fd;
+
+// MSVCRT per-slot flag bits (the CRT `ioinfo` `osfile` byte).
+const FOPEN: u8 = 0x01; // slot is in use
+const FPIPE: u8 = 0x08; // anonymous/named pipe
+const FDEV: u8 = 0x40; // character device (console/tty)
+
+// Byte width of a serialized handle in the blob: a native pointer.
+const HANDLE_SIZE: usize = size_of::<HANDLE>();
+
+/// Device class of an inherited handle, driving its CRT flag bits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FdKind {
+    Pipe,
+    File,
+    CharDev,
+}
+
+/// An encoded `lpReserved2` blob plus the present handles it references. The
+/// spawn path marks `handles` inheritable (and passes `bytes` as `lpReserved2`)
+/// before calling `CreateProcessW`.
+pub(crate) struct FdTable {
+    pub bytes: Vec<u8>,
+    pub handles: Vec<HANDLE>,
+}
+
+/// Classify `h` into the CRT device kind via `GetFileType`.
+///
+/// `GetFileType` returns `FILE_TYPE_UNKNOWN` both for a genuinely unknown (but
+/// valid) handle and on failure; the two are told apart by `GetLastError`. It
+/// does not reset last-error on the success path, so we clear it first — the
+/// canonical MSDN idiom — otherwise a stale nonzero code from an earlier call
+/// would masquerade as a classify failure.
+pub(crate) fn classify(h: HANDLE) -> Result<FdKind, Error> {
+    // SAFETY: `SetLastError` only writes the calling thread's last-error slot.
+    unsafe { SetLastError(NO_ERROR) };
+    // SAFETY: `GetFileType` reads only the handle's type; any handle value is a
+    // valid argument (an invalid one yields `FILE_TYPE_UNKNOWN` + a set error).
+    let file_type = unsafe { GetFileType(h) };
+    if file_type == FILE_TYPE_PIPE {
+        Ok(FdKind::Pipe)
+    } else if file_type == FILE_TYPE_CHAR {
+        Ok(FdKind::CharDev)
+    } else if file_type == FILE_TYPE_DISK {
+        Ok(FdKind::File)
+    } else {
+        // `FILE_TYPE_UNKNOWN` (or any other value): a set last-error means the
+        // call failed; `NO_ERROR` means the type is genuinely unknown (treat as
+        // a regular file for CRT flag purposes).
+        // SAFETY: reads the calling thread's last-error slot; no preconditions.
+        let err = unsafe { GetLastError() };
+        if err == NO_ERROR {
+            Ok(FdKind::File)
+        } else {
+            Err(Error::Io(std::io::Error::from_raw_os_error(err.0 as i32)))
+        }
+    }
+}
+
+/// The `osfile` flag byte for a present slot of the given kind.
+fn present_flag(kind: FdKind) -> u8 {
+    let kind_bits = match kind {
+        FdKind::Pipe => FPIPE,
+        FdKind::CharDev => FDEV,
+        FdKind::File => 0,
+    };
+    FOPEN | kind_bits
+}
+
+/// Byte length of the `lpReserved2` blob for a dense `0..=maxfd` table.
+///
+/// The exact length is computed with checked arithmetic. Any length that cannot
+/// fit the `WORD`-sized `cbReserved2` field can never reach `CreateProcessW`, so
+/// it is reported as `usize::MAX` — a saturating "does not fit" sentinel that
+/// [`table_fits`] rejects. This is overflow-safe on every target width (a
+/// negative fd, a narrow-`usize` multiply, or an `i32::MAX` fd all saturate to
+/// `usize::MAX`), so a wrapped-small value can never slip past the cap and admit
+/// a giant [`encode`] allocation.
+pub(crate) fn encoded_len(maxfd: i32) -> usize {
+    match usize::try_from(maxfd)
+        .ok()
+        .and_then(|m| m.checked_add(1))
+        .and_then(|n| n.checked_mul(1 + HANDLE_SIZE))
+        .and_then(|x| x.checked_add(4))
+    {
+        Some(len) if table_fits(len) => len,
+        _ => usize::MAX,
+    }
+}
+
+/// Whether an encoded blob fits the `WORD`-sized `cbReserved2` field.
+pub(crate) fn table_fits(byte_len: usize) -> bool {
+    byte_len <= u16::MAX as usize
+}
+
+/// Encode `entries` into a dense `0..=maxfd` `lpReserved2` blob (`maxfd` is the
+/// largest key; an empty map yields a zero-count blob). Interior gaps get a zero
+/// flag and `INVALID_HANDLE_VALUE`; present slots get `FOPEN | kind` and push
+/// their handle to `handles` (gap handles are NOT pushed).
+///
+/// Precondition: the caller has checked `table_fits(encoded_len(maxfd))` — this
+/// pre-sizes and fills the blob without re-checking the cap.
+pub(crate) fn encode(entries: &BTreeMap<Fd, (HANDLE, FdKind)>) -> FdTable {
+    let maxfd: i32 = entries.keys().next_back().map_or(-1, |fd| fd.raw());
+    debug_assert!(
+        entries.is_empty() || table_fits(encoded_len(maxfd)),
+        "encode called past the size cap; gate on table_fits(encoded_len(maxfd)) first"
+    );
+    // Slot count N = maxfd + 1 (0 for an empty map). `maxfd` is a real, in-range
+    // descriptor, so `+ 1` cannot overflow `i32`.
+    let n: usize = usize::try_from(maxfd).map_or(0, |m| m + 1);
+
+    let mut bytes = Vec::with_capacity((1 + HANDLE_SIZE).saturating_mul(n).saturating_add(4));
+    bytes.extend_from_slice(&(n as i32).to_le_bytes());
+
+    let mut handles: Vec<HANDLE> = Vec::new();
+    // Flags section: one byte per slot.
+    for i in 0..n {
+        match entries.get(&Fd::from_raw(i as i32)) {
+            Some((_, kind)) => bytes.push(present_flag(*kind)),
+            None => bytes.push(0),
+        }
+    }
+    // Handles section: one pointer-sized native-endian handle per slot.
+    for i in 0..n {
+        match entries.get(&Fd::from_raw(i as i32)) {
+            Some((h, _)) => {
+                bytes.extend_from_slice(&(h.0 as usize).to_ne_bytes());
+                handles.push(*h);
+            }
+            None => bytes.extend_from_slice(&(INVALID_HANDLE_VALUE.0 as usize).to_ne_bytes()),
+        }
+    }
+
+    FdTable { bytes, handles }
+}
+
+#[cfg(test)]
+#[path = "crt_fds_tests.rs"]
+mod crt_fds_tests;

--- a/src/child/spawn/windows_raw/crt_fds_tests.rs
+++ b/src/child/spawn/windows_raw/crt_fds_tests.rs
@@ -1,0 +1,53 @@
+use super::*;
+use crate::stdio::Fd;
+use std::collections::BTreeMap;
+const FOPEN: u8 = 0x01;
+const FPIPE: u8 = 0x08;
+const HSZ: usize = std::mem::size_of::<*mut core::ffi::c_void>();
+fn h(v: isize) -> windows::Win32::Foundation::HANDLE {
+    windows::Win32::Foundation::HANDLE(v as _)
+}
+
+#[test]
+fn encodes_count_flags_and_handles_for_fd3() {
+    let mut m = BTreeMap::new();
+    for (n, v) in [(0i32, 10isize), (1, 11), (2, 12)] {
+        m.insert(Fd::from_raw(n), (h(v), FdKind::CharDev));
+    }
+    m.insert(Fd::from_raw(3), (h(99), FdKind::Pipe));
+    let t = encode(&m);
+    assert_eq!(&t.bytes[0..4], &4i32.to_le_bytes());
+    assert_eq!(t.bytes[4 + 3] & (FOPEN | FPIPE), FOPEN | FPIPE);
+    assert_eq!(t.bytes.len(), 4 + 4 + 4 * HSZ);
+    assert_eq!(t.bytes.len(), encoded_len(3));
+    assert_eq!(t.handles.len(), 4);
+}
+#[test]
+fn interior_gap_is_invalid_handle_and_zero_flag() {
+    let mut m = BTreeMap::new();
+    m.insert(Fd::from_raw(3), (h(30), FdKind::Pipe));
+    m.insert(Fd::from_raw(5), (h(50), FdKind::File));
+    let t = encode(&m);
+    assert_eq!(&t.bytes[0..4], &6i32.to_le_bytes());
+    assert_eq!(t.bytes[4 + 4], 0);
+    let off = 4 + 6 + 4 * HSZ;
+    assert_eq!(&t.bytes[off..off + HSZ], &(-1isize as usize).to_ne_bytes()[..]);
+    assert_eq!(t.handles.len(), 2);
+}
+#[test]
+fn cap_computed_len_boundary_and_overflow_safe() {
+    assert!(table_fits(encoded_len(10)));
+    // exact boundary: the largest maxfd whose encoded_len <= u16::MAX fits; the next does not.
+    let hsz = std::mem::size_of::<*mut core::ffi::c_void>();
+    let max_n = (u16::MAX as usize - 4) / (1 + hsz); // N slots fit
+    assert!(table_fits(encoded_len((max_n - 1) as i32)));
+    assert!(!table_fits(encoded_len((max_n + 8) as i32)));
+    // overflow-safe: i32::MAX must saturate, not panic/wrap, and cleanly reject.
+    assert_eq!(encoded_len(i32::MAX), usize::MAX);
+    assert!(!table_fits(encoded_len(i32::MAX)));
+}
+#[test]
+fn classify_invalid_handle_is_error() {
+    // An invalid handle drives GetFileType -> FILE_TYPE_UNKNOWN with a nonzero GetLastError.
+    assert!(classify(windows::Win32::Foundation::INVALID_HANDLE_VALUE).is_err());
+}

--- a/src/child/spawn/windows_raw/proc.rs
+++ b/src/child/spawn/windows_raw/proc.rs
@@ -114,7 +114,9 @@ impl RawChild {
     }
 }
 
-/// The outcome of [`wait_handle_or_cancel`].
+/// The outcome of [`wait_handle_or_cancel`]. `Copy`/`Eq`: the async backend clones it across the
+/// per-instance test observer channel and asserts on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WaitOutcome {
     /// The process handle signaled — the child exited.
     Exited,
@@ -150,8 +152,9 @@ pub(crate) fn wait_handle_or_cancel(proc: HANDLE, cancel: Option<HANDLE>) -> io:
     }
 }
 
-/// Read an exited process's status. Only valid after the handle has signaled.
-fn exit_status(handle: HANDLE) -> io::Result<ExitStatus> {
+/// Read an exited process's status. Only valid after the handle has signaled. `pub(crate)`: the
+/// async raw backend reads its exit status through the same seam.
+pub(crate) fn exit_status(handle: HANDLE) -> io::Result<ExitStatus> {
     let mut code: u32 = 0;
     // SAFETY: `handle` is a live, owned process handle; the process has exited so its code is final.
     unsafe { GetExitCodeProcess(handle, &mut code) }?;

--- a/src/child/spawn/windows_raw/proc.rs
+++ b/src/child/spawn/windows_raw/proc.rs
@@ -44,12 +44,6 @@ impl RawChild {
         self.pid
     }
 
-    /// The process handle, for foreign/async control that borrows it (Task 7).
-    #[allow(dead_code)] // consumed by the async backend in Task 7
-    pub(crate) fn process_handle(&self) -> HANDLE {
-        self.handle()
-    }
-
     /// Block until the child exits, returning its status.
     pub(crate) fn wait(&self) -> io::Result<ExitStatus> {
         match wait_handle_or_cancel(self.handle(), None)? {

--- a/src/child/spawn/windows_raw/proc.rs
+++ b/src/child/spawn/windows_raw/proc.rs
@@ -13,7 +13,7 @@ use std::process::ExitStatus;
 use std::time::Instant;
 
 use windows::core::{PCWSTR, PWSTR};
-use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_EVENT, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED, HANDLE, WAIT_EVENT, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Threading::{
     CreateProcessW, GetExitCodeProcess, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject,
     PROCESS_CREATION_FLAGS, PROCESS_INFORMATION, STARTUPINFOEXW,
@@ -99,14 +99,17 @@ impl RawChild {
         // SAFETY: `handle` is our live, owned process handle; exit code 1 is the forced-kill code.
         match unsafe { TerminateProcess(self.handle(), 1) } {
             Ok(()) => Ok(()),
-            // TerminateProcess fails on an already-exited process; treat that as success.
-            Err(e) => {
-                if self.try_wait()?.is_some() {
-                    Ok(())
-                } else {
-                    Err(e.into())
-                }
+            // TerminateProcess reports ERROR_ACCESS_DENIED once the target is already exiting or
+            // exited. We hold a full-access handle to our OWN child, so a real permission failure
+            // is impossible — the denial means its exit is already underway and guaranteed. BLOCK
+            // on that exit (a genuine external event, never a timer) to confirm it, rather than a
+            // non-blocking `try_wait` that races the OS teardown window where TerminateProcess
+            // reports the denial *before* the process object is signaled (a spurious kill error).
+            Err(e) if e.code() == windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0) => {
+                self.wait()?;
+                Ok(())
             }
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/src/child/spawn/windows_raw/proc.rs
+++ b/src/child/spawn/windows_raw/proc.rs
@@ -1,0 +1,201 @@
+//! The raw-child process handle and the `CreateProcessW`/wait FFI primitives.
+//!
+//! [`RawChild`] owns the process `HANDLE` a raw spawn returns and answers the
+//! same wait/kill/identity questions as the std backend. [`create_process`] and
+//! [`wait_handle_or_cancel`] are the shared FFI seams the async backend reuses
+//! (Task 7): the former is the sole `CreateProcessW` call site, the latter a
+//! cancellable process wait.
+
+use std::io;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::os::windows::process::ExitStatusExt;
+use std::process::ExitStatus;
+use std::time::Instant;
+
+use windows::core::{PCWSTR, PWSTR};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_EVENT, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{
+    CreateProcessW, GetExitCodeProcess, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject,
+    PROCESS_CREATION_FLAGS, PROCESS_INFORMATION, STARTUPINFOEXW,
+};
+
+use crate::error::Error;
+
+/// `WaitForSingleObject`/`WaitForMultipleObjects` "no timeout" sentinel.
+const INFINITE: u32 = 0xFFFF_FFFF;
+
+/// A child spawned via raw `CreateProcessW`, owning its process handle directly.
+#[derive(Debug)]
+pub(crate) struct RawChild {
+    proc: OwnedHandle,
+    pid: u32,
+}
+
+impl RawChild {
+    pub(crate) fn new(proc: OwnedHandle, pid: u32) -> RawChild {
+        RawChild { proc, pid }
+    }
+
+    fn handle(&self) -> HANDLE {
+        HANDLE(self.proc.as_raw_handle())
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.pid
+    }
+
+    /// The process handle, for foreign/async control that borrows it (Task 7).
+    #[allow(dead_code)] // consumed by the async backend in Task 7
+    pub(crate) fn process_handle(&self) -> HANDLE {
+        self.handle()
+    }
+
+    /// Block until the child exits, returning its status.
+    pub(crate) fn wait(&self) -> io::Result<ExitStatus> {
+        match wait_handle_or_cancel(self.handle(), None)? {
+            WaitOutcome::Exited => exit_status(self.handle()),
+            WaitOutcome::Cancelled => unreachable!("wait with no cancel handle cannot be cancelled"),
+        }
+    }
+
+    /// The exit status if the child has already exited, else `None`.
+    pub(crate) fn try_wait(&self) -> io::Result<Option<ExitStatus>> {
+        // SAFETY: `handle` is our live, owned process handle; a zero timeout polls without blocking.
+        let r = unsafe { WaitForSingleObject(self.handle(), 0) };
+        if r == WAIT_OBJECT_0 {
+            Ok(Some(exit_status(self.handle())?))
+        } else if r == WAIT_TIMEOUT {
+            Ok(None)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    /// Block until the child exits or `deadline` passes (`Ok(None)` at expiry). The wait is on a
+    /// real external event (child exit); the timeout is the caller's deadline, not a sync bet.
+    pub(crate) fn wait_deadline(&self, deadline: Instant) -> io::Result<Option<ExitStatus>> {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            // Cap below INFINITE so a >49-day deadline never becomes an unbounded wait; the loop
+            // re-arms against the true deadline if the OS wait returns early on the cap.
+            let millis = u32::try_from(remaining.as_millis()).unwrap_or(INFINITE - 1);
+            // SAFETY: `handle` is our live, owned process handle.
+            let r = unsafe { WaitForSingleObject(self.handle(), millis) };
+            if r == WAIT_OBJECT_0 {
+                return Ok(Some(exit_status(self.handle())?));
+            } else if r == WAIT_TIMEOUT {
+                if Instant::now() >= deadline {
+                    return Ok(None);
+                }
+                continue; // capped wait elapsed before the deadline; re-arm
+            } else {
+                return Err(io::Error::last_os_error());
+            }
+        }
+    }
+
+    /// Hard-kill the process. An already-exited child is success (matches std's `kill`).
+    pub(crate) fn kill(&self) -> io::Result<()> {
+        // SAFETY: `handle` is our live, owned process handle; exit code 1 is the forced-kill code.
+        match unsafe { TerminateProcess(self.handle(), 1) } {
+            Ok(()) => Ok(()),
+            // TerminateProcess fails on an already-exited process; treat that as success.
+            Err(e) => {
+                if self.try_wait()?.is_some() {
+                    Ok(())
+                } else {
+                    Err(e.into())
+                }
+            }
+        }
+    }
+}
+
+/// The outcome of [`wait_handle_or_cancel`].
+pub(crate) enum WaitOutcome {
+    /// The process handle signaled — the child exited.
+    Exited,
+    /// The cancel handle signaled first (async grace cancellation, Task 7).
+    Cancelled,
+}
+
+/// Wait for `proc` to exit, or for `cancel` (if given) to signal first. With no cancel handle this
+/// is a plain blocking wait; the cancel arm backs the async backend's grace cancellation (Task 7).
+pub(crate) fn wait_handle_or_cancel(proc: HANDLE, cancel: Option<HANDLE>) -> io::Result<WaitOutcome> {
+    match cancel {
+        Some(cancel) => {
+            let handles = [proc, cancel];
+            // SAFETY: both handles are live for the duration of the wait.
+            let r = unsafe { WaitForMultipleObjects(&handles, false, INFINITE) };
+            if r == WAIT_OBJECT_0 {
+                Ok(WaitOutcome::Exited)
+            } else if r == WAIT_EVENT(WAIT_OBJECT_0.0 + 1) {
+                Ok(WaitOutcome::Cancelled)
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+        None => {
+            // SAFETY: `proc` is live for the duration of the wait.
+            let r = unsafe { WaitForSingleObject(proc, INFINITE) };
+            if r == WAIT_OBJECT_0 {
+                Ok(WaitOutcome::Exited)
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+}
+
+/// Read an exited process's status. Only valid after the handle has signaled.
+fn exit_status(handle: HANDLE) -> io::Result<ExitStatus> {
+    let mut code: u32 = 0;
+    // SAFETY: `handle` is a live, owned process handle; the process has exited so its code is final.
+    unsafe { GetExitCodeProcess(handle, &mut code) }?;
+    Ok(ExitStatus::from_raw(code))
+}
+
+/// The sole `CreateProcessW` call site, shared by the sync and async raw backends. The caller
+/// pre-fills `si.StartupInfo` (`dwFlags`/`hStd*`) and `si.lpAttributeList`, and passes a mutable
+/// NUL-terminated `cmdline` (`CreateProcessW` may edit it in place). Sets `si.StartupInfo.cb` here
+/// so every caller gets the extended-struct size right. Returns the owned process handle + pid.
+pub(crate) fn create_process(
+    app: Option<&[u16]>,
+    cmdline: &mut [u16],
+    si: &mut STARTUPINFOEXW,
+    env: &Option<Vec<u16>>,
+    cwd: &Option<Vec<u16>>,
+    flags: u32,
+) -> Result<(OwnedHandle, u32), Error> {
+    si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+    let mut pi = PROCESS_INFORMATION::default();
+    let app = app.map_or(PCWSTR::null(), |w| PCWSTR(w.as_ptr()));
+    let cwd = cwd.as_ref().map_or(PCWSTR::null(), |w| PCWSTR(w.as_ptr()));
+    let env_ptr = env.as_ref().map(|b| b.as_ptr() as *const core::ffi::c_void);
+    // SAFETY: all pointers are valid for the call; `cmdline` is a mutable NUL-terminated buffer
+    // `CreateProcessW` may edit in place; `&si.StartupInfo` is backed by the full `STARTUPINFOEXW`
+    // (cb set above, EXTENDED_STARTUPINFO_PRESENT in `flags`).
+    unsafe {
+        CreateProcessW(
+            app,
+            Some(PWSTR(cmdline.as_mut_ptr())),
+            None,
+            None,
+            true,
+            PROCESS_CREATION_FLAGS(flags),
+            env_ptr,
+            cwd,
+            &si.StartupInfo,
+            &mut pi,
+        )
+    }
+    .map_err(|e| Error::Io(e.into()))?;
+    // SAFETY: `CreateProcessW` succeeded, so `hProcess` is a valid handle we now own.
+    let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess.0) };
+    // SAFETY: `hThread` is owned and unneeded; close it. This runs under the spawn lock, so a
+    // panic here (debug_assert) would poison the lock and cascade to every future spawn — log only.
+    if let Err(e) = unsafe { CloseHandle(pi.hThread) } {
+        log::debug!("CloseHandle(hThread): {e:?}");
+    }
+    Ok((proc, pi.dwProcessId))
+}

--- a/src/child/spawn/windows_raw/resolve.rs
+++ b/src/child/spawn/windows_raw/resolve.rs
@@ -1,0 +1,163 @@
+//! Program resolution + Windows environment-block construction for the raw
+//! `CreateProcessW` backend.
+//!
+//! [`resolve_executable`] applies a deliberate cwd+`PATH`+`.exe` rule (base cwd
+//! first, then `PATH` directories; append `.exe` only when the program has no
+//! extension) rather than full `CreateProcessW` search parity — this keeps
+//! `.bat`/`.cmd` out of resolution so batch-program rejection stays a separate
+//! concern. [`build_env_block`] produces the sorted, wide, double-NUL block
+//! `CreateProcessW` expects from a recorded [`EnvOp`] sequence.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use crate::command::EnvOp;
+use crate::error::Error;
+
+// Program resolution =====
+
+/// Resolve `exe` against the current process's cwd and `PATH`.
+///
+/// Convenience wrapper over [`resolve_executable_in`] seeded from
+/// [`std::env::current_dir`] and the `PATH` variable.
+pub(crate) fn resolve_executable(exe: &Path) -> Result<PathBuf, Error> {
+    let base_cwd = std::env::current_dir()?;
+    let path = std::env::var_os("PATH");
+    resolve_executable_in(exe, &base_cwd, path.as_deref())
+}
+
+/// Resolve `exe` against an explicit `base_cwd` and `PATH` string.
+///
+/// An absolute `exe` that is an existing file is returned unchanged. Otherwise
+/// the search visits `base_cwd` first, then each `PATH` directory, testing
+/// `dir/exe` and — only when `exe` carries no extension — `dir/exe.exe`; the
+/// first existing file wins. A miss is [`std::io::ErrorKind::NotFound`].
+///
+/// Existence is tested with [`Path::is_file`], not [`Path::exists`]: a directory
+/// is never a runnable program, so a same-named directory must not shadow the
+/// executable (which would end the search early and hand `CreateProcessW` an
+/// unlaunchable path with no fallback).
+pub(crate) fn resolve_executable_in(exe: &Path, base_cwd: &Path, path: Option<&OsStr>) -> Result<PathBuf, Error> {
+    if exe.is_absolute() && exe.is_file() {
+        return Ok(exe.to_path_buf());
+    }
+
+    let append_exe = exe.extension().is_none();
+    let path_dirs = path.into_iter().flat_map(std::env::split_paths);
+    let dirs = std::iter::once(base_cwd.to_path_buf()).chain(path_dirs);
+
+    for dir in dirs {
+        let candidate = dir.join(exe);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+        if append_exe {
+            let with_exe = candidate.with_extension("exe");
+            if with_exe.is_file() {
+                return Ok(with_exe);
+            }
+        }
+    }
+
+    Err(Error::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("could not resolve executable: {}", exe.display()),
+    )))
+}
+
+// Environment block =====
+
+/// Build the `CreateProcessW` environment block for `ops`, inheriting the parent
+/// environment as the base.
+pub(crate) fn build_env_block(ops: &[EnvOp]) -> Result<Option<Vec<u16>>, Error> {
+    let base: Vec<(OsString, OsString)> = std::env::vars_os().collect();
+    build_env_block_from(&base, ops)
+}
+
+/// Build the `CreateProcessW` environment block from an explicit `base` plus
+/// `ops`.
+///
+/// Returns `Ok(None)` when `ops` is empty — the child inherits the parent
+/// environment. Otherwise the block is a UTF-16 sequence of `KEY=VAL\0` entries
+/// sorted by their case-folded key and closed by a trailing `\0` (a
+/// double-NUL terminator). Keys collide case-insensitively (Windows env
+/// semantics), last write wins, and the last writer's key casing is emitted. An
+/// embedded NUL in any key or value is [`std::io::ErrorKind::InvalidInput`].
+pub(crate) fn build_env_block_from(base: &[(OsString, OsString)], ops: &[EnvOp]) -> Result<Option<Vec<u16>>, Error> {
+    if ops.is_empty() {
+        return Ok(None);
+    }
+
+    // Keyed by the case-folded key; the value keeps the original-case key so the
+    // emitted block preserves the caller's casing.
+    let mut vars: BTreeMap<Vec<u16>, (OsString, OsString)> = BTreeMap::new();
+    for (key, val) in base {
+        vars.insert(fold_key(key), (key.clone(), val.clone()));
+    }
+    for op in ops {
+        match op {
+            EnvOp::Set(key, val) => {
+                vars.insert(fold_key(key), (key.clone(), val.clone()));
+            }
+            EnvOp::Remove(key) => {
+                vars.remove(&fold_key(key));
+            }
+            EnvOp::Clear => vars.clear(),
+        }
+    }
+
+    let mut block: Vec<u16> = Vec::new();
+    // An empty-but-present environment is signalled by a leading NUL, so the
+    // block is never a lone terminator that `CreateProcessW` reads as "inherit".
+    if vars.is_empty() {
+        block.push(0);
+    }
+    for (key, val) in vars.values() {
+        ensure_no_nul_wide(key)?;
+        ensure_no_nul_wide(val)?;
+        block.extend(key.encode_wide());
+        block.push(u16::from(b'='));
+        block.extend(val.encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    Ok(Some(block))
+}
+
+/// Reject a key or value carrying an embedded NUL, which would truncate the
+/// wide, NUL-delimited environment block.
+pub(crate) fn ensure_no_nul_wide(s: &OsStr) -> Result<(), Error> {
+    if s.encode_wide().any(|unit| unit == 0) {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "environment key or value contains an embedded NUL",
+        )));
+    }
+    Ok(())
+}
+
+/// Case-fold an environment key for case-insensitive comparison and sorting.
+///
+/// Uppercases each Unicode scalar of the UTF-16 encoding; unpaired surrogates
+/// (which have no case) pass through unchanged so distinct keys never collide.
+fn fold_key(key: &OsStr) -> Vec<u16> {
+    let mut folded = Vec::new();
+    for unit in char::decode_utf16(key.encode_wide()) {
+        match unit {
+            Ok(c) => {
+                let mut buf = [0u16; 2];
+                for upper in c.to_uppercase() {
+                    folded.extend_from_slice(upper.encode_utf16(&mut buf));
+                }
+            }
+            Err(e) => folded.push(e.unpaired_surrogate()),
+        }
+    }
+    folded
+}
+
+#[cfg(test)]
+#[path = "resolve_tests.rs"]
+mod resolve_tests;

--- a/src/child/spawn/windows_raw/resolve_tests.rs
+++ b/src/child/spawn/windows_raw/resolve_tests.rs
@@ -1,0 +1,129 @@
+use super::*;
+use crate::command::EnvOp;
+use std::ffi::OsString;
+
+#[test]
+fn resolve_absolute_existing_is_returned_as_is() {
+    let me = std::env::current_exe().unwrap();
+    assert_eq!(resolve_executable(&me).unwrap(), me);
+}
+#[test]
+fn resolve_bare_name_prefers_base_cwd_over_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let shadow = dir.path().join("sp_shadow.exe");
+    std::fs::copy(std::env::current_exe().unwrap(), &shadow).unwrap();
+    // Explicit base dir — no process-global SetCurrentDirectory, so parallel tests can't race.
+    let got = resolve_executable_in(std::path::Path::new("sp_shadow"), dir.path(), None).unwrap();
+    assert_eq!(got.canonicalize().unwrap(), shadow.canonicalize().unwrap());
+}
+#[test]
+fn resolve_bare_name_appends_exe_from_path() {
+    let p = resolve_executable(std::path::Path::new("cmd")).unwrap();
+    assert!(
+        p.is_absolute() && p.exists() && p.extension().is_some_and(|e| e.eq_ignore_ascii_case("exe")),
+        "{p:?}"
+    );
+}
+#[test]
+fn empty_ops_inherit() {
+    assert!(build_env_block(&[]).unwrap().is_none());
+}
+#[test]
+fn set_sorts_ci_and_double_nul() {
+    let b = build_env_block_from(
+        &[],
+        &[
+            EnvOp::Set("Zeta".into(), "1".into()),
+            EnvOp::Set("alpha".into(), "2".into()),
+        ],
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(&b[b.len() - 2..], &[0u16, 0u16]);
+    let s = String::from_utf16(&b).unwrap();
+    assert!(s.find("alpha=").unwrap() < s.find("Zeta=").unwrap(), "{s:?}");
+}
+#[test]
+fn remove_is_case_insensitive() {
+    let b = build_env_block_from(
+        &[(OsString::from("SP_R"), OsString::from("x"))],
+        &[EnvOp::Remove("sp_r".into())],
+    )
+    .unwrap()
+    .unwrap();
+    assert!(!String::from_utf16(&b).unwrap().to_uppercase().contains("SP_R="));
+}
+#[test]
+fn clear_then_set_yields_only_the_set_var() {
+    let b = build_env_block_from(
+        &[(OsString::from("PATH"), OsString::from("x"))],
+        &[EnvOp::Clear, EnvOp::Set("ONLYME".into(), "1".into())],
+    )
+    .unwrap()
+    .unwrap();
+    let s = String::from_utf16(&b).unwrap();
+    assert!(s.contains("ONLYME=1") && !s.to_uppercase().contains("PATH="));
+}
+#[test]
+fn embedded_nul_is_rejected() {
+    let e = build_env_block_from(&[], &[EnvOp::Set("K".into(), OsString::from("a\u{0}b"))]).unwrap_err();
+    assert!(matches!(e, crate::error::Error::Io(_)));
+}
+#[test]
+fn resolve_skips_directory_shadow_and_finds_path_exe() {
+    let base = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    // A directory in base_cwd whose name matches the bare program must not
+    // shadow the real executable found later on PATH — a directory can never run.
+    std::fs::create_dir(base.path().join("sp_dirtool")).unwrap();
+    let path_copy = other.path().join("sp_dirtool.exe");
+    std::fs::copy(std::env::current_exe().unwrap(), &path_copy).unwrap();
+    let got = resolve_executable_in(
+        std::path::Path::new("sp_dirtool"),
+        base.path(),
+        Some(other.path().as_os_str()),
+    )
+    .unwrap();
+    assert_eq!(got.canonicalize().unwrap(), path_copy.canonicalize().unwrap());
+}
+#[test]
+fn resolve_absolute_directory_is_not_returned() {
+    let dir = tempfile::tempdir().unwrap();
+    // An absolute path naming an existing *directory* is not a runnable program.
+    let got = resolve_executable_in(dir.path(), std::path::Path::new("."), None);
+    assert!(got.is_err(), "{got:?}");
+}
+#[test]
+fn base_cwd_shadows_path_when_both_have_exe() {
+    let base = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    let me = std::env::current_exe().unwrap();
+    let base_copy = base.path().join("sp_pref.exe");
+    std::fs::copy(&me, &base_copy).unwrap();
+    std::fs::copy(&me, other.path().join("sp_pref.exe")).unwrap();
+    // base_cwd precedes PATH: the base_cwd copy wins even though PATH also has one.
+    let got = resolve_executable_in(
+        std::path::Path::new("sp_pref"),
+        base.path(),
+        Some(other.path().as_os_str()),
+    )
+    .unwrap();
+    assert_eq!(got.canonicalize().unwrap(), base_copy.canonicalize().unwrap());
+}
+#[test]
+fn clear_only_yields_empty_double_nul_block() {
+    // An empty-but-present environment is a bare double-NUL, distinct from the
+    // `None` "inherit" signal — pins the leading-NUL push.
+    let b = build_env_block_from(&[(OsString::from("A"), OsString::from("1"))], &[EnvOp::Clear])
+        .unwrap()
+        .unwrap();
+    assert_eq!(b, vec![0u16, 0u16]);
+}
+#[test]
+fn embedded_nul_in_key_is_rejected_as_invalid_input() {
+    let e = build_env_block_from(&[], &[EnvOp::Set(OsString::from("a\u{0}b"), "1".into())]).unwrap_err();
+    assert!(
+        matches!(e, crate::error::Error::Io(ref io) if io.kind() == std::io::ErrorKind::InvalidInput),
+        "{e:?}"
+    );
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -91,10 +91,11 @@ impl Command {
     ///
     /// # Platform note
     ///
-    /// Combining `commandline` with [`executable`](Self::executable) is
-    /// unsupported on Windows in this plan (returns
-    /// [`Error::Unsupported`](crate::error::Error::Unsupported)); POSIX
-    /// supports it.
+    /// Combining `commandline` with [`executable`](Self::executable) is supported
+    /// on both POSIX and Windows. On Windows the raw `CreateProcessW` backend sets
+    /// the loaded image (`lpApplicationName`) independently of the command line
+    /// (`lpCommandLine`), so `executable` selects the file that runs while the
+    /// child's argv[0] is the command line's first token.
     pub fn commandline<S: Into<OsString>>(&mut self, line: S) -> &mut Command {
         self.input = CommandInput::CommandLine(line.into());
         self
@@ -109,12 +110,13 @@ impl Command {
     /// `executable("/bin/busybox").args(["sh", "-c", "..."])` correctly loads
     /// busybox while the child sees `"sh"` as its argv[0].
     ///
-    /// On Windows, `std::process` has no stable API to set argv[0] independently
-    /// of the executable, so argv[0] will be the executable path instead of the
-    /// user-supplied value. This limitation is lifted in Plan 4's raw backend.
-    /// Combining `executable` with [`commandline`](Self::commandline) is
-    /// unsupported on Windows (returns
-    /// [`Error::Unsupported`](crate::error::Error::Unsupported)).
+    /// On Windows, a set `executable` spawns through the raw `CreateProcessW`
+    /// backend, which sets `lpApplicationName` independently of `lpCommandLine` —
+    /// so argv[0] is preserved (it no longer degrades to the executable path), and
+    /// combining `executable` with [`commandline`](Self::commandline) is supported.
+    /// A bare or relative `executable` is resolved with a deliberate rule (not full
+    /// `CreateProcessW` search parity): the current directory first, then each
+    /// `PATH` directory, appending `.exe` when the name has no extension.
     pub fn executable<P: Into<PathBuf>>(&mut self, path: P) -> &mut Command {
         self.executable = Some(path.into());
         self
@@ -130,6 +132,16 @@ impl Command {
 
     /// Wire descriptor `slot` to `target`. Errors now if the target's direction
     /// is ambiguous for `slot` (a bare `pipe()` on a descriptor >= 3).
+    ///
+    /// # Platform note
+    ///
+    /// A descriptor `slot >= 3` is delivered on Windows through the raw
+    /// `CreateProcessW` backend's MSVCRT `lpReserved2` fd-table, so only a child
+    /// linked against the MSVC/UCRT runtime sees it as a numbered fd; a non-MSVCRT
+    /// child (foreign or no CRT) cannot recover it — inherent to the CRT-private
+    /// table, not a bug. `Stdio::inherit()` on a `slot >= 3` (no defined parent
+    /// stream) and a chained merge (a merge whose target is itself a merge) remain
+    /// [`Error::Unsupported`](crate::error::Error::Unsupported) on every platform.
     pub fn fd(&mut self, slot: impl Into<Fd>, target: Stdio) -> Result<&mut Command, Error> {
         let slot = slot.into();
         let resolved = target.resolve(slot)?;

--- a/src/command.rs
+++ b/src/command.rs
@@ -217,7 +217,6 @@ impl Command {
         self
     }
 
-    #[allow(dead_code)]
     pub(crate) fn contain_request(&self) -> ContainRequest {
         self.contain
     }

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -179,6 +179,42 @@ pub(crate) fn unix_setup_for(mode: Option<ContainMode>) -> UnixSetup {
     }
 }
 
+/// The Windows pre-spawn containment decision, shared by the std `prepare` path and the raw
+/// `CreateProcessW` backend. Encodes ONLY the decision; the caller applies it (`creation_flags`
+/// onto the command, the root env marker, `clear_std_handle_inheritance`).
+#[cfg(windows)]
+pub(crate) struct WindowsContain {
+    /// Creation flags to OR into the spawn: `root_flags` (suspend + new group) for a Strongest
+    /// root, `group_flags` (new group only) otherwise; `0` when uncontained (`mode` is `None`).
+    pub creation_flags: u32,
+    /// Whether this spawn must set the inherited root marker so descendants join THIS group.
+    pub marker_env: bool,
+}
+
+/// Decide the Windows pre-spawn containment flags + marker for `req`/`is_root`. Pure — directly
+/// unit-testable. Returns `{ creation_flags: 0, marker_env: false }` when `req.mode` is `None`.
+#[cfg(windows)]
+pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> WindowsContain {
+    let Some(mode) = req.mode else {
+        return WindowsContain {
+            creation_flags: 0,
+            marker_env: false,
+        };
+    };
+    let creation_flags = if is_root && !matches!(mode, ContainMode::TreeWalk) {
+        // Strongest root: suspend + new process group (job assigned in attach).
+        crate::containment::windows::root_flags()
+    } else {
+        // TreeWalk root (no suspend, no job — identity teardown) and all nested spawns:
+        // CREATE_NEW_PROCESS_GROUP only, so `terminate` can CTRL_BREAK the root's group.
+        crate::containment::windows::group_flags()
+    };
+    WindowsContain {
+        creation_flags,
+        marker_env: is_root && req.nesting == Nesting::Mark,
+    }
+}
+
 /// Phase 1 (before spawn): env-marker root detection + pre-spawn OS setup.
 pub(crate) fn prepare(std_cmd: &mut std::process::Command, req: &ContainRequest) -> Prepared {
     let mode = req.mode;
@@ -272,19 +308,16 @@ pub(crate) fn prepare(std_cmd: &mut std::process::Command, req: &ContainRequest)
         }
     }
 
-    // Windows: clear handle inheritance + apply creation_flags.
+    // Windows: clear handle inheritance + apply creation_flags. The flag/marker decision
+    // lives in `windows_contain_setup` (shared with the raw `CreateProcessW` backend); the
+    // root marker itself is applied above (shared with the Unix path), so only the creation
+    // flags are applied here.
     #[cfg(windows)]
     if mode.is_some() {
+        use std::os::windows::process::CommandExt;
         crate::containment::windows::clear_std_handle_inheritance();
-        if is_root && !matches!(mode, Some(ContainMode::TreeWalk)) {
-            // Strongest root: suspend + new process group (job assigned in attach).
-            crate::containment::windows::set_root_flags(std_cmd);
-        } else {
-            // TreeWalk root (no suspend, no job — identity teardown) and all
-            // nested spawns: CREATE_NEW_PROCESS_GROUP only, so `terminate` can
-            // CTRL_BREAK the root's group.
-            crate::containment::windows::set_group_flags(std_cmd);
-        }
+        let setup = windows_contain_setup(req, is_root);
+        std_cmd.creation_flags(setup.creation_flags);
     }
 
     #[allow(unreachable_code)]
@@ -401,7 +434,7 @@ pub(crate) fn attach(
                 Ok(None) => {
                     // Job assignment failed: fall back to the universal TreeWalk
                     // mechanism rather than silently yielding no containment. The
-                    // root was spawned with CREATE_NEW_PROCESS_GROUP (set_root_flags),
+                    // root was spawned with CREATE_NEW_PROCESS_GROUP (root_flags),
                     // so `terminate`'s CTRL_BREAK still reaches the group.
                     return Ok((Containment::TreeWalk, Attached::TreeWalk(resolve_root_id(pid)?)));
                 }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -324,6 +324,41 @@ pub(crate) fn attach_job(proc_handle: std::os::windows::io::RawHandle) -> io::Re
     }
 }
 
+/// Test-only membership probe: whether `pid` is inside the Job Object held by `attached`, via
+/// `IsProcessInJob` against OUR job handle (not "any job"). Membership is immutable once assigned,
+/// so it is deterministic for a handle-pinned child regardless of run state. Shared by the sync and
+/// async `Child::test_job_handle_contains_self` accessors (both compiled outside `cfg(test)` so
+/// integration crates can call them).
+pub(crate) fn job_contains_pid(attached: &crate::containment::Attached, pid: u32) -> bool {
+    use windows::Win32::System::JobObjects::IsProcessInJob;
+    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_INFORMATION};
+
+    let crate::containment::Attached::JobObject(job) = attached else {
+        return false;
+    };
+    let Some(job_handle) = job.as_handle() else {
+        return false;
+    };
+
+    // Open the child process by PID; the backend doesn't expose its handle.
+    // SAFETY: standard Win32 call; the handle is closed below.
+    let process_handle = unsafe {
+        match OpenProcess(PROCESS_QUERY_INFORMATION, false, pid) {
+            Ok(h) => h,
+            Err(_) => return false,
+        }
+    };
+
+    let mut in_job = windows::core::BOOL(0);
+    // SAFETY: both handles are valid for the duration of the call.
+    let ok = unsafe { IsProcessInJob(process_handle, Some(job_handle), &mut in_job) };
+    // SAFETY: `process_handle` was opened above and must be closed.
+    unsafe {
+        let _ = CloseHandle(process_handle);
+    }
+    ok.is_ok() && in_job.as_bool()
+}
+
 #[cfg(test)]
 #[path = "windows_tests.rs"]
 mod windows_tests;

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -149,20 +149,19 @@ impl Drop for JobHandle {
     }
 }
 
-/// Apply pre-spawn flags to `std_cmd` for a root spawn.
+/// Pre-spawn creation flags for a root spawn.
 /// `CREATE_SUSPENDED`: child must not execute before it is inside the job.
 /// `CREATE_NEW_PROCESS_GROUP`: child leads its own console group so
 /// `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` can target it.
-pub(crate) fn set_root_flags(std_cmd: &mut std::process::Command) {
-    use std::os::windows::process::CommandExt;
-    std_cmd.creation_flags(CREATE_SUSPENDED.0 | CREATE_NEW_PROCESS_GROUP.0);
+/// Shared by the std path and the raw `CreateProcessW` backend via `windows_contain_setup`.
+pub(crate) fn root_flags() -> u32 {
+    CREATE_SUSPENDED.0 | CREATE_NEW_PROCESS_GROUP.0
 }
 
-/// Apply pre-spawn flags to `std_cmd` for a nested (non-root) spawn.
+/// Pre-spawn creation flags for a nested (non-root) spawn.
 /// Only `CREATE_NEW_PROCESS_GROUP` — no suspension needed for nested spawns.
-pub(crate) fn set_group_flags(std_cmd: &mut std::process::Command) {
-    use std::os::windows::process::CommandExt;
-    std_cmd.creation_flags(CREATE_NEW_PROCESS_GROUP.0);
+pub(crate) fn group_flags() -> u32 {
+    CREATE_NEW_PROCESS_GROUP.0
 }
 
 /// Clear the inherit flag on the parent's std handles before spawning. Prevents

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -35,7 +35,7 @@ fn unsupported_displays_op_platform_and_detail() {
     let e = Error::Unsupported {
         op: "fd 3".into(),
         platform: "windows",
-        detail: "arbitrary fds require the raw backend (Plan 4)".into(),
+        detail: "arbitrary fds require the raw backend".into(),
     };
     let s = e.to_string();
     assert!(s.contains("fd 3"), "{s}");

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use crate::error::Error;
 
 /// A target descriptor. `i32` matches POSIX fd numbering; on Windows 0/1/2 are
-/// the std handles and n>=3 is the MSVCRT fd-table slot (Plan 4). Use a bare
+/// the std handles and n>=3 is the MSVCRT fd-table slot. Use a bare
 /// `i32` at call sites via `From`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Fd(i32);

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -19,6 +19,14 @@ impl Fd {
     pub fn raw(self) -> i32 {
         self.0
     }
+
+    /// Rebuild an `Fd` from a raw descriptor number, without the non-negativity
+    /// debug-assert of `From<i32>`. Used by the Windows raw spawn backend to walk
+    /// a dense `0..=maxfd` fd-table; unused (hence `dead_code`-allowed) on Unix.
+    #[allow(dead_code)]
+    pub(crate) fn from_raw(n: i32) -> Fd {
+        Fd(n)
+    }
 }
 
 impl From<i32> for Fd {

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -4,6 +4,10 @@
 #[path = "child/graceful.rs"]
 mod graceful;
 
+#[path = "child/proc_source.rs"]
+mod proc_source;
+pub(crate) use proc_source::ProcSource;
+
 use std::collections::BTreeMap;
 use std::process::ExitStatus;
 
@@ -15,9 +19,8 @@ use crate::stdio::Fd;
 
 #[derive(Debug)]
 pub struct Child {
-    // `pub(super)`: the sibling `pump` module borrows the inner tokio child for `communicate`'s
-    // `wait` future.
-    pub(super) child: ::tokio::process::Child,
+    // `pub(super)`: the sibling `pump` module borrows the backend for `communicate`'s `wait` future.
+    pub(super) proc: ProcSource,
     id: ProcessId,
     attached: Attached,
     kill_on_drop: bool,
@@ -34,7 +37,7 @@ pub struct Child {
 impl Child {
     // The only caller is the sibling `spawn` (and `OwnedStd` is module-scoped).
     pub(super) fn from_parts(
-        child: ::tokio::process::Child,
+        proc: ProcSource,
         id: ProcessId,
         attached: Attached,
         kill_on_drop: bool,
@@ -43,7 +46,7 @@ impl Child {
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
-            child,
+            proc,
             id,
             attached,
             kill_on_drop,
@@ -68,7 +71,7 @@ impl Child {
         if let Some(owned) = self.take_owned_in(crate::stdio::Fd::STDIN) {
             return Some(super::stdio::ChildStdin { inner: owned });
         }
-        self.child.stdin.take().map(|s| super::stdio::ChildStdin {
+        self.proc.take_stdin().map(|s| super::stdio::ChildStdin {
             inner: super::stdio::InInner::Tokio(s),
         })
     }
@@ -76,7 +79,7 @@ impl Child {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDOUT) {
             return Some(super::stdio::ChildStdout { inner: owned });
         }
-        self.child.stdout.take().map(|s| super::stdio::ChildStdout {
+        self.proc.take_stdout().map(|s| super::stdio::ChildStdout {
             inner: super::stdio::OutInner::Stdout(s),
         })
     }
@@ -84,7 +87,7 @@ impl Child {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDERR) {
             return Some(super::stdio::ChildStderr { inner: owned });
         }
-        self.child.stderr.take().map(|s| super::stdio::ChildStderr {
+        self.proc.take_stderr().map(|s| super::stdio::ChildStderr {
             inner: super::stdio::OutInner::Stderr(s),
         })
     }
@@ -246,11 +249,11 @@ impl Child {
     /// Block until the child exits, returning its status. For a bounded wait use
     /// `tokio::time::timeout(d, child.wait())`.
     pub async fn wait(&mut self) -> Result<ExitStatus, Error> {
-        self.child.wait().await.map_err(Error::Io)
+        self.proc.wait().await
     }
     /// Exit status if the child has already exited (non-blocking).
     pub fn try_wait(&mut self) -> Result<Option<ExitStatus>, Error> {
-        self.child.try_wait().map_err(Error::Io)
+        self.proc.try_wait()
     }
 
     /// Hard-kill the (lone) child. Handle-bound, so it cannot race a recycled pid.
@@ -258,7 +261,7 @@ impl Child {
     /// `start_kill` maps the reaped state to `Ok`). Signal-only: does not reap —
     /// `wait().await` (or `Drop`) collects the exit status.
     pub fn kill(&mut self) -> Result<(), Error> {
-        self.child.start_kill().map_err(Error::Io)
+        self.proc.start_kill()
     }
 
     /// Hard-kill the contained tree. Requires an actionable containment mechanism
@@ -303,6 +306,19 @@ impl Child {
     }
 }
 
+#[cfg(all(test, windows))]
+impl Child {
+    /// Test-only: install the per-instance raw-wait observer on this child (see the raw backend's
+    /// `WaitObserver`), forwarded to the backend.
+    pub(crate) fn install_wait_observer(
+        &mut self,
+        started: ::tokio::sync::oneshot::Sender<()>,
+        outcome: ::tokio::sync::oneshot::Sender<crate::child::spawn::windows_raw::WaitOutcome>,
+    ) {
+        self.proc.install_wait_observer(started, outcome);
+    }
+}
+
 impl Drop for Child {
     fn drop(&mut self) {
         if !self.kill_on_drop {
@@ -318,10 +334,10 @@ impl Drop for Child {
         );
         let _ = tree;
         // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
-        // the dropping thread; the child is SIGKILL'd so it exits at once. `true`: a prior wait()
-        // (a Done child) is legal on Drop.
+        // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend
+        // (tokio field-drop reap vs the raw handle's kill-then-wait).
         let pid = self.id.pid();
-        reap_now(&mut self.child, pid, true);
+        self.proc.reap_now_on_drop(pid);
     }
 }
 

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -11,11 +11,21 @@ pub(crate) use proc_source::ProcSource;
 use std::collections::BTreeMap;
 use std::process::ExitStatus;
 
+#[cfg(unix)]
 use crate::child::ParentEnd;
 use crate::containment::{Attached, Containment};
 use crate::error::Error;
 use crate::identity::ProcessId;
 use crate::stdio::Fd;
+
+/// Parent ends of fd >= 3 pipes, keyed by descriptor. Unix stashes the raw sync `ParentEnd`
+/// (converted to a reactor pipe at take time); Windows stashes the already-registered overlapped
+/// async end (the raw backend's fd >= 3 pipes), taken directly (no `from_raw_handle`, which would
+/// double-register the IOCP handle).
+#[cfg(unix)]
+pub(super) type FdPipes = BTreeMap<Fd, ParentEnd>;
+#[cfg(windows)]
+pub(super) type FdPipes = BTreeMap<Fd, super::stdio::OwnedStd>;
 
 #[derive(Debug)]
 pub struct Child {
@@ -25,10 +35,11 @@ pub struct Child {
     attached: Attached,
     kill_on_drop: bool,
     containment: Containment,
-    /// Parent ends of fd >= 3 pipes (Unix; always empty on Windows, which rejects fd >= 3).
-    // Only the cfg(unix) accessors read it; the derived Debug read doesn't count.
-    #[cfg_attr(windows, allow(dead_code))]
-    pipes: BTreeMap<Fd, ParentEnd>,
+    /// Parent ends of fd >= 3 pipes, read by [`fd_read_end`](Child::fd_read_end) /
+    /// [`fd_write_end`](Child::fd_write_end). Unix: `command-fds`-wired reactor pipes; Windows: the
+    /// raw backend's overlapped async ends (empty on the std path, which routes fd >= 3 to the raw
+    /// backend).
+    pipes: FdPipes,
     /// Our-owned parent ends of piped std-slot MERGE TARGETS (the spawn pre-pass owns those
     /// pipes; tokio's internal ones cannot be shared), keyed by the target slot.
     owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
@@ -42,7 +53,7 @@ impl Child {
         attached: Attached,
         kill_on_drop: bool,
         containment: Containment,
-        pipes: BTreeMap<Fd, ParentEnd>,
+        pipes: FdPipes,
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
@@ -244,6 +255,61 @@ impl Child {
                 None
             }
         }
+    }
+
+    /// Take the parent's read end of the pipe on child descriptor `fd` (configured via
+    /// `Command::fd(n, Stdio::pipe_out())`), as an async [`ChildStdout`](super::stdio::ChildStdout).
+    /// The raw `CreateProcessW` backend serves fd >= 3 on Windows; the end is the overlapped
+    /// named-pipe async end created at spawn (inside the runtime), yielded directly.
+    ///
+    /// # Returns
+    ///
+    /// `Some(reader)` on success. `None` if the fd was not configured as a piped read end, or was
+    /// already taken. A wrong-direction take (a write end) leaves the end in place for
+    /// [`fd_write_end`](Child::fd_write_end).
+    #[cfg(windows)]
+    pub fn fd_read_end(&mut self, fd: impl Into<Fd>) -> Option<super::stdio::ChildStdout> {
+        let fd = fd.into();
+        match self.pipes.remove(&fd)? {
+            super::stdio::OwnedStd::Read(r) => Some(super::stdio::ChildStdout {
+                inner: super::stdio::OutInner::Owned(r),
+            }),
+            end => {
+                self.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
+                None
+            }
+        }
+    }
+
+    /// Take the parent's write end of the pipe on child descriptor `fd` (configured via
+    /// `Command::fd(n, Stdio::pipe_in())`), as an async [`ChildStdin`](super::stdio::ChildStdin).
+    /// See [`fd_read_end`](Child::fd_read_end) for the Windows raw-backend surface.
+    ///
+    /// # Returns
+    ///
+    /// `Some(writer)` on success. `None` if the fd was not configured as a piped write end, or was
+    /// already taken. A wrong-direction take leaves the end in place for
+    /// [`fd_read_end`](Child::fd_read_end).
+    #[cfg(windows)]
+    pub fn fd_write_end(&mut self, fd: impl Into<Fd>) -> Option<super::stdio::ChildStdin> {
+        let fd = fd.into();
+        match self.pipes.remove(&fd)? {
+            super::stdio::OwnedStd::Write(w) => Some(super::stdio::ChildStdin {
+                inner: super::stdio::InInner::Owned(w),
+            }),
+            end => {
+                self.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
+                None
+            }
+        }
+    }
+
+    /// Test-only: return whether this child is inside our Job Object (via `IsProcessInJob` against
+    /// the handle we hold, not "any job"). Exposed outside `cfg(test)` so integration tests (a
+    /// separate compilation unit) can call it.
+    #[cfg(windows)]
+    pub fn test_job_handle_contains_self(&self) -> bool {
+        crate::containment::windows::job_contains_pid(&self.attached, self.id.pid())
     }
 
     /// Block until the child exits, returning its status. For a bounded wait use

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -1,0 +1,101 @@
+//! The process backend behind an async [`Child`](super::Child): tokio's own `process::Child`, or
+//! (Windows) a raw `CreateProcessW` child that tokio's `Command` cannot express. `Child` forwards
+//! its wait/kill/stream operations here so it stays backend-blind, mirroring the sync
+//! [`ProcHandle`](crate::child::proc_handle::ProcHandle).
+
+use std::process::ExitStatus;
+
+use crate::error::Error;
+
+/// The process backend behind an async [`Child`](super::Child).
+// The `Tokio` arm carries `::tokio::process::Child` inline — the common (and, on Unix, only)
+// variant, and previously a plain `Child` field, so keeping it inline is no regression. Boxing it
+// to shrink the rare Windows-only `Raw` variant would add a heap allocation + indirection to every
+// async spawn, so the size difference is accepted deliberately.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub(crate) enum ProcSource {
+    /// A `::tokio::process::Child` (the default path).
+    Tokio(::tokio::process::Child),
+    /// A raw `CreateProcessW` child owning its process handle directly — the executable/argv[0]
+    /// independence (and, later, arbitrary descriptors) that tokio's `Command` cannot express.
+    #[cfg(windows)]
+    Raw(crate::tokio::spawn::windows_raw::RawAsyncChild),
+}
+
+impl ProcSource {
+    /// Take tokio's own stdin stream (the Raw backend serves its piped std ends via `owned_std`,
+    /// so it has none here).
+    pub(crate) fn take_stdin(&mut self) -> Option<::tokio::process::ChildStdin> {
+        match self {
+            ProcSource::Tokio(c) => c.stdin.take(),
+            #[cfg(windows)]
+            ProcSource::Raw(_) => None,
+        }
+    }
+    pub(crate) fn take_stdout(&mut self) -> Option<::tokio::process::ChildStdout> {
+        match self {
+            ProcSource::Tokio(c) => c.stdout.take(),
+            #[cfg(windows)]
+            ProcSource::Raw(_) => None,
+        }
+    }
+    pub(crate) fn take_stderr(&mut self) -> Option<::tokio::process::ChildStderr> {
+        match self {
+            ProcSource::Tokio(c) => c.stderr.take(),
+            #[cfg(windows)]
+            ProcSource::Raw(_) => None,
+        }
+    }
+
+    /// Block until the child exits, returning its status.
+    pub(crate) async fn wait(&mut self) -> Result<ExitStatus, Error> {
+        match self {
+            ProcSource::Tokio(c) => c.wait().await.map_err(Error::Io),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.wait().await,
+        }
+    }
+
+    /// Exit status if the child has already exited (non-blocking).
+    pub(crate) fn try_wait(&mut self) -> Result<Option<ExitStatus>, Error> {
+        match self {
+            ProcSource::Tokio(c) => c.try_wait().map_err(Error::Io),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.try_wait(),
+        }
+    }
+
+    /// Signal a hard kill (does not reap). Already-exited ⇒ `Ok`.
+    pub(crate) fn start_kill(&mut self) -> Result<(), Error> {
+        match self {
+            ProcSource::Tokio(c) => c.start_kill().map_err(Error::Io),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.start_kill(),
+        }
+    }
+
+    /// Guaranteed synchronous teardown for `Drop`: kill, then block until the child has exited.
+    /// **Invariant:** no `wait()` future for this child is in flight when this runs.
+    pub(crate) fn reap_now_on_drop(&mut self, pid: u32) {
+        match self {
+            ProcSource::Tokio(c) => super::reap_now(c, pid, true),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.reap_blocking(),
+        }
+    }
+
+    /// Install the per-instance test wait observer (raw backend only). Panics on a Tokio child —
+    /// the observer seam exists solely for the raw async wait path.
+    #[cfg(all(test, windows))]
+    pub(crate) fn install_wait_observer(
+        &mut self,
+        started: ::tokio::sync::oneshot::Sender<()>,
+        outcome: ::tokio::sync::oneshot::Sender<crate::child::spawn::windows_raw::WaitOutcome>,
+    ) {
+        match self {
+            ProcSource::Raw(r) => r.set_observer(started, outcome),
+            ProcSource::Tokio(_) => panic!("wait observer requires the raw CreateProcessW backend"),
+        }
+    }
+}

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -155,6 +155,21 @@ impl Command {
         let out = child.communicate(None).await?;
         String::from_utf8(out.stdout).map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
     }
+
+    /// Test-only spawn variant that installs a per-instance wait observer on the resulting raw
+    /// child, so a cancellation test observes exactly THIS child's blocking wait (see the raw
+    /// backend's `WaitObserver`) rather than racing a parallel test. Routes through the normal
+    /// spawn, so the config must reach the raw backend (executable, uncontained, no fd >= 3).
+    #[cfg(all(test, windows))]
+    pub(crate) fn spawn_with_wait_observer(
+        &mut self,
+        started: ::tokio::sync::oneshot::Sender<()>,
+        outcome: ::tokio::sync::oneshot::Sender<crate::child::spawn::windows_raw::WaitOutcome>,
+    ) -> Result<Child, Error> {
+        let mut child = self.spawn()?;
+        child.install_wait_observer(started, outcome);
+        Ok(child)
+    }
 }
 
 #[cfg(test)]

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -12,11 +12,10 @@ use super::child::Child;
 ///
 /// # Limitations
 ///
-/// Mirror the sync API: arbitrary descriptors (fd ≥ 3) are Unix-only — parent pipe ends via
-/// `Child::fd_read_end`/`Child::fd_write_end`; Windows returns the sync path's typed
-/// [`Error::Unsupported`](crate::error::Error::Unsupported) at spawn. Merging into a *piped*
-/// target works on all platforms, in both directions; a merge whose target is itself a merge
-/// is rejected.
+/// Mirror the sync API: arbitrary descriptors (fd ≥ 3) work on every platform — parent pipe ends
+/// via `Child::fd_read_end`/`Child::fd_write_end` (Unix wires them through `command-fds`; Windows
+/// through the raw `CreateProcessW` backend's MSVCRT fd-table). Merging into a *piped* target works
+/// on all platforms, in both directions; a merge whose target is itself a merge is rejected.
 #[derive(Debug, Default)]
 pub struct Command {
     inner: SyncCommand,

--- a/src/tokio/pump.rs
+++ b/src/tokio/pump.rs
@@ -12,8 +12,8 @@ use super::child::Child;
 impl Child {
     pub async fn communicate(&mut self, input: Option<Vec<u8>>) -> Result<Output, Error> {
         // Take the three streams into owned locals BEFORE the join: only `wait` then borrows
-        // `self.child` (so the four-future join compiles), and tokio's `Child::wait` internally
-        // drops `self.child.stdin`, already None here, so it cannot race the write future.
+        // `self.proc` (so the four-future join compiles), and the Tokio backend's `wait` internally
+        // drops its own stdin, already taken here, so it cannot race the write future.
         let mut stdin = self.stdin();
         let mut stdout = self.stdout();
         let mut stderr = self.stderr();
@@ -36,30 +36,35 @@ impl Child {
             }
             if let Some(mut w) = stdin.take() {
                 if let Some(bytes) = input.as_ref() {
-                    w.write_all(bytes).await.or_else(swallow_broken_pipe)?;
-                    w.flush().await.or_else(swallow_broken_pipe)?;
+                    w.write_all(bytes)
+                        .await
+                        .or_else(swallow_broken_pipe)
+                        .map_err(Error::Io)?;
+                    w.flush().await.or_else(swallow_broken_pipe).map_err(Error::Io)?;
                 }
                 drop(w); // EOF
             }
-            Ok::<(), std::io::Error>(())
+            Ok::<(), Error>(())
         };
         let read_out = async {
             let mut buf = Vec::new();
             if let Some(mut r) = stdout.take() {
-                r.read_to_end(&mut buf).await?;
+                r.read_to_end(&mut buf).await.map_err(Error::Io)?;
             }
-            Ok::<Vec<u8>, std::io::Error>(buf)
+            Ok::<Vec<u8>, Error>(buf)
         };
         let read_err = async {
             let mut buf = Vec::new();
             if let Some(mut r) = stderr.take() {
-                r.read_to_end(&mut buf).await?;
+                r.read_to_end(&mut buf).await.map_err(Error::Io)?;
             }
-            Ok::<Vec<u8>, std::io::Error>(buf)
+            Ok::<Vec<u8>, Error>(buf)
         };
-        let wait = async { self.child.wait().await };
+        // `wait` is the sole borrow of `self` here (already mapped to `Error`); the stream futures
+        // own their taken locals, so the four-future join has no aliasing conflict.
+        let wait = async { self.proc.wait().await };
 
-        let ((), out, err, status) = ::tokio::try_join!(write, read_out, read_err, wait).map_err(Error::Io)?;
+        let ((), out, err, status) = ::tokio::try_join!(write, read_out, read_err, wait)?;
         Ok(Output {
             status,
             stdout: out,

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -26,9 +26,9 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let mut fds = std::mem::take(cmd.fds_mut());
     let kill_on_drop = cmd.kill_on_drop_flag();
 
-    // fd >= 3 is Unix-only (command-fds), exactly as on the sync path — Windows rejects it
-    // with the sync spawn's strings VERBATIM (op has no "async" prefix; the detail cites
-    // the raw backend) so the two paths report identically:
+    // fd >= 3 on Windows needs the raw `CreateProcessW` backend, which the async path does not have
+    // yet (the sync path routes there). Reject it rather than silently dropping the descriptor; the
+    // detail cites the raw backend:
     #[cfg(windows)]
     for slot in fds.keys() {
         if slot.raw() >= 3 {

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -28,41 +28,14 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let mut fds = std::mem::take(cmd.fds_mut());
     let kill_on_drop = cmd.kill_on_drop_flag();
 
-    // fd >= 3 on Windows needs the raw `CreateProcessW` backend, which the async path does not have
-    // yet (the sync path routes there). Reject it rather than silently dropping the descriptor; the
-    // detail cites the raw backend:
-    #[cfg(windows)]
-    for slot in fds.keys() {
-        if slot.raw() >= 3 {
-            return Err(Error::Unsupported {
-                op: format!("{slot}"),
-                platform: std::env::consts::OS,
-                detail: "arbitrary descriptors (>= 3) require the raw backend (Plan 4)".into(),
-            });
-        }
-    }
-
     // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend
-    // (Plan 12 Task 7): an `executable()` loaded independently of argv[0]. fd >= 3 was rejected
-    // above, so no high fd reaches here.
+    // (Plan 12): an `executable()` loaded independently of argv[0], OR arbitrary descriptors
+    // (fd >= 3, wired through the MSVCRT `lpReserved2` table). The raw backend handles BOTH
+    // contained and uncontained via its own async containment (Task 8); everything else stays on
+    // the std/tokio path, whose `prepare` applies containment for argv/commandline spawns.
     #[cfg(windows)]
-    if cmd.executable_path().is_some() {
-        // Uncontained → the async raw backend (independent argv[0]).
-        if cmd.contain_request().mode.is_none() {
-            return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
-        }
-        // Contained executable() has no async raw path yet (Task 8 wires async containment). Reject
-        // LOUDLY for BOTH argv and commandline input — falling through to the std path would
-        // silently drop the user's argv[0] (std's arg0 preservation is Unix-only on Windows), a
-        // silent deferral this crate forbids.
-        return Err(Error::Unsupported {
-            op: "spawn with executable() and containment".into(),
-            platform: "windows",
-            detail: "a contained child loaded via executable() (independent of argv[0]) needs the \
-                     raw CreateProcessW backend's async containment, not yet wired (Task 8); spawn \
-                     uncontained, or use argv()/commandline() without executable()"
-                .into(),
-        });
+    if cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3) {
+        return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
     }
 
     let std_cmd = build_std_command(cmd)?;
@@ -119,9 +92,9 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
             #[cfg(windows)]
             let (child_end, parent_end) = super::stdio::owned_overlapped_pipe(dir)?;
             // Merging slots: each gets a dup of the child end. A merging slot with
-            // raw() >= 3 (Unix only — Windows rejected fd >= 3 above) is not assignable as
-            // std stdio: it joins the fd >= 3 child-ends collection the command-fds block
-            // consumes, dup2'd into the child like any other fd >= 3 end — sync parity,
+            // raw() >= 3 (Unix only — Windows routed fd >= 3 to the raw backend above) is not
+            // assignable as std stdio: it joins the fd >= 3 child-ends collection the command-fds
+            // block consumes, dup2'd into the child like any other fd >= 3 end — sync parity,
             // never silently dropped.
             let mergers: Vec<Fd> = fds
                 .iter()
@@ -138,7 +111,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                     #[cfg(unix)]
                     merge_fd_ends.push((slot, dup(&child_end)?));
                     #[cfg(windows)]
-                    unreachable!("fd >= 3 was rejected above");
+                    unreachable!("fd >= 3 routed to the raw backend above");
                 }
             }
             fds.remove(&target);
@@ -159,8 +132,8 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         v.extend(fds.keys().copied().filter(|f| f.raw() >= 3));
         v
     };
-    // Windows: fd >= 3 was rejected above, and the slot list NEVER includes fd >= 3 — a
-    // stray end cannot exist by construction, so no assert/drop pairing to keep in sync.
+    // Windows: fd >= 3 was routed to the raw backend above, and the slot list NEVER includes
+    // fd >= 3 — a stray end cannot exist by construction, so no assert/drop pairing to keep in sync.
     #[cfg(windows)]
     let all_slots: Vec<Fd> = resolve_std_slots.collect();
     let (mut child_ends, parent_ends) = resolve_stdio(&fds, &all_slots, PipeOwnership::Deferred)?;
@@ -266,13 +239,28 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         }
     };
 
+    // fd >= 3 parent ends: Unix's `command-fds`-wired reactor pipes; on Windows the std path
+    // resolves none (fd >= 3 routes to the raw backend), so `parent_ends` is provably empty and the
+    // Windows `FdPipes` (overlapped async ends) is empty.
+    #[cfg(unix)]
+    let pipes = parent_ends;
+    #[cfg(windows)]
+    let pipes = {
+        debug_assert!(
+            parent_ends.is_empty(),
+            "the async std path resolves no fd >= 3 ends on Windows"
+        );
+        drop(parent_ends);
+        super::child::FdPipes::new()
+    };
+
     Ok(Child::from_parts(
         ProcSource::Tokio(child),
         id,
         attached,
         kill_on_drop,
         containment,
-        parent_ends,
+        pipes,
         owned_std,
     ))
 }

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -9,9 +9,11 @@ use std::process::Stdio as StdStdio;
 use crate::child::spawn::{build_std_command, dup, resolve_identity, resolve_stdio, PipeOwnership};
 use crate::command::Command;
 use crate::error::Error;
-use crate::stdio::{Direction, Fd, ResolvedStdio};
+#[cfg(unix)]
+use crate::stdio::Direction;
+use crate::stdio::{Fd, ResolvedStdio};
 
-use super::child::{reap_now, Child};
+use super::child::{reap_now, Child, ProcSource};
 
 pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     // tokio's `process::Command::spawn` needs a running reactor; outside ANY runtime it panics on
@@ -38,6 +40,15 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                 detail: "arbitrary descriptors (>= 3) require the raw backend (Plan 4)".into(),
             });
         }
+    }
+
+    // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend
+    // (Plan 12 Task 7): an `executable()` loaded independently of argv[0], UNCONTAINED, with no
+    // fd >= 3 (the rejection above already guaranteed the latter). Contained executables stay on
+    // the std path until Task 8.
+    #[cfg(windows)]
+    if cmd.executable_path().is_some() && cmd.contain_request().mode.is_none() {
+        return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
     }
 
     let std_cmd = build_std_command(cmd)?;
@@ -92,21 +103,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                 }
             };
             #[cfg(windows)]
-            let (child_end, parent_end) = {
-                use super::stdio::{ConnectingPipe, OwnedStd, WinOwnedRead, WinOwnedWrite};
-                match dir {
-                    Direction::In => {
-                        let (server, client) = super::stdio::overlapped_in_pipe()?;
-                        let connecting = ConnectingPipe::Connecting(super::stdio::connect_task(server));
-                        (client, OwnedStd::Write(WinOwnedWrite(connecting)))
-                    }
-                    Direction::Out => {
-                        let (server, client) = super::stdio::overlapped_out_pipe()?;
-                        let connecting = ConnectingPipe::Connecting(super::stdio::connect_task(server));
-                        (client, OwnedStd::Read(WinOwnedRead(connecting)))
-                    }
-                }
-            };
+            let (child_end, parent_end) = super::stdio::owned_overlapped_pipe(dir)?;
             // Merging slots: each gets a dup of the child end. A merging slot with
             // raw() >= 3 (Unix only — Windows rejected fd >= 3 above) is not assignable as
             // std stdio: it joins the fd >= 3 child-ends collection the command-fds block
@@ -211,7 +208,13 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         }
     }
 
-    let mut child = tcmd.spawn().map_err(Error::Io)?;
+    // Serialize the spawn against the raw backend's inheritable-handle window via the shared spawn
+    // lock: tokio's own handle-inheritance marking must not overlap a raw `CreateProcessW` spawn on
+    // another thread (mirrors the sync std path).
+    let mut child = {
+        let _guard = crate::child::spawn::spawn_lock();
+        tcmd.spawn().map_err(Error::Io)?
+    };
 
     // Identity must be read before any await: spawn + attach are synchronous, so the runtime cannot
     // park and reap the child in between. Even if the child has already exited, tokio's held handle
@@ -250,7 +253,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     };
 
     Ok(Child::from_parts(
-        child,
+        ProcSource::Tokio(child),
         id,
         attached,
         kill_on_drop,
@@ -259,6 +262,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         owned_std,
     ))
 }
+
+#[cfg(windows)]
+#[path = "spawn/windows_raw.rs"]
+pub(crate) mod windows_raw;
 
 #[cfg(test)]
 #[path = "spawn_tests.rs"]

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -43,12 +43,26 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     }
 
     // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend
-    // (Plan 12 Task 7): an `executable()` loaded independently of argv[0], UNCONTAINED, with no
-    // fd >= 3 (the rejection above already guaranteed the latter). Contained executables stay on
-    // the std path until Task 8.
+    // (Plan 12 Task 7): an `executable()` loaded independently of argv[0]. fd >= 3 was rejected
+    // above, so no high fd reaches here.
     #[cfg(windows)]
-    if cmd.executable_path().is_some() && cmd.contain_request().mode.is_none() {
-        return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
+    if cmd.executable_path().is_some() {
+        // Uncontained → the async raw backend (independent argv[0]).
+        if cmd.contain_request().mode.is_none() {
+            return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
+        }
+        // Contained executable() has no async raw path yet (Task 8 wires async containment). Reject
+        // LOUDLY for BOTH argv and commandline input — falling through to the std path would
+        // silently drop the user's argv[0] (std's arg0 preservation is Unix-only on Windows), a
+        // silent deferral this crate forbids.
+        return Err(Error::Unsupported {
+            op: "spawn with executable() and containment".into(),
+            platform: "windows",
+            detail: "a contained child loaded via executable() (independent of argv[0]) needs the \
+                     raw CreateProcessW backend's async containment, not yet wired (Task 8); spawn \
+                     uncontained, or use argv()/commandline() without executable()"
+                .into(),
+        });
     }
 
     let std_cmd = build_std_command(cmd)?;

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -1,14 +1,17 @@
-//! Async (tokio) raw `CreateProcessW` spawn backend (Plan 12 Task 7).
+//! Async (tokio) raw `CreateProcessW` spawn backend (Plan 12 Tasks 7-8).
 //!
 //! The async mirror of [`crate::child::spawn::windows_raw`]: it loads an `executable()`
-//! independently of argv[0] (the case std/tokio cannot express on Windows) for an UNCONTAINED
-//! child with no fd >= 3. It reuses the sync backend's `CreateProcessW` FFI verbatim
-//! (`create_process`, the STARTUPINFOEXW/HANDLE_LIST build, the lock/close discipline, the
-//! error-teardown) and differs only where async demands it: piped std ends come from the tokio
-//! overlapped-named-pipe machinery, and the owned child is a [`RawAsyncChild`] whose waits run on
-//! the blocking pool over a cancellable handle wait. fd >= 3 + contained parity is Task 8.
+//! independently of argv[0] (the case std/tokio cannot express on Windows), wires arbitrary
+//! descriptors (fd >= 3, via the MSVCRT `lpReserved2` table), and applies containment (Job Object /
+//! TreeWalk) — the full sync feature set. It reuses the sync backend's `CreateProcessW` FFI verbatim
+//! (`spawn_step`/`create_process`, the fd-table encode + cap, the STARTUPINFOEXW/HANDLE_LIST build,
+//! the containment decision, the lock/close discipline, the error-teardown) and differs only where
+//! async demands it: piped ends come from the tokio overlapped-named-pipe machinery (std slots via
+//! the stdin/stdout/stderr accessors, fd >= 3 via fd_read_end/fd_write_end), and the owned child is
+//! a [`RawAsyncChild`] whose waits run on the blocking pool over a cancellable handle wait.
 
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::os::windows::io::{AsRawHandle, OwnedHandle};
 use std::process::ExitStatus;
 use std::sync::Arc;
@@ -21,7 +24,7 @@ use windows::Win32::System::Threading::{
 
 use crate::child::spawn::windows_raw as sync_raw;
 use crate::child::spawn::{attach_or_fault, dup, resolve_identity, resolve_non_merge, spawn_lock};
-use crate::command::Command;
+use crate::command::{Command, EnvOp};
 use crate::error::Error;
 use crate::stdio::{Fd, ResolvedStdio};
 use crate::tokio::child::{Child, ProcSource};
@@ -38,7 +41,8 @@ use sync_raw::{exit_status, wait_handle_or_cancel, AttributeList, WaitOutcome};
 #[derive(Debug)]
 pub(crate) struct RawAsyncChild {
     proc: Arc<OwnedHandle>,
-    /// The child's OS pid — retained for diagnostics (and Task 8 containment queries).
+    /// The child's OS pid — retained for diagnostics (the `Child`'s stable `ProcessId` is the
+    /// source of truth for containment queries).
     pid: u32,
     /// Memoized once the child has exited, so a second `wait`/`try_wait` is immediate and cannot
     /// re-read a status off a (post-close) recycled handle.
@@ -208,11 +212,12 @@ struct WaitObserver {
     outcome: ::tokio::sync::oneshot::Sender<WaitOutcome>,
 }
 
-/// Spawn `cmd` via the async raw backend: an `executable()` loaded independently of argv[0],
-/// UNCONTAINED, with descriptors 0/1/2 only (fd >= 3 is Task 8). Reuses the sync backend's FFI.
+/// Spawn `cmd` via the async raw backend: an `executable()` loaded independently of argv[0], with
+/// arbitrary descriptors (fd >= 3) and containment — the full sync feature set. Reuses the sync
+/// backend's FFI (fd-table + HANDLE_LIST + containment decision + lock/close + error-teardown).
 pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
     // Batch reject on the program token, resolve the executable, NUL-check, build the command line
-    // and env block — all shared verbatim with the sync raw backend.
+    // — all shared verbatim with the sync raw backend.
     sync_raw::reject_batch_program(cmd)?;
     let image = cmd
         .executable_path()
@@ -227,30 +232,64 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let app_name: Option<Vec<u16>> = image.as_ref().map(|p| sync_raw::to_wide_nul(p.as_os_str()));
     let mut cmdline = sync_raw::raw_program_and_line(cmd)?; // each token NUL-checked
     cmdline.push(0);
-    // Uncontained (Task 7): the parent environment, no nested-root marker.
-    let env_block = sync_raw::resolve::build_env_block(cmd.env_ops())?;
+
+    // Containment: mirror the sync raw backend's pre-spawn decision. Uncontained keeps the defaults
+    // (flags 0, `mode: None`/`is_root: false`); a Strongest root spawns CREATE_SUSPENDED and is
+    // job-assigned + resumed in `attach_or_fault`.
+    let req = cmd.contain_request();
+    let (contain_flags, is_root, marker_env) = if req.mode.is_some() {
+        let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
+        let is_root = !crate::containment::dispatch::is_nested(marker_present);
+        crate::containment::windows::clear_std_handle_inheritance();
+        let setup = crate::containment::dispatch::windows_contain_setup(&req, is_root);
+        (setup.creation_flags, is_root, setup.marker_env)
+    } else {
+        (0u32, false, false)
+    };
+
+    // Append the inherited root marker AFTER the user's env ops so it survives a user `env_clear()`
+    // (mirrors the sync path).
+    let env_block = if marker_env {
+        let mut ops = cmd.env_ops().to_vec();
+        ops.push(EnvOp::Set(
+            OsString::from(crate::containment::NESTED_ENV),
+            OsString::from("1"),
+        ));
+        sync_raw::resolve::build_env_block(&ops)?
+    } else {
+        sync_raw::resolve::build_env_block(cmd.env_ops())?
+    };
     let cwd_w = cmd.cwd().map(|c| sync_raw::to_wide_nul(c.as_os_str()));
 
-    // Resolve 0/1/2 to child handles: piped slots via the tokio overlapped-pipe machinery (we own
-    // the async parent ends, stashed for the accessors), merges as dups, the rest (inherit/file/
-    // null) via the shared core.
-    let (child_ends, owned_std) = resolve_raw_std_ends(&fds)?;
+    // Cap the MSVCRT fd-table to the WORD-sized `cbReserved2` field BEFORE allocating any pipes.
+    sync_raw::ensure_fd_table_fits(&fds)?;
 
-    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2, inheritance scoped to exactly those
-    // three handles via the HANDLE_LIST (which also backs EXTENDED_STARTUPINFO_PRESENT). No
-    // lpReserved2 — fd >= 3 is Task 8; the child CRT recovers 0/1/2 from the std handles, as
-    // std::process does.
+    // Resolve 0/1/2 (always) plus any configured fd >= 3 to child handles: piped slots via the
+    // tokio overlapped-pipe machinery (we own the async parent ends — std slots via the
+    // stdin/stdout/stderr accessors, fd >= 3 via fd_read_end/fd_write_end), merges as dups, the rest
+    // (inherit/file/null) via the shared core (which rejects inherit on fd >= 3).
+    let (child_ends, owned_std, fd_pipes) = resolve_raw_ends(&fds)?;
+
+    // Classify + encode the dense MSVCRT fd-table the child CRT reads back from `lpReserved2` — the
+    // SAME layout + single HANDLE_LIST source as the sync backend.
+    let table = sync_raw::build_fd_table(&child_ends)?;
+
+    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2; `lpReserved2` carries the fd-table so
+    // the child CRT recovers fd >= 3; the HANDLE_LIST (`table.handles`) scopes inheritance AND backs
+    // EXTENDED_STARTUPINFO_PRESENT. `table` (`bytes`) is kept alive until after CreateProcessW.
     let mut si = STARTUPINFOEXW::default();
     si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
     si.StartupInfo.hStdInput = HANDLE(child_ends[&Fd::STDIN].as_raw_handle());
     si.StartupInfo.hStdOutput = HANDLE(child_ends[&Fd::STDOUT].as_raw_handle());
     si.StartupInfo.hStdError = HANDLE(child_ends[&Fd::STDERR].as_raw_handle());
-    // Each std slot resolved to a DISTINCT owned handle (a merge dups its target), so the list has
-    // no duplicate — `UpdateProcThreadAttribute` rejects duplicates.
-    let handles: Vec<HANDLE> = child_ends.values().map(|e| HANDLE(e.as_raw_handle())).collect();
-    let attr = AttributeList::build(&handles)?;
+    si.StartupInfo.cbReserved2 = table.bytes.len() as u16; // fits: capped above
+    si.StartupInfo.lpReserved2 = table.bytes.as_ptr() as *mut u8;
+    // SINGLE handle source: `table.handles` is 0/1/2 + fd >= 3, each a distinct fresh dup (its
+    // 0/1/2 entries ARE the hStd* handles), so no duplicate reaches the list.
+    let all_handles: &[HANDLE] = &table.handles;
+    let attr = AttributeList::build(all_handles)?;
     si.lpAttributeList = attr.as_ptr();
-    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0;
+    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
 
     // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
     // the attribute list BEFORE the guard releases on EVERY path (mirrors the sync raw backend —
@@ -259,7 +298,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let spawned = {
         let _guard = spawn_lock();
         let r = sync_raw::spawn_step(
-            &handles,
+            all_handles,
             app_name.as_deref(),
             &mut cmdline,
             &mut si,
@@ -273,13 +312,14 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     };
     let (proc, pid) = spawned?;
 
-    // Identity read + attach BEFORE building `Child`, UNCONTAINED (`mode: None`), with the SAME
-    // kill+reap error-teardown as the sync-raw/std path (dropping the OwnedHandle alone neither
-    // kills nor reaps on Windows). Spawn + attach + identity are synchronous — no await before the
-    // identity read, so the runtime cannot park and reap in between.
+    // Identity read + attach BEFORE building `Child`, with the REAL mode + is_root (Job Object for a
+    // Strongest root, else TreeWalk/Delegated), and the SAME kill+reap error-teardown as the
+    // sync-raw/std path (dropping the OwnedHandle alone neither kills nor reaps on Windows). Spawn +
+    // attach + identity are synchronous — no await before the identity read, so the runtime cannot
+    // park and reap in between.
     let prepared = crate::containment::Prepared {
-        mode: None,
-        is_root: false,
+        mode: req.mode,
+        is_root,
     };
     let raw_handle = proc.as_raw_handle();
     let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {
@@ -305,22 +345,33 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
         attached,
         kill_on_drop,
         containment,
-        BTreeMap::new(), // no fd >= 3 parent ends in Task 7
+        fd_pipes,
         owned_std,
     ))
 }
 
-/// The raw backend's resolved std stdio: the child's 0/1/2 handle ends, keyed by slot, plus the
-/// async parent ends we own for the piped slots (keyed by slot).
-type RawStdEnds = (BTreeMap<Fd, OwnedHandle>, BTreeMap<Fd, OwnedStd>);
+/// The raw backend's resolved stdio ends: the child's handle ends (0/1/2 + fd >= 3) keyed by slot,
+/// plus the async parent ends we own — std-slot pipes (for the stdin/stdout/stderr accessors) and
+/// fd >= 3 pipes (for fd_read_end/fd_write_end), each keyed by slot.
+type RawEnds = (
+    BTreeMap<Fd, OwnedHandle>,
+    BTreeMap<Fd, OwnedStd>,
+    BTreeMap<Fd, OwnedStd>,
+);
 
-/// Resolve the child's std handles (0/1/2) for the raw backend, plus the async parent ends we own.
-/// Piped slots use OUR overlapped pipe (tokio owns none here — there is no `tokio::process::Child`);
-/// merges dup their target's child end; the rest resolve via the shared core.
-fn resolve_raw_std_ends(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<RawStdEnds, Error> {
-    let std_slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR];
+/// Resolve the child's handle ends (0/1/2 + fd >= 3) for the raw backend, plus the async parent ends
+/// we own. Piped slots use OUR overlapped pipe (tokio owns none here — there is no
+/// `tokio::process::Child`); merges dup their target's child end; the rest resolve via the shared
+/// core (which rejects inherit on fd >= 3).
+fn resolve_raw_ends(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<RawEnds, Error> {
+    // Slots to resolve: 0/1/2 always, plus every configured fd >= 3.
+    let slots: Vec<Fd> = {
+        let mut v = vec![Fd::STDIN, Fd::STDOUT, Fd::STDERR];
+        v.extend(fds.keys().copied().filter(|f| f.raw() >= 3));
+        v
+    };
     // Reject chained merges (single-level indirection only), mirroring the shared resolver.
-    for &slot in &std_slots {
+    for &slot in &slots {
         if let Some(ResolvedStdio::Merge(target)) = fds.get(&slot) {
             if matches!(fds.get(target), Some(ResolvedStdio::Merge(_))) {
                 return Err(Error::Unsupported {
@@ -335,25 +386,31 @@ fn resolve_raw_std_ends(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<RawStdEnds,
     }
     let mut child_ends: BTreeMap<Fd, OwnedHandle> = BTreeMap::new();
     let mut owned_std: BTreeMap<Fd, OwnedStd> = BTreeMap::new();
-    // First pass: non-merge slots. Piped slots use our overlapped pipe (async parent end stashed);
-    // the rest (inherit/file/null/unconfigured) resolve via the shared core.
-    for &slot in &std_slots {
+    let mut fd_pipes: BTreeMap<Fd, OwnedStd> = BTreeMap::new();
+    // First pass: non-merge slots. Piped slots use our overlapped pipe (async parent end stashed —
+    // std slots for the stdin/stdout/stderr accessors, fd >= 3 for fd_read_end/fd_write_end); the
+    // rest (inherit/file/null/unconfigured std) resolve via the shared core.
+    for &slot in &slots {
         match fds.get(&slot) {
             Some(ResolvedStdio::Merge(_)) => continue, // second pass
             Some(ResolvedStdio::Pipe(dir)) => {
                 let (child_end, parent) = crate::tokio::stdio::owned_overlapped_pipe(*dir)?;
                 child_ends.insert(slot, child_end);
-                owned_std.insert(slot, parent);
+                if slot.raw() < 3 {
+                    owned_std.insert(slot, parent);
+                } else {
+                    fd_pipes.insert(slot, parent);
+                }
             }
             other => {
                 let (child_end, parent) = resolve_non_merge(slot, other)?;
-                debug_assert!(parent.is_none(), "a std non-pipe slot yields no parent end");
+                debug_assert!(parent.is_none(), "a raw non-pipe slot yields no parent end");
                 child_ends.insert(slot, child_end);
             }
         }
     }
     // Second pass: each merge dups its target's already-resolved child end.
-    for &slot in &std_slots {
+    for &slot in &slots {
         if let Some(ResolvedStdio::Merge(target)) = fds.get(&slot) {
             let src = child_ends.get(target).ok_or_else(|| Error::Unsupported {
                 op: format!("merge {slot} -> {target}"),
@@ -363,7 +420,7 @@ fn resolve_raw_std_ends(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<RawStdEnds,
             child_ends.insert(slot, dup(src)?);
         }
     }
-    Ok((child_ends, owned_std))
+    Ok((child_ends, owned_std, fd_pipes))
 }
 
 #[cfg(test)]

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -1,0 +1,371 @@
+//! Async (tokio) raw `CreateProcessW` spawn backend (Plan 12 Task 7).
+//!
+//! The async mirror of [`crate::child::spawn::windows_raw`]: it loads an `executable()`
+//! independently of argv[0] (the case std/tokio cannot express on Windows) for an UNCONTAINED
+//! child with no fd >= 3. It reuses the sync backend's `CreateProcessW` FFI verbatim
+//! (`create_process`, the STARTUPINFOEXW/HANDLE_LIST build, the lock/close discipline, the
+//! error-teardown) and differs only where async demands it: piped std ends come from the tokio
+//! overlapped-named-pipe machinery, and the owned child is a [`RawAsyncChild`] whose waits run on
+//! the blocking pool over a cancellable handle wait. fd >= 3 + contained parity is Task 8.
+
+use std::collections::BTreeMap;
+use std::os::windows::io::{AsRawHandle, OwnedHandle};
+use std::process::ExitStatus;
+use std::sync::Arc;
+
+use windows::Win32::Foundation::{ERROR_ACCESS_DENIED, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{
+    TerminateProcess, WaitForSingleObject, CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, INFINITE,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW,
+};
+
+use crate::child::spawn::windows_raw as sync_raw;
+use crate::child::spawn::{attach_or_fault, dup, resolve_identity, resolve_non_merge, spawn_lock};
+use crate::command::Command;
+use crate::error::Error;
+use crate::stdio::{Fd, ResolvedStdio};
+use crate::tokio::child::{Child, ProcSource};
+use crate::tokio::stdio::OwnedStd;
+use crate::wait::backend::{new_cancel_event, signal_cancel};
+
+use sync_raw::{exit_status, wait_handle_or_cancel, AttributeList, WaitOutcome};
+
+/// A raw `CreateProcessW` child driven from tokio. The process handle lives behind an `Arc` so a
+/// dropped `wait()` future — or a dropped child — never closes a handle a blocking watcher is still
+/// parked on: the blocking task holds its own clone until it returns. Async waits run on the
+/// blocking pool over the shared cancellable handle wait; a cancel event (signaled by the future's
+/// drop guard) releases a parked wait promptly.
+#[derive(Debug)]
+pub(crate) struct RawAsyncChild {
+    proc: Arc<OwnedHandle>,
+    /// The child's OS pid — retained for diagnostics (and Task 8 containment queries).
+    pid: u32,
+    /// Memoized once the child has exited, so a second `wait`/`try_wait` is immediate and cannot
+    /// re-read a status off a (post-close) recycled handle.
+    exited: Option<ExitStatus>,
+    #[cfg(test)]
+    observer: Option<WaitObserver>,
+}
+
+impl RawAsyncChild {
+    pub(crate) fn new(proc: OwnedHandle, pid: u32) -> RawAsyncChild {
+        RawAsyncChild {
+            proc: Arc::new(proc),
+            pid,
+            exited: None,
+            #[cfg(test)]
+            observer: None,
+        }
+    }
+
+    fn handle(&self) -> HANDLE {
+        HANDLE(self.proc.as_raw_handle())
+    }
+
+    /// Block until the child exits, returning its status. Runs the blocking handle wait on the
+    /// blocking pool; a `CancelGuard` in this future signals a cancel event on drop so an aborted
+    /// or timed-out wait releases the parked watcher at once.
+    pub(crate) async fn wait(&mut self) -> Result<ExitStatus, Error> {
+        loop {
+            if let Some(status) = self.exited {
+                return Ok(status);
+            }
+            // Arc-owned handles: the blocking task holds clones for its whole lifetime, so dropping
+            // this future (or the child) never closes a handle the task is parked on.
+            let cancel = Arc::new(new_cancel_event()?);
+            let proc = Arc::clone(&self.proc);
+            let cancel_for_task = Arc::clone(&cancel);
+            #[cfg(test)]
+            let observer = self.observer.take();
+            let task = ::tokio::task::spawn_blocking(move || {
+                #[cfg(test)]
+                let (started, outcome_tx) = match observer {
+                    Some(obs) => (Some(obs.started), Some(obs.outcome)),
+                    None => (None, None),
+                };
+                // The task is on the blocking pool and about to park on the handle wait.
+                #[cfg(test)]
+                if let Some(tx) = started {
+                    let _ = tx.send(());
+                }
+                let result = wait_handle_or_cancel(
+                    HANDLE(proc.as_raw_handle()),
+                    Some(HANDLE(cancel_for_task.as_raw_handle())),
+                );
+                #[cfg(test)]
+                if let (Some(tx), Ok(outcome)) = (outcome_tx, result.as_ref()) {
+                    let _ = tx.send(*outcome);
+                }
+                result
+            });
+            // Signals the cancel event if THIS future is dropped before the blocking wait returns,
+            // releasing the parked watcher promptly. Harmless after completion (manual-reset event,
+            // nothing waits on it any more). The Arcs above keep both handles live until the task
+            // returns, so the signal races nothing.
+            let _guard = CancelGuard(cancel);
+            let outcome = match task.await {
+                Ok(o) => o,
+                // A JoinError (task panic / runtime shutdown) is not an exit — surface it.
+                Err(_e) => return Err(Error::Io(std::io::Error::other("raw async wait task failed"))),
+            };
+            match outcome {
+                Ok(WaitOutcome::Exited) => {
+                    let status = exit_status(self.handle()).map_err(Error::Io)?;
+                    self.exited = Some(status);
+                    return Ok(status);
+                }
+                // Only `CancelGuard::drop` signals the cancel event, and it runs solely when THIS
+                // future is dropped — in which case this continuation never executes. A defensive
+                // re-wait (fresh event) preserves the "resolved ⇒ exited" postcondition if that
+                // ever broke; never a false exit.
+                Ok(WaitOutcome::Cancelled) => {
+                    debug_assert!(false, "raw async wait resolved Cancelled while its future was live");
+                    continue;
+                }
+                Err(e) => return Err(Error::Io(e)),
+            }
+        }
+    }
+
+    /// Exit status if the child has already exited (non-blocking), memoizing it.
+    pub(crate) fn try_wait(&mut self) -> Result<Option<ExitStatus>, Error> {
+        if let Some(status) = self.exited {
+            return Ok(Some(status));
+        }
+        // SAFETY: our live, owned process handle; a zero timeout polls without blocking.
+        let r = unsafe { WaitForSingleObject(self.handle(), 0) };
+        if r == WAIT_OBJECT_0 {
+            let status = exit_status(self.handle()).map_err(Error::Io)?;
+            self.exited = Some(status);
+            Ok(Some(status))
+        } else if r == WAIT_TIMEOUT {
+            Ok(None)
+        } else {
+            Err(Error::Io(std::io::Error::last_os_error()))
+        }
+    }
+
+    /// Signal a hard kill (does not reap). Signal-only, so it never blocks.
+    pub(crate) fn start_kill(&mut self) -> Result<(), Error> {
+        // SAFETY: our live, owned process handle; exit code 1 is the forced-kill code.
+        match unsafe { TerminateProcess(self.handle(), 1) } {
+            Ok(()) => Ok(()),
+            // We hold a full-access handle to our OWN child, so ERROR_ACCESS_DENIED is never a real
+            // permission failure — the child's exit is already underway (matches tokio's
+            // `start_kill` mapping an already-reaped child to Ok). Never blocks on it (signal-only).
+            Err(e) if e.code() == windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0) => Ok(()),
+            Err(e) => Err(Error::Io(e.into())),
+        }
+    }
+
+    /// Synchronous kill-then-block-until-exit for `Drop` (no reactor, no `wait()` future in
+    /// flight). The child is `TerminateProcess`d so the wait returns at once.
+    pub(crate) fn reap_blocking(&mut self) {
+        if self.exited.is_some() {
+            return;
+        }
+        let _ = self.start_kill();
+        // SAFETY: our live, owned process handle; INFINITE is bounded by the kill above.
+        let waited = unsafe { WaitForSingleObject(self.handle(), INFINITE) };
+        debug_assert!(
+            waited == WAIT_OBJECT_0,
+            "raw async Drop did not observe child {} exit: {waited:?}",
+            self.pid
+        );
+        let _ = waited;
+    }
+
+    /// Install the per-instance test wait observer on THIS child (see `WaitObserver`).
+    #[cfg(test)]
+    pub(crate) fn set_observer(
+        &mut self,
+        started: ::tokio::sync::oneshot::Sender<()>,
+        outcome: ::tokio::sync::oneshot::Sender<WaitOutcome>,
+    ) {
+        self.observer = Some(WaitObserver { started, outcome });
+    }
+}
+
+/// Signals the cancel event when the `wait()` future is dropped (aborted / timed-out), releasing
+/// the parked blocking watcher. Harmless once the wait has already returned.
+struct CancelGuard(Arc<OwnedHandle>);
+
+impl Drop for CancelGuard {
+    fn drop(&mut self) {
+        // `signal_cancel` asserts loudly on failure (see wait/windows.rs); Drop cannot propagate.
+        signal_cancel(&self.0);
+    }
+}
+
+/// Per-instance test observable seam: the blocking wait closure signals when it has parked
+/// (`started`) and reports its `WaitOutcome` — on THIS child's channels only, so a parallel test's
+/// wait never fires into another test's receivers (a process-global seam would). Injected via
+/// `RawAsyncChild::set_observer`; consumed on the next `wait()`.
+#[cfg(test)]
+#[derive(Debug)]
+struct WaitObserver {
+    started: ::tokio::sync::oneshot::Sender<()>,
+    outcome: ::tokio::sync::oneshot::Sender<WaitOutcome>,
+}
+
+/// Spawn `cmd` via the async raw backend: an `executable()` loaded independently of argv[0],
+/// UNCONTAINED, with descriptors 0/1/2 only (fd >= 3 is Task 8). Reuses the sync backend's FFI.
+pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on_drop: bool) -> Result<Child, Error> {
+    // Batch reject on the program token, resolve the executable, NUL-check, build the command line
+    // and env block — all shared verbatim with the sync raw backend.
+    sync_raw::reject_batch_program(cmd)?;
+    let image = cmd
+        .executable_path()
+        .map(sync_raw::resolve::resolve_executable)
+        .transpose()?;
+    if let Some(p) = &image {
+        sync_raw::resolve::ensure_no_nul_wide(p.as_os_str())?;
+    }
+    if let Some(c) = cmd.cwd() {
+        sync_raw::resolve::ensure_no_nul_wide(c.as_os_str())?;
+    }
+    let app_name: Option<Vec<u16>> = image.as_ref().map(|p| sync_raw::to_wide_nul(p.as_os_str()));
+    let mut cmdline = sync_raw::raw_program_and_line(cmd)?; // each token NUL-checked
+    cmdline.push(0);
+    // Uncontained (Task 7): the parent environment, no nested-root marker.
+    let env_block = sync_raw::resolve::build_env_block(cmd.env_ops())?;
+    let cwd_w = cmd.cwd().map(|c| sync_raw::to_wide_nul(c.as_os_str()));
+
+    // Resolve 0/1/2 to child handles: piped slots via the tokio overlapped-pipe machinery (we own
+    // the async parent ends, stashed for the accessors), merges as dups, the rest (inherit/file/
+    // null) via the shared core.
+    let (child_ends, owned_std) = resolve_raw_std_ends(&fds)?;
+
+    // STARTUPINFOEXW: STARTF_USESTDHANDLES + hStd* for 0/1/2, inheritance scoped to exactly those
+    // three handles via the HANDLE_LIST (which also backs EXTENDED_STARTUPINFO_PRESENT). No
+    // lpReserved2 — fd >= 3 is Task 8; the child CRT recovers 0/1/2 from the std handles, as
+    // std::process does.
+    let mut si = STARTUPINFOEXW::default();
+    si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+    si.StartupInfo.hStdInput = HANDLE(child_ends[&Fd::STDIN].as_raw_handle());
+    si.StartupInfo.hStdOutput = HANDLE(child_ends[&Fd::STDOUT].as_raw_handle());
+    si.StartupInfo.hStdError = HANDLE(child_ends[&Fd::STDERR].as_raw_handle());
+    // Each std slot resolved to a DISTINCT owned handle (a merge dups its target), so the list has
+    // no duplicate — `UpdateProcThreadAttribute` rejects duplicates.
+    let handles: Vec<HANDLE> = child_ends.values().map(|e| HANDLE(e.as_raw_handle())).collect();
+    let attr = AttributeList::build(&handles)?;
+    si.lpAttributeList = attr.as_ptr();
+    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0;
+
+    // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
+    // the attribute list BEFORE the guard releases on EVERY path (mirrors the sync raw backend —
+    // an early `?` would drop the inner guard before `child_ends`/`attr`, exposing inheritable
+    // handles to a concurrent spawn).
+    let spawned = {
+        let _guard = spawn_lock();
+        let r = sync_raw::spawn_step(
+            &handles,
+            app_name.as_deref(),
+            &mut cmdline,
+            &mut si,
+            &env_block,
+            &cwd_w,
+            flags,
+        );
+        drop(child_ends); // close the child ends inside the lock, on success AND error
+        drop(attr); // DeleteProcThreadAttributeList before the guard releases
+        r
+    };
+    let (proc, pid) = spawned?;
+
+    // Identity read + attach BEFORE building `Child`, UNCONTAINED (`mode: None`), with the SAME
+    // kill+reap error-teardown as the sync-raw/std path (dropping the OwnedHandle alone neither
+    // kills nor reaps on Windows). Spawn + attach + identity are synchronous — no await before the
+    // identity read, so the runtime cannot park and reap in between.
+    let prepared = crate::containment::Prepared {
+        mode: None,
+        is_root: false,
+    };
+    let raw_handle = proc.as_raw_handle();
+    let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {
+        Ok(v) => v,
+        Err(e) => {
+            sync_raw::raw_spawn_teardown(proc, pid);
+            return Err(e);
+        }
+    };
+    let id = match resolve_identity(pid) {
+        Some(id) => id,
+        None => {
+            sync_raw::raw_spawn_teardown(proc, pid);
+            return Err(Error::Io(std::io::Error::other(
+                "spawned async child vanished before its identity could be read",
+            )));
+        }
+    };
+
+    Ok(Child::from_parts(
+        ProcSource::Raw(RawAsyncChild::new(proc, pid)),
+        id,
+        attached,
+        kill_on_drop,
+        containment,
+        BTreeMap::new(), // no fd >= 3 parent ends in Task 7
+        owned_std,
+    ))
+}
+
+/// The raw backend's resolved std stdio: the child's 0/1/2 handle ends, keyed by slot, plus the
+/// async parent ends we own for the piped slots (keyed by slot).
+type RawStdEnds = (BTreeMap<Fd, OwnedHandle>, BTreeMap<Fd, OwnedStd>);
+
+/// Resolve the child's std handles (0/1/2) for the raw backend, plus the async parent ends we own.
+/// Piped slots use OUR overlapped pipe (tokio owns none here — there is no `tokio::process::Child`);
+/// merges dup their target's child end; the rest resolve via the shared core.
+fn resolve_raw_std_ends(fds: &BTreeMap<Fd, ResolvedStdio>) -> Result<RawStdEnds, Error> {
+    let std_slots = [Fd::STDIN, Fd::STDOUT, Fd::STDERR];
+    // Reject chained merges (single-level indirection only), mirroring the shared resolver.
+    for &slot in &std_slots {
+        if let Some(ResolvedStdio::Merge(target)) = fds.get(&slot) {
+            if matches!(fds.get(target), Some(ResolvedStdio::Merge(_))) {
+                return Err(Error::Unsupported {
+                    op: format!("merge {slot} -> {target} -> <another merge>"),
+                    platform: "windows",
+                    detail: "chained merges (merge-to-merge) are not supported; redirect to a \
+                             concrete slot (pipe/file/null/inherit)"
+                        .into(),
+                });
+            }
+        }
+    }
+    let mut child_ends: BTreeMap<Fd, OwnedHandle> = BTreeMap::new();
+    let mut owned_std: BTreeMap<Fd, OwnedStd> = BTreeMap::new();
+    // First pass: non-merge slots. Piped slots use our overlapped pipe (async parent end stashed);
+    // the rest (inherit/file/null/unconfigured) resolve via the shared core.
+    for &slot in &std_slots {
+        match fds.get(&slot) {
+            Some(ResolvedStdio::Merge(_)) => continue, // second pass
+            Some(ResolvedStdio::Pipe(dir)) => {
+                let (child_end, parent) = crate::tokio::stdio::owned_overlapped_pipe(*dir)?;
+                child_ends.insert(slot, child_end);
+                owned_std.insert(slot, parent);
+            }
+            other => {
+                let (child_end, parent) = resolve_non_merge(slot, other)?;
+                debug_assert!(parent.is_none(), "a std non-pipe slot yields no parent end");
+                child_ends.insert(slot, child_end);
+            }
+        }
+    }
+    // Second pass: each merge dups its target's already-resolved child end.
+    for &slot in &std_slots {
+        if let Some(ResolvedStdio::Merge(target)) = fds.get(&slot) {
+            let src = child_ends.get(target).ok_or_else(|| Error::Unsupported {
+                op: format!("merge {slot} -> {target}"),
+                platform: "windows",
+                detail: "merge target descriptor is not configured".into(),
+            })?;
+            child_ends.insert(slot, dup(src)?);
+        }
+    }
+    Ok((child_ends, owned_std))
+}
+
+#[cfg(test)]
+#[path = "windows_raw_tests.rs"]
+mod windows_raw_tests;

--- a/src/tokio/spawn/windows_raw_tests.rs
+++ b/src/tokio/spawn/windows_raw_tests.rs
@@ -1,0 +1,60 @@
+//! Unit tests for the async raw `CreateProcessW` backend (Plan 12 Task 7). These live in the
+//! library (not `tests/`) because the cancellation proof drives the per-instance wait observer — a
+//! `#[cfg(test)]` seam unreachable from an integration crate — and needs no `CARGO_BIN_EXE` testbin
+//! (a system blocker resolvable via `PATH` suffices). The executable≠argv0 proof is the public
+//! integration test `tests/raw_windows_async.rs`.
+
+use std::future::Future;
+use std::task::Context;
+
+use crate::child::spawn::windows_raw::WaitOutcome;
+use crate::tokio::Command;
+use crate::Stdio;
+
+/// Dropping an in-flight `wait()` future cancels its blocking watcher promptly — the `CancelGuard`
+/// signals the cancel event — AND the child stays waitable: after the cancelled wait, closing the
+/// child's stdin (EOF) lets it exit and a FRESH `wait()` resolves. Fully event-driven: the
+/// observer's `started` signal proves the wait parked, its `Cancelled` outcome proves the drop
+/// released it; no wall-clock.
+///
+/// The wait is driven by a manual poll-to-parking then `drop`, rather than `tokio::spawn` +
+/// `abort`: that keeps the child accessible (aborting a task that owns the child would drop and
+/// reap it) so "stays waitable" is provable on the SAME child, and it isolates the cancel event
+/// from the child's own exit (no drop-order race between `signal_cancel` and Drop's kill).
+#[tokio::test]
+async fn async_wait_drop_cancels_and_child_stays_waitable() {
+    // `findstr` with no file argument reads stdin until EOF — a stdin-driven blocker resolvable via
+    // PATH (System32), so this unit test needs no CARGO_BIN_EXE testbin.
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (outcome_tx, outcome_rx) = tokio::sync::oneshot::channel();
+    let mut c = Command::new();
+    c.executable("findstr")
+        .args(["findstr", "/c:needle"])
+        .stdin(Stdio::pipe())
+        .unwrap();
+    // The test-only variant injects the observer into THIS child only (no process-global seam).
+    let mut child = c.spawn_with_wait_observer(started_tx, outcome_tx).unwrap();
+
+    // Poll the wait future to parking (an unpolled `async fn` runs no code, so this is what brings
+    // `spawn_blocking` + `CancelGuard` into existence), await the "parked" signal, then drop the
+    // future to fire the cancel event.
+    {
+        let mut fut = Box::pin(child.wait());
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        assert!(
+            fut.as_mut().poll(&mut cx).is_pending(),
+            "wait must park on a live, wedged child"
+        );
+        started_rx.await.expect("the blocking watcher parked");
+        drop(fut); // CancelGuard signals the cancel event
+    }
+    // Observed on THIS child, event-driven: the blocking watcher released with Cancelled.
+    assert_eq!(outcome_rx.await.unwrap(), WaitOutcome::Cancelled);
+
+    // Child stays waitable: closing its stdin (EOF) lets findstr exit, and a FRESH wait resolves.
+    drop(child.stdin().expect("owned stdin writer"));
+    child
+        .wait()
+        .await
+        .expect("a fresh wait resolves after the cancelled one");
+}

--- a/src/tokio/stdio.rs
+++ b/src/tokio/stdio.rs
@@ -367,6 +367,29 @@ impl AsyncWrite for WinOwnedWrite {
     }
 }
 
+/// Build a direction-appropriate overlapped (reactor-registered) pipe: the child's raw handle end
+/// plus our owned parent wrapper, whose mandatory `ConnectNamedPipe` is spawned as a task here
+/// (inside the runtime). Shared by the async std spawn's merge pre-pass and the async raw backend's
+/// piped std slots. Any failure is a typed `Err` — no retry.
+#[cfg(windows)]
+pub(crate) fn owned_overlapped_pipe(
+    dir: crate::stdio::Direction,
+) -> Result<(std::os::windows::io::OwnedHandle, OwnedStd), crate::error::Error> {
+    use crate::stdio::Direction;
+    match dir {
+        Direction::In => {
+            let (server, client) = overlapped_in_pipe()?;
+            let connecting = ConnectingPipe::Connecting(connect_task(server));
+            Ok((client, OwnedStd::Write(WinOwnedWrite(connecting))))
+        }
+        Direction::Out => {
+            let (server, client) = overlapped_out_pipe()?;
+            let connecting = ConnectingPipe::Connecting(connect_task(server));
+            Ok((client, OwnedStd::Read(WinOwnedRead(connecting))))
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "stdio_tests.rs"]
 mod stdio_tests;

--- a/src/wait/windows.rs
+++ b/src/wait/windows.rs
@@ -52,7 +52,8 @@ pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>)
 
 /// An unnamed manual-reset event, initially unsignaled, for releasing
 /// `block_until_exit_or_cancel` early. Signal with [`signal_cancel`]; `OwnedHandle` closes it.
-#[cfg_attr(not(feature = "tokio"), allow(dead_code))] // only consumer is tokio::wait::grace_wait
+// consumers: tokio::wait::grace_wait and the async raw backend (tokio::spawn::windows_raw).
+#[cfg_attr(not(feature = "tokio"), allow(dead_code))]
 pub(crate) fn new_cancel_event() -> Result<OwnedHandle, Error> {
     // SAFETY: creating an unnamed event has no preconditions; the handle is immediately
     // wrapped in an OwnedHandle, which closes it.
@@ -61,7 +62,8 @@ pub(crate) fn new_cancel_event() -> Result<OwnedHandle, Error> {
     Ok(unsafe { OwnedHandle::from_raw_handle(h.0 as _) })
 }
 
-#[cfg_attr(not(feature = "tokio"), allow(dead_code))] // only consumer is tokio::wait::grace_wait
+// consumers: tokio::wait::grace_wait and the async raw backend (tokio::spawn::windows_raw).
+#[cfg_attr(not(feature = "tokio"), allow(dead_code))]
 pub(crate) fn signal_cancel(event: &OwnedHandle) {
     // SAFETY: `event` is a live event handle (the OwnedHandle keeps it open).
     let set = unsafe { SetEvent(HANDLE(event.as_raw_handle())) };

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -21,6 +21,28 @@ fn borrow_std_file(handle: std::os::windows::io::RawHandle) -> std::mem::Manuall
     std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_handle(handle) })
 }
 
+/// Wrap CRT fd `fd` as a `File` for the `read-fd`/`write-fd` relay modes. Callers must
+/// `std::mem::forget` the result after use so the drop does not close a descriptor this
+/// process still owns (double-close on exit). On Windows the CRT fd is translated to its OS
+/// handle via `get_osfhandle`; on unix the fd is used directly.
+#[cfg(windows)]
+fn file_from_fd(fd: i32) -> std::fs::File {
+    use std::os::windows::io::{FromRawHandle, RawHandle};
+    // SAFETY: get_osfhandle only reads the CRT fd table; it has no preconditions.
+    let h = unsafe { libc::get_osfhandle(fd) };
+    assert!(h != -1, "fd {fd} not wired into the CRT fd table");
+    // SAFETY: `h` is a live OS handle for this open fd; the caller forgets the File so the
+    // handle is not closed out from under the fd.
+    unsafe { std::fs::File::from_raw_handle(h as RawHandle) }
+}
+#[cfg(unix)]
+fn file_from_fd(fd: i32) -> std::fs::File {
+    use std::os::fd::{FromRawFd, RawFd};
+    // SAFETY: `fd` is an open descriptor passed in by the test; the caller forgets the File so
+    // the descriptor is not closed out from under the fd.
+    unsafe { std::fs::File::from_raw_fd(fd as RawFd) }
+}
+
 #[cfg(windows)]
 fn install_ignore_break() {
     use windows::core::BOOL;
@@ -40,6 +62,40 @@ fn main() {
             // Print this process's argv[0] so callers can verify it.
             let argv0 = std::env::args().next().unwrap_or_default();
             println!("{argv0}");
+        }
+        "argv0-report" => {
+            // Report argv[0] and the resolved image path on separate lines, so the raw backend
+            // tests can prove argv[0] is independent of the executable that actually ran.
+            let argv0 = std::env::args().next().unwrap_or_default();
+            let image = std::env::current_exe().expect("current_exe");
+            println!("argv0={argv0}");
+            println!("image={}", image.display());
+        }
+        "read-fd" => {
+            // Copy the given CRT fd to stdout (proves an inherited fd reached the child).
+            let fd: i32 = args[2].parse().unwrap();
+            let mut f = file_from_fd(fd);
+            let mut out = std::io::stdout().lock();
+            std::io::copy(&mut f, &mut out).unwrap();
+            out.flush().unwrap();
+            std::mem::forget(f); // keep the inherited fd open; do not close on exit
+        }
+        "write-fd" => {
+            // Write the given text straight to the given CRT fd (proves the child can drive an
+            // inherited fd back to the parent).
+            let fd: i32 = args[2].parse().unwrap();
+            let mut f = file_from_fd(fd);
+            f.write_all(args[3].as_bytes()).unwrap();
+            f.flush().unwrap();
+            std::mem::forget(f); // keep the inherited fd open; do not close on exit
+        }
+        "isatty-fd" => {
+            // Report whether the given CRT fd is a character device (console) vs a pipe/file, so
+            // the raw backend tests can classify inherited stdio.
+            let fd: i32 = args[2].parse().unwrap();
+            // SAFETY: isatty only queries the fd; it has no preconditions.
+            let tty = unsafe { libc::isatty(fd) };
+            println!("isatty={tty}");
         }
         "echo-argv" => {
             let mut out = std::io::stdout().lock();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,9 +89,9 @@ pub fn spawn_control_async(mode: &str, extra: &[&str], contain: bool) -> (subpro
     argv.extend(extra.iter().map(|s| s.to_string()));
     let mut cmd = subprocess::tokio::Command::new();
     if contain {
-        // async Windows rejects contained `executable()` until Task 8 wires the raw backend's async
-        // containment; load the testbin as argv[0] via the std path instead (mode/addr stay at
-        // args[1..], so the testbin behaves identically).
+        // Load the testbin as argv[0] via the std path (mode/addr stay at args[1..], so it behaves
+        // identically) — keeps this shared helper on one code path across OSes. The async raw
+        // backend also serves contained `executable()` (see raw_windows_async.rs).
         let mut path_argv = vec![testbin().to_string()];
         path_argv.extend(argv.into_iter().skip(1));
         cmd.args(path_argv);
@@ -118,10 +118,10 @@ pub fn spawn_tree_async(
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = subprocess::tokio::Command::new();
-    // Load the testbin as argv[0] via the std path (mode/addr at args[1..]): these trees are
-    // contained (and async Windows rejects contained `executable()` until Task 8's async
-    // containment), and the sole uncontained caller is backend-agnostic. `configure` applies the
-    // containment/nesting/kill_on_drop.
+    // Load the testbin as argv[0] via the std path (mode/addr at args[1..], so it behaves
+    // identically): these trees are usually contained and the sole uncontained caller is
+    // backend-agnostic, so argv[0] keeps this helper on one code path across OSes. `configure`
+    // applies the containment/nesting/kill_on_drop.
     cmd.args([testbin(), mode, addr.as_str()]);
     configure(&mut cmd);
     let child = cmd.spawn().expect("spawn async tree");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -88,9 +88,16 @@ pub fn spawn_control_async(mode: &str, extra: &[&str], contain: bool) -> (subpro
     let mut argv: Vec<String> = vec!["subprocess_testbin".into(), mode.into(), addr];
     argv.extend(extra.iter().map(|s| s.to_string()));
     let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(testbin()).args(&argv);
     if contain {
+        // async Windows rejects contained `executable()` until Task 8 wires the raw backend's async
+        // containment; load the testbin as argv[0] via the std path instead (mode/addr stay at
+        // args[1..], so the testbin behaves identically).
+        let mut path_argv = vec![testbin().to_string()];
+        path_argv.extend(argv.into_iter().skip(1));
+        cmd.args(path_argv);
         cmd.contain();
+    } else {
+        cmd.executable(testbin()).args(&argv); // uncontained → the async raw backend
     }
     let child = cmd.spawn().expect("spawn async control child");
     let (mut sock, _) = listener.accept().expect("accept");
@@ -111,8 +118,11 @@ pub fn spawn_tree_async(
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(testbin())
-        .args(["subprocess_testbin", mode, addr.as_str()]);
+    // Load the testbin as argv[0] via the std path (mode/addr at args[1..]): these trees are
+    // contained (and async Windows rejects contained `executable()` until Task 8's async
+    // containment), and the sole uncontained caller is backend-agnostic. `configure` applies the
+    // containment/nesting/kill_on_drop.
+    cmd.args([testbin(), mode, addr.as_str()]);
     configure(&mut cmd);
     let child = cmd.spawn().expect("spawn async tree");
     let (mut root, mut grandchild) = (None, None);

--- a/tests/raw_windows.rs
+++ b/tests/raw_windows.rs
@@ -130,3 +130,114 @@ fn batch_script_via_executable_is_unsupported() {
         .unwrap_err();
     assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
 }
+
+// Raw backend, sync fd >= 3 via the MSVCRT lpReserved2 table (Plan 12 Task 5) =====
+
+/// A child-writes pipe on fd 3 delivers the child's bytes to the parent's read end — proving the
+/// fd-table wired fd 3 into the child's CRT and the parent kept the read end. EOF (from the child
+/// closing fd 3 on exit) bounds the read; no timer.
+#[test]
+fn fd3_pipe_out_delivers_child_bytes() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "write-fd", "3", "hi-fd3"])
+        .fd(3, subprocess::Stdio::pipe_out())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.fd_read_end(subprocess::Fd::from(3)).unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    assert_eq!(s, "hi-fd3");
+}
+
+/// A parent-writes pipe on fd 3 feeds the child: the child copies fd 3 to stdout, so dropping the
+/// parent's write end (EOF) makes the child echo exactly what was written. EOF bounds both reads.
+#[test]
+fn fd3_pipe_in_feeds_child() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "read-fd", "3"])
+        .fd(3, subprocess::Stdio::pipe_in())
+        .unwrap()
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut w = child.fd_write_end(subprocess::Fd::from(3)).unwrap();
+    std::io::Write::write_all(&mut w, b"ping3").unwrap();
+    drop(w); // child reads to EOF, copies, exits
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    assert_eq!(s, "ping3");
+}
+
+/// `Stdio::inherit()` on fd >= 3 has no defined parent stream to dup — the raw path rejects it via
+/// the hardened `inherit_end` arm.
+#[test]
+fn inherit_on_fd3_is_unsupported() {
+    let e = subprocess::Command::new()
+        .executable(common::testbin())
+        .args(["subprocess_testbin", "exit", "0"])
+        .fd(3, subprocess::Stdio::inherit())
+        .unwrap()
+        .spawn()
+        .unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+}
+
+/// A regular file on fd 3 classifies as a disk file (`FILE_TYPE_DISK` -> no `FDEV`), so the child's
+/// `_isatty(3)` reports 0. Deterministic device-class coverage with no console needed.
+#[test]
+fn fd3_file_is_not_a_tty() {
+    let f = tempfile::tempfile().expect("tempfile");
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "isatty-fd", "3"])
+        .fd(3, subprocess::Stdio::from_file(f))
+        .unwrap()
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    assert!(s.contains("isatty=0"), "file on fd3 is not a tty: {s}");
+}
+
+/// NUL is `FILE_TYPE_CHAR` -> `classify` = `CharDev` -> `FDEV`, so the child's `_isatty(3)` is
+/// nonzero (MSVCRT returns the raw `FDEV` bit, `0x40`, not a normalized 1 — the file/pipe case
+/// still returns 0). Deterministic `CharDev` coverage without allocating a real console.
+#[test]
+fn fd3_nul_is_a_char_device() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "isatty-fd", "3"])
+        .fd(3, subprocess::Stdio::null())
+        .unwrap()
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    let val: i32 = s
+        .trim()
+        .strip_prefix("isatty=")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("unexpected isatty output: {s}"));
+    assert_ne!(val, 0, "NUL on fd3 is a char device (tty), got {s}");
+}
+
+/// A descriptor whose dense fd table would exceed the `WORD`-sized `cbReserved2` field is rejected
+/// up front (before any allocation), as `Unsupported`.
+#[test]
+fn oversized_fd_is_unsupported() {
+    let e = subprocess::Command::new()
+        .executable(common::testbin())
+        .args(["subprocess_testbin", "exit", "0"])
+        .fd(70_000, subprocess::Stdio::null())
+        .unwrap()
+        .spawn()
+        .unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+}

--- a/tests/raw_windows.rs
+++ b/tests/raw_windows.rs
@@ -69,3 +69,64 @@ fn testbin_isatty_fd_reports_zero_for_a_pipe() {
     let s = String::from_utf8_lossy(&out.stdout);
     assert!(s.contains("isatty=0"), "got: {s}");
 }
+
+// Raw `CreateProcessW` backend, sync path (Plan 12 Task 4) =====
+
+/// The raw backend loads `executable()` while the child's argv[0] is the command line's first
+/// token — the independence std cannot express on Windows. `argv0-report` echoes both, proving
+/// the loaded image (`testbin`) differs from the reported argv[0] (`pretend-name`).
+#[test]
+fn executable_independent_of_argv0_on_windows() {
+    let exe = common::testbin();
+    let mut c = subprocess::Command::new();
+    c.executable(exe)
+        .commandline("pretend-name argv0-report")
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.stdout().unwrap(), &mut s).unwrap();
+    child.wait().unwrap();
+    assert!(
+        s.contains("argv0=pretend-name") && s.to_lowercase().contains("testbin"),
+        "{s}"
+    );
+}
+
+/// An embedded NUL in the command line cannot reach `CreateProcessW` (it would truncate the
+/// wide buffer); the raw backend rejects it up front as an `Io` error.
+#[test]
+fn embedded_nul_in_commandline_is_rejected() {
+    let e = subprocess::Command::new()
+        .executable(common::testbin())
+        .commandline("a\u{0}b")
+        .spawn()
+        .unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Io(_)), "{e:?}");
+}
+
+/// An embedded NUL in the working directory is rejected the same way (it would truncate the
+/// wide `lpCurrentDirectory`).
+#[test]
+fn embedded_nul_in_cwd_is_rejected() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .commandline("x argv0-report")
+        .current_dir(std::path::PathBuf::from("a\u{0}b"));
+    assert!(matches!(c.spawn().unwrap_err(), subprocess::error::Error::Io(_)));
+}
+
+/// A `.bat`/`.cmd` reached via `executable()` is rejected BEFORE resolution (CVE-2024-24576): a
+/// batch program has cmd.exe escaping semantics the raw quoter does not implement.
+#[test]
+fn batch_script_via_executable_is_unsupported() {
+    let dir = tempfile::tempdir().unwrap();
+    let bat = dir.path().join("x.bat");
+    std::fs::write(&bat, b"@echo off\n").unwrap();
+    let e = subprocess::Command::new()
+        .executable(&bat)
+        .commandline("x.bat")
+        .spawn()
+        .unwrap_err();
+    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+}

--- a/tests/raw_windows.rs
+++ b/tests/raw_windows.rs
@@ -241,3 +241,43 @@ fn oversized_fd_is_unsupported() {
         .unwrap_err();
     assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
 }
+
+// Containment over the raw backend (Plan 12 Task 6) =====
+
+/// A CONTAINED child with fd >= 3 routes through the raw backend AND lands in OUR Job Object:
+/// `test_job_handle_contains_self()` confirms membership (immutable once assigned, so it is
+/// deterministic for a handle-pinned child regardless of run state), fd 3 delivers the child's
+/// bytes, and `kill_tree()` tears the tree down cleanly. EOF (child closing fd 3 on exit) bounds
+/// the read; no timer.
+#[test]
+fn contained_raw_child_is_in_our_job_and_kill_tree_reaps() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "write-fd", "3", "x"])
+        .fd(3, subprocess::Stdio::pipe_out())
+        .unwrap()
+        .contain();
+    let mut child = c.spawn().expect("contained raw spawn");
+    // Fixed at spawn (run-state-independent): the achieved mechanism is the Job Object.
+    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert!(child.test_job_handle_contains_self(), "child must be inside OUR job");
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut child.fd_read_end(subprocess::Fd::from(3)).unwrap(), &mut s).unwrap();
+    assert_eq!(s, "x");
+    child.kill_tree().expect("kill_tree");
+}
+
+/// An UNCONTAINED executable spawn (no `.contain()`) reports `Containment::None` — the raw backend
+/// wires containment only when requested; without it the child is a lone process.
+#[test]
+fn uncontained_raw_child_has_no_containment() {
+    let mut c = subprocess::Command::new();
+    c.executable(common::testbin())
+        .commandline("x argv0-report")
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    assert!(matches!(
+        c.spawn().unwrap().containment(),
+        subprocess::Containment::None
+    ));
+}

--- a/tests/raw_windows.rs
+++ b/tests/raw_windows.rs
@@ -1,0 +1,71 @@
+//! Smoke tests for the testbin helper modes the raw-`CreateProcessW` backend tests rely on
+//! (`read-fd` / `write-fd` / `argv0-report` / `isatty-fd`). Windows-only: the raw backend and
+//! its fd/argv[0]/CRT-device proofs are a Windows concern, so the whole crate is `#![cfg(windows)]`.
+//! These prove the four modes EXIST and emit their documented output over std pipes; the
+//! executable-vs-argv[0] independence itself is proven later via the crate's own `Command`.
+#![cfg(windows)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[path = "common/mod.rs"]
+mod common;
+
+/// `argv0-report` emits both an `argv0=` and an `image=` line. Spawned via a RAW
+/// `std::process::Command`, so argv[0] is the exe path and the mode is `args[0]` — do NOT
+/// prepend "subprocess_testbin" (that convention is the crate's own `Command`). This asserts
+/// only that the mode works; the argv[0]≠exe behavior is proven later via `subprocess::Command`.
+#[test]
+fn testbin_argv0_report_emits_argv0_and_image() {
+    let out = Command::new(common::testbin())
+        .args(["argv0-report"])
+        .output()
+        .expect("spawn");
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(s.contains("argv0=") && s.contains("image="), "got: {s}");
+}
+
+/// `write-fd <n> <text>` writes `text` straight to CRT fd `n`. Targeting fd 1 (stdout) with a
+/// piped stdout proves the fd→`File` path reaches the intended handle.
+#[test]
+fn testbin_write_fd_writes_to_the_target_fd() {
+    let out = Command::new(common::testbin())
+        .args(["write-fd", "1", "hello-fd1"])
+        .output()
+        .expect("spawn");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "hello-fd1");
+}
+
+/// `read-fd <n>` copies CRT fd `n` to stdout. Feeding a piped stdin (fd 0) and reading it back
+/// on stdout proves the read direction of the fd→`File` path. The child sees EOF when the write
+/// end drops — a real close event, not a timer.
+#[test]
+fn testbin_read_fd_copies_the_source_fd_to_stdout() {
+    let mut child = Command::new(common::testbin())
+        .args(["read-fd", "0"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(b"payload-fd0")
+        .expect("write stdin");
+    // stdin dropped above → child reads to EOF, copies, exits.
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "payload-fd0");
+}
+
+/// `isatty-fd <n>` reports `isatty=<0|1>` via `libc::isatty`. A piped fd is not a console, so a
+/// piped stdout (fd 1) must classify as `isatty=0`.
+#[test]
+fn testbin_isatty_fd_reports_zero_for_a_pipe() {
+    let out = Command::new(common::testbin())
+        .args(["isatty-fd", "1"])
+        .output()
+        .expect("spawn");
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(s.contains("isatty=0"), "got: {s}");
+}

--- a/tests/raw_windows_async.rs
+++ b/tests/raw_windows_async.rs
@@ -1,0 +1,30 @@
+//! Async (tokio) raw-`CreateProcessW` backend tests (Plan 12 Task 7). Windows + tokio only: the
+//! raw backend is a Windows concern, and its async mirror needs the tokio runtime.
+#![cfg(all(windows, feature = "tokio"))]
+
+use tokio::io::AsyncReadExt;
+
+#[path = "common/mod.rs"]
+mod common;
+
+/// Async twin of sync `executable_independent_of_argv0_on_windows`: the raw backend loads
+/// `executable()` while argv[0] is the command line's first token. `argv0-report` echoes both,
+/// proving the loaded image (`testbin`) differs from the reported argv[0] (`pretend-name`). The
+/// stdout pipe is served by the tokio overlapped-named-pipe machinery.
+#[tokio::test]
+async fn async_executable_independent_of_argv0() {
+    let exe = common::testbin();
+    let mut c = subprocess::tokio::Command::new();
+    c.executable(exe)
+        .commandline("pretend-name argv0-report")
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut s = String::new();
+    child.stdout().unwrap().read_to_string(&mut s).await.unwrap();
+    child.wait().await.unwrap();
+    assert!(
+        s.contains("argv0=pretend-name") && s.to_lowercase().contains("testbin"),
+        "{s}"
+    );
+}

--- a/tests/raw_windows_async.rs
+++ b/tests/raw_windows_async.rs
@@ -1,8 +1,8 @@
-//! Async (tokio) raw-`CreateProcessW` backend tests (Plan 12 Task 7). Windows + tokio only: the
+//! Async (tokio) raw-`CreateProcessW` backend tests (Plan 12 Tasks 7-8). Windows + tokio only: the
 //! raw backend is a Windows concern, and its async mirror needs the tokio runtime.
 #![cfg(all(windows, feature = "tokio"))]
 
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[path = "common/mod.rs"]
 mod common;
@@ -29,18 +29,70 @@ async fn async_executable_independent_of_argv0() {
     );
 }
 
-/// A CONTAINED `executable()` async spawn has no raw backend yet (Task 8 wires async containment):
-/// it must be rejected LOUDLY, not fall through to the std path — which would silently drop the
-/// user's argv[0] (std's arg0 preservation is Unix-only on Windows). Covers ARGV input; the
-/// commandline case is separately rejected by `build_from_commandline`.
+// Async raw fd >= 3 via the MSVCRT lpReserved2 table (Plan 12 Task 8) =====
+
+/// Async twin of sync `fd3_pipe_out_delivers_child_bytes`: a child-writes pipe on fd 3 delivers the
+/// child's bytes to the parent's async read end (`AsyncReadExt`). The fd-table wired fd 3 into the
+/// child's CRT; EOF (child closing fd 3 on exit) bounds the read — no timer.
 #[tokio::test]
-async fn async_contained_executable_is_unsupported() {
+async fn async_fd3_pipe_out_delivers_child_bytes() {
     let mut c = subprocess::tokio::Command::new();
     c.executable(common::testbin())
-        .args(["fakename", "exit", "0"]) // argv[0] "fakename" ≠ the loaded image
+        .args(["subprocess_testbin", "write-fd", "3", "hi-fd3"])
+        .fd(3, subprocess::Stdio::pipe_out())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut r = child.fd_read_end(subprocess::Fd::from(3)).expect("fd 3 reader");
+    let mut s = String::new();
+    r.read_to_string(&mut s).await.unwrap();
+    child.wait().await.unwrap();
+    assert_eq!(s, "hi-fd3");
+}
+
+/// Async twin of sync `fd3_pipe_in_feeds_child`: a parent-writes pipe on fd 3 feeds the child
+/// (`AsyncWriteExt`). The child copies fd 3 to stdout, so dropping the parent's write end (EOF)
+/// makes it echo exactly what was written. EOF bounds both reads — no timer.
+#[tokio::test]
+async fn async_fd3_pipe_in_feeds_child() {
+    let mut c = subprocess::tokio::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "read-fd", "3"])
+        .fd(3, subprocess::Stdio::pipe_in())
+        .unwrap()
+        .stdout(subprocess::Stdio::pipe())
+        .unwrap();
+    let mut child = c.spawn().expect("raw spawn");
+    let mut w = child.fd_write_end(subprocess::Fd::from(3)).expect("fd 3 writer");
+    w.write_all(b"ping3").await.unwrap();
+    drop(w); // child reads to EOF, copies, exits
+    let mut s = String::new();
+    child.stdout().unwrap().read_to_string(&mut s).await.unwrap();
+    child.wait().await.unwrap();
+    assert_eq!(s, "ping3");
+}
+
+// Async containment over the raw backend (Plan 12 Task 8) =====
+
+/// Async twin of sync `contained_raw_child_is_in_our_job_and_kill_tree_reaps`: a CONTAINED child
+/// loaded via `executable()` (with fd >= 3) routes through the async raw backend AND lands in OUR
+/// Job Object — `test_job_handle_contains_self()` confirms membership (immutable once assigned).
+/// fd 3 delivers the child's bytes over the async read end, and `kill_tree()` tears the tree down.
+/// EOF (child closing fd 3 on exit) bounds the read — no timer.
+#[tokio::test]
+async fn async_contained_raw_child_is_in_our_job() {
+    let mut c = subprocess::tokio::Command::new();
+    c.executable(common::testbin())
+        .args(["subprocess_testbin", "write-fd", "3", "x"])
+        .fd(3, subprocess::Stdio::pipe_out())
+        .unwrap()
         .contain();
-    let err = c
-        .spawn()
-        .expect_err("contained executable() must be rejected until Task 8");
-    assert!(matches!(err, subprocess::error::Error::Unsupported { .. }), "{err:?}");
+    let mut child = c.spawn().expect("contained raw spawn");
+    // Fixed at spawn (run-state-independent): the achieved mechanism is the Job Object.
+    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert!(child.test_job_handle_contains_self(), "child must be inside OUR job");
+    let mut r = child.fd_read_end(subprocess::Fd::from(3)).expect("fd 3 reader");
+    let mut s = String::new();
+    r.read_to_string(&mut s).await.unwrap();
+    assert_eq!(s, "x");
+    child.kill_tree().expect("kill_tree");
 }

--- a/tests/raw_windows_async.rs
+++ b/tests/raw_windows_async.rs
@@ -28,3 +28,19 @@ async fn async_executable_independent_of_argv0() {
         "{s}"
     );
 }
+
+/// A CONTAINED `executable()` async spawn has no raw backend yet (Task 8 wires async containment):
+/// it must be rejected LOUDLY, not fall through to the std path — which would silently drop the
+/// user's argv[0] (std's arg0 preservation is Unix-only on Windows). Covers ARGV input; the
+/// commandline case is separately rejected by `build_from_commandline`.
+#[tokio::test]
+async fn async_contained_executable_is_unsupported() {
+    let mut c = subprocess::tokio::Command::new();
+    c.executable(common::testbin())
+        .args(["fakename", "exit", "0"]) // argv[0] "fakename" ≠ the loaded image
+        .contain();
+    let err = c
+        .spawn()
+        .expect_err("contained executable() must be rejected until Task 8");
+    assert!(matches!(err, subprocess::error::Error::Unsupported { .. }), "{err:?}");
+}

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -176,22 +176,6 @@ fn null_stdout_discards_output() {
 
 // Rejections =====
 
-#[cfg(windows)]
-#[test]
-fn contained_fd_ge_3_is_rejected() {
-    // Uncontained fd >= 3 now works via the raw backend (see tests/raw_windows.rs). Under
-    // containment it stays Unsupported until the raw backend's containment wiring lands (Task 6).
-    let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
-    cmd.fd(3, Stdio::null()).expect("fd attach ok");
-    cmd.contain();
-    let err = cmd.spawn().expect_err("should reject contained fd >= 3 on Windows");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "expected Unsupported, got {err:?}"
-    );
-}
-
 #[test]
 fn merge_to_merge_is_rejected() {
     // stdout -> merge(stderr), stderr -> merge(stdout): chained merge.

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -393,7 +393,7 @@ fn unix_fd3_null_is_accepted() {
 }
 
 /// Prove that Stdio::inherit() on fd 3 is rejected with Unsupported (no defined
-/// parent stream to dup for n>=3). The raw backend (Plan 4) lifts this.
+/// parent stream to dup for n>=3) — a retained design limit on every path.
 #[cfg(unix)]
 #[test]
 fn unix_fd3_inherit_is_rejected() {

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -178,11 +178,14 @@ fn null_stdout_discards_output() {
 
 #[cfg(windows)]
 #[test]
-fn fd_ge_3_is_rejected() {
+fn contained_fd_ge_3_is_rejected() {
+    // Uncontained fd >= 3 now works via the raw backend (see tests/raw_windows.rs). Under
+    // containment it stays Unsupported until the raw backend's containment wiring lands (Task 6).
     let mut cmd = Command::new();
     cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
     cmd.fd(3, Stdio::null()).expect("fd attach ok");
-    let err = cmd.spawn().expect_err("should reject fd >= 3 on Windows");
+    cmd.contain();
+    let err = cmd.spawn().expect_err("should reject contained fd >= 3 on Windows");
     assert!(
         matches!(err, subprocess::error::Error::Unsupported { .. }),
         "expected Unsupported, got {err:?}"
@@ -346,16 +349,6 @@ fn null_stdout_discards() {
     cmd.stdout(Stdio::null()).unwrap();
     let status = cmd.status().expect("status");
     assert!(status.success());
-}
-
-#[cfg(windows)]
-#[test]
-fn arbitrary_fd_is_unsupported_on_windows() {
-    let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
-    cmd.fd(3, Stdio::pipe_out()).unwrap(); // attaches fine
-    let err = cmd.spawn().unwrap_err(); // but spawn rejects it on Windows
-    assert!(matches!(err, subprocess::error::Error::Unsupported { .. }));
 }
 
 // Arbitrary fd (n>=3) — Unix only, wired via command-fds =====

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -391,8 +391,9 @@ async fn async_unix_fd3_null_is_accepted() {
     assert_eq!(status.code(), Some(0));
 }
 
-/// Async twin of sync `arbitrary_fd_is_unsupported_on_windows`: config attaches fine, spawn
-/// rejects with the sync path's typed error.
+/// The async path has no raw backend yet (Task 7), so fd >= 3 on Windows still rejects: config
+/// attaches fine, spawn rejects with the sync path's typed error. (The sync path already routes
+/// uncontained fd >= 3 through the raw backend — see tests/raw_windows.rs.)
 #[cfg(windows)]
 #[tokio::test]
 async fn async_fd3_is_unsupported_on_windows() {

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -391,19 +391,10 @@ async fn async_unix_fd3_null_is_accepted() {
     assert_eq!(status.code(), Some(0));
 }
 
-/// The async path has no raw backend yet (Task 7), so fd >= 3 on Windows still rejects: config
-/// attaches fine, spawn rejects with the sync path's typed error. (The sync path already routes
-/// uncontained fd >= 3 through the raw backend — see tests/raw_windows.rs.)
-#[cfg(windows)]
-#[tokio::test]
-async fn async_fd3_is_unsupported_on_windows() {
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "0"]);
-    cmd.fd(3, subprocess::Stdio::pipe_out()).unwrap(); // attaches fine
-    let err = cmd.spawn().unwrap_err(); // but spawn rejects it on Windows
-    assert!(matches!(err, subprocess::error::Error::Unsupported { .. }));
-}
+// Windows fd >= 3 routes through the async raw `CreateProcessW` backend (Plan 12 Task 8): the
+// MSVCRT fd-table wires the descriptor and the parent end is the overlapped-named-pipe async end.
+// Its round-trips (both directions) + contained twin live in `tests/raw_windows_async.rs`,
+// alongside the rest of the raw-backend proofs.
 
 /// fd 3 as pipe_out: the testbin's `fd3-write` mode writes a token to fd 3; the parent
 /// reads it back via the reactor-registered `fd_read_end`.


### PR DESCRIPTION
Closes #4.

Lifts the two Windows-only `Unsupported` limitations `std::process` cannot express, on **both** the sync and async (tokio) surfaces, routed only when the std path can't express the request (`needs_raw == executable() || fd >= 3`; otherwise the std/tokio path is unchanged):

- **`fd(n)` for n >= 3** — MSVCRT `lpReserved2` fd-table smuggle, scoped by `STARTUPINFOEX` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` (MSVC/UCRT children), with an overflow-safe pre-allocation size cap and `GetFileType` device classification.
- **`executable()` + `commandline()`** — independent `lpApplicationName` / `lpCommandLine`; also fixes the prior `executable()`-alone argv[0] degradation on Windows.

## Approach
- A process-handle abstraction (`ProcHandle` sync / `ProcSource` async) lets the raw `CreateProcessW` child coexist with `SharedChild` / `tokio::process::Child`.
- A single shared FFI/resolution/containment core (`create_process`, `crt_fds`, `resolve`, `windows_contain_setup`) backs both surfaces.
- Inheritance safety: a poison-tolerant crate spawn mutex serialises the mark-inheritable -> spawn -> close window across all four spawn paths; every raw spawn scopes inheritance via a HANDLE_LIST built from a single source.
- Containment reuses the existing `attach_job` (CREATE_SUSPENDED + Toolhelp resume); the async raw wait is Arc-owned + cancel-on-drop, waiting directly on the owned handle.

## Retained as loud `Unsupported` (documented, out of scope)
Chained merges, `inherit()` on fd >= 3, `.bat`/`.cmd` programs (CVE-2024-24576), oversized fd-tables, and non-MSVCRT children for fd >= 3 (inherent).

## Testing
TDD throughout; the full suite is green on the Windows host **and** WSL Ubuntu (both default and `--features tokio`). No time-based synchronisation — child exit and wait-cancellation are proven by pipe EOF / inspected `ExitStatus` / event-driven signals.

Spec and plan: `.tmp/claude/superpowers/{specs,plans}/2026-07-18-plan12-windows-raw-backend*.md`.