### PR TITLE
docs: add README with Apache-2.0 license assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# subprocess
+
+Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation.
+
+`std::process` hands you a child and little else. It cannot tell you whether the process you spawned is still the process you think it is, cannot tear down a process tree, cannot address a process it did not spawn, and cannot run one elevated. This crate covers those, with one API across Linux, macOS, and Windows, and a `tokio` mirror behind a feature flag.
+
+> **Status:** under construction. The crate is unpublished and the API is not stable. User-facing documentation is tracked in [#30](https://github.com/bindreams/subprocess/issues/30).
+
+## License
+
+<img align="right" width="150px" height="150px" src="https://www.apache.org/foundation/press/kit/img/the-apache-way-badge/ASF_Badge_apacheway-purple.png">
+
+Copyright 2026, Anna Zhukova
+
+This project is licensed under the Apache 2.0 license. The license text can be found at [LICENSE](/LICENSE).
+
+`src/quote/posix.rs` is a Rust port of the `internal/foundation/shlex` package from [JetBrains qodana-cli](https://github.com/JetBrains/qodana-cli), used under that project's Apache 2.0 license.


### PR DESCRIPTION
The repo had no README. This adds one carrying the license-asserting block, matching the pattern used in `skuld`.

The Apache Way badge has been redesigned since `skuld` adopted it — `Indigo-THE_APACHE_WAY_BADGE-rgb.svg` is no longer listed in the [ASF press kit](https://www.apache.org/foundation/press/kit/), replaced by `ASF_Badge_apacheway-<color>` in five colors. The new asset is raster-only (no SVG) and square at 1000x1000, so the existing 150x150 slot carries over unchanged. Purple is the nearest match to the old indigo; blue, orange, red, and yellow are also available.

The block also credits the qodana-cli shlex port, which is the substantive part of #22 — Apache-2.0 §4(c) and §4(d) impose nothing here, since the upstream files carry no notice headers and the project ships no NOTICE file.

Part of #30; does not close it, as the full documentation pass is still outstanding.