### PR TITLE
refactor: rename crate to cosca

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
         if: matrix.os == 'darwin'
         run: cargo test --locked --release --lib --target ${{ matrix.target }}
 
-      # Live cgroup v2 containment tests are gated behind SUBPROCESS_TEST_CGROUP
+      # Live cgroup v2 containment tests are gated behind COSCA_TEST_CGROUP
       # (a no-op without it). They need a cgroup the supervisor may create child
       # cgroups under. We make a fresh leaf directly under the unified root cgroup:
       # its `cgroup.subtree_control` is empty, so the v2 "no internal processes"
@@ -112,9 +112,9 @@ jobs:
           test -n "$BIN"
           echo "cgroup test binary: $BIN"
           sudo bash -euxc '
-            CG=/sys/fs/cgroup/subprocess-ci
+            CG=/sys/fs/cgroup/cosca-ci
             mkdir -p "$CG"
             echo $$ > "$CG/cgroup.procs"
-            export SUBPROCESS_TEST_CGROUP=1
+            export COSCA_TEST_CGROUP=1
             exec "$0" cgroup --nocapture --test-threads=1
           ' "$BIN"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosca"
+version = "0.0.0"
+dependencies = [
+ "command-fds",
+ "getrandom",
+ "libc",
+ "log",
+ "nix",
+ "rustix",
+ "shared_child",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "windows",
+ "zeroize",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,24 +231,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "subprocess"
-version = "0.0.0"
-dependencies = [
- "command-fds",
- "getrandom",
- "libc",
- "log",
- "nix",
- "rustix",
- "shared_child",
- "tempfile",
- "thiserror",
- "tokio",
- "windows",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "subprocess"
+name = "cosca"
 version = "0.0.0"
 edition = "2021"
 rust-version = "1.87"
-description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity (and, later, elevation)."
+description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation."
 license = "Apache-2.0"
-publish = false           # working name; not yet published
+publish = false           # name settled (`cosca`); not yet published
 
 [features]
 pty = []
@@ -56,7 +56,7 @@ command-fds = "0.3"
 rustix = { version = "1", features = ["process", "event"] }
 
 [[bin]]
-name = "subprocess_testbin"
+name = "cosca_testbin"
 path = "testbin/main.rs"
 test = false
 doc = false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# subprocess
+# cosca
 
 Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation.
 

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -154,7 +154,7 @@ impl Default for ContainRequest {
 /// jobs nest but Unix process groups do not, so only the OUTERMOST `.contain()`
 /// creates a group; descendants inherit this marker and join it. **Reserved and
 /// load-bearing: nothing outside this crate may set it.**
-pub(crate) const NESTED_ENV: &str = "__SUBPROCESS_GROUP_ROOT";
+pub(crate) const NESTED_ENV: &str = "__COSCA_GROUP_ROOT";
 
 #[cfg(unix)]
 #[path = "containment/unix.rs"]

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -100,7 +100,7 @@ use nix::unistd::Pid;
 /// firing `cgroup.kill` first if the leaf is still occupied.
 #[cfg(target_os = "linux")]
 pub(crate) struct CgroupLeaf {
-    /// Absolute path to the leaf directory, e.g. `/sys/fs/cgroup/…/subprocess-<pid>`.
+    /// Absolute path to the leaf directory, e.g. `/sys/fs/cgroup/…/cosca-<pid>`.
     leaf_path: PathBuf,
     /// Pre-opened `cgroup.procs` fd (O_CLOEXEC cleared) for the `pre_exec` write.
     procs_fd: RawFd,
@@ -161,7 +161,7 @@ impl CgroupLeaf {
     /// fd or path.
     pub(crate) fn placeholder_for_test() -> CgroupLeaf {
         CgroupLeaf {
-            leaf_path: PathBuf::from("/nonexistent/subprocess-cgroup-placeholder"),
+            leaf_path: PathBuf::from("/nonexistent/cosca-cgroup-placeholder"),
             procs_fd: -1,
         }
     }
@@ -204,7 +204,7 @@ pub(crate) fn try_create_leaf() -> Option<CgroupLeaf> {
     // different seq values mean different leaf names).
     // Safety: getpid() is always valid.
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let leaf_name = format!("subprocess-{}-{}", unsafe { libc::getpid() }, seq);
+    let leaf_name = format!("cosca-{}-{}", unsafe { libc::getpid() }, seq);
     let leaf_path = current.join(&leaf_name);
 
     fs::create_dir(&leaf_path).ok()?;

--- a/src/containment/enumerate.rs
+++ b/src/containment/enumerate.rs
@@ -13,7 +13,7 @@ use crate::identity::RawPid;
 mod backend;
 
 #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
-compile_error!("subprocess::containment::enumerate is implemented only for Windows, Linux, and macOS");
+compile_error!("cosca::containment::enumerate is implemented only for Windows, Linux, and macOS");
 
 /// A `(pid, ppid)` pair for every currently-listable process. Best-effort: a
 /// process that vanishes mid-snapshot is simply absent. Only pid/ppid are read;

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -20,7 +20,7 @@ pub(crate) mod stat_parse;
 mod backend;
 
 #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
-compile_error!("subprocess::identity is implemented only for Windows, Linux, and macOS");
+compile_error!("cosca::identity is implemented only for Windows, Linux, and macOS");
 
 /// A process identifier as the OS knows it (matches `std::process::id`).
 pub type RawPid = u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! `subprocess`: unified cross-platform subprocess management.
+//! `cosca`: unified cross-platform subprocess management.
 //!
 //! Under construction. The first landed layer is the pure core: the error
 //! taxonomy, argv quoting, and the command input model. Modules are added by

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -8,7 +8,7 @@ use crate::stdio::Stdio;
 
 use super::child::Child;
 
-/// An async (tokio) process to configure and spawn — mirrors [`subprocess::Command`](crate::Command).
+/// An async (tokio) process to configure and spawn — mirrors [`cosca::Command`](crate::Command).
 ///
 /// # Limitations
 ///
@@ -111,7 +111,7 @@ impl Command {
         self
     }
 
-    /// Run the child elevated — mirrors [`subprocess::Command::elevate`](crate::Command::elevate).
+    /// Run the child elevated — mirrors [`cosca::Command::elevate`](crate::Command::elevate).
     pub fn elevate(&mut self) -> &mut Command {
         self.inner.elevate();
         self

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -21,7 +21,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     // Err on every platform.
     if ::tokio::runtime::Handle::try_current().is_err() {
         return Err(Error::Io(std::io::Error::other(
-            "subprocess::tokio::Command must be spawned from within a Tokio runtime",
+            "cosca::tokio::Command must be spawned from within a Tokio runtime",
         )));
     }
 
@@ -128,7 +128,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let std_cmd = build_std_command(cmd)?;
     let mut tcmd = ::tokio::process::Command::new(std::ffi::OsStr::new(""));
     *tcmd.as_std_mut() = std_cmd;
-    // tokio's own `kill_on_drop` is intentionally left at its `false` default: subprocess's
+    // tokio's own `kill_on_drop` is intentionally left at its `false` default: cosca's
     // `Child::drop` (attached.hard_kill + reap_now) is the SOLE teardown owner. Forwarding the
     // builder's `kill_on_drop` to `tcmd` would make tokio fire its own kill and race reap_now.
 

--- a/src/tokio/stdio.rs
+++ b/src/tokio/stdio.rs
@@ -173,7 +173,7 @@ fn overlapped_pipe(
     let mut r = [0u8; 8];
     getrandom::fill(&mut r).map_err(|e| crate::error::Error::Io(std::io::Error::other(e)))?;
     let name = format!(
-        r"\\.\pipe\subprocess.{}.{}.{:016x}",
+        r"\\.\pipe\cosca.{}.{}.{:016x}",
         std::process::id(),
         COUNTER.fetch_add(1, Ordering::Relaxed),
         u64::from_ne_bytes(r)

--- a/src/tokio/stdio_tests.rs
+++ b/src/tokio/stdio_tests.rs
@@ -58,7 +58,7 @@ async fn overlapped_in_pipe_feeds_a_real_childs_input() {
 // first_pipe_instance makes the second create fail PermissionDenied.
 #[tokio::test]
 async fn overlapped_pipe_never_attaches_to_a_squatted_name() {
-    let name = format!(r"\\.\pipe\subprocess-test-squat.{}", std::process::id());
+    let name = format!(r"\\.\pipe\cosca-test-squat.{}", std::process::id());
     let _squatter = tokio::net::windows::named_pipe::ServerOptions::new()
         .first_pipe_instance(true)
         .create(&name)
@@ -78,7 +78,7 @@ async fn overlapped_pipe_never_attaches_to_a_squatted_name() {
 // what `overlapped_pipe_named` does when it loses the race.
 #[tokio::test]
 async fn overlapped_pipe_client_slot_is_exclusive() {
-    let name = format!(r"\\.\pipe\subprocess-test-slot.{}", std::process::id());
+    let name = format!(r"\\.\pipe\cosca-test-slot.{}", std::process::id());
     // The same instance overlapped_pipe_named creates (Out orientation).
     let _server = tokio::net::windows::named_pipe::ServerOptions::new()
         .access_inbound(true)
@@ -148,7 +148,7 @@ async fn owned_write_poll_after_join_error_is_err_not_panic() {
 async fn overlapped_pipe_connect_pending_completes_on_late_client_open() {
     use std::future::Future;
     use std::io::Write;
-    let name = format!(r"\\.\pipe\subprocess-test-pending.{}", std::process::id());
+    let name = format!(r"\\.\pipe\cosca-test-pending.{}", std::process::id());
     let mut server = tokio::net::windows::named_pipe::ServerOptions::new()
         .access_inbound(true)
         .first_pipe_instance(true)

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -14,7 +14,7 @@ use crate::identity::ProcessId;
 pub(crate) mod backend;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
-compile_error!("subprocess::wait is implemented only for Linux, macOS, and Windows");
+compile_error!("cosca::wait is implemented only for Linux, macOS, and Windows");
 
 /// Force the NEXT grace-watch on THIS thread to fail (consumed by `block_until_exit`,
 /// `Child::wait_timeout`, and `tokio::wait::{grace_wait, wait_exit}`), so the watch-error

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -1,5 +1,5 @@
 //! Test-only helper spawned by the crate's integration tests. std-only, with
-//! one exception: the `report-nested-kill-tree` mode uses the `subprocess` crate
+//! one exception: the `report-nested-kill-tree` mode uses the `cosca` crate
 //! to exercise the real nested-member `kill_tree` path. Behavior is selected by argv[1].
 
 use std::io::{Read, Write};
@@ -376,15 +376,15 @@ fn main() {
             // be Unsupported. Report 'D' (Delegated + Unsupported) or 'O' (other).
             let addr = &args[2];
             let exe = std::env::current_exe().unwrap();
-            let mut gc = subprocess::Command::new();
-            gc.executable(&exe).args(["subprocess_testbin", "exit", "0"]).contain();
+            let mut gc = cosca::Command::new();
+            gc.executable(&exe).args(["cosca_testbin", "exit", "0"]).contain();
             let child = gc.spawn().unwrap();
             // A nested member must report Containment::Delegated AND reject kill_tree as
             // Unsupported. Transmitting both discriminates the Delegated path from an
             // uncontained None (which also yields Unsupported) — so a marker-propagation
             // regression (nested -> None) is caught, not silently passed.
-            let is_delegated = child.containment() == subprocess::Containment::Delegated;
-            let unsupported = matches!(child.kill_tree(), Err(subprocess::error::Error::Unsupported { .. }));
+            let is_delegated = child.containment() == cosca::Containment::Delegated;
+            let unsupported = matches!(child.kill_tree(), Err(cosca::error::Error::Unsupported { .. }));
             let _ = child.wait();
             let mut sock = std::net::TcpStream::connect(addr).unwrap();
             sock.write_all(if is_delegated && unsupported { b"D" } else { b"O" })
@@ -407,11 +407,11 @@ fn main() {
             let _ = sock.read(&mut buf);
         }
         "is-elevated-report" => {
-            println!("{}", if subprocess::elevation::is_elevated() { "1" } else { "0" });
+            println!("{}", if cosca::elevation::is_elevated() { "1" } else { "0" });
         }
         #[cfg(unix)]
         "controlling-terminal" => {
-            let present = subprocess::elevation::controlling_terminal_present();
+            let present = cosca::elevation::controlling_terminal_present();
             println!("{}", if present { "1" } else { "0" });
         }
         // Linux PTY harness: become a session leader with no ctty (setsid), acquire the
@@ -425,7 +425,7 @@ fn main() {
                 assert!(libc::setsid() != -1, "setsid failed");
                 assert!(libc::ioctl(3, libc::TIOCSCTTY as _, 0) != -1, "TIOCSCTTY failed");
             }
-            let present = subprocess::elevation::controlling_terminal_present();
+            let present = cosca::elevation::controlling_terminal_present();
             println!("{}", if present { "1" } else { "0" });
         }
         "write-marker" => {
@@ -442,7 +442,7 @@ fn main() {
             std::thread::sleep(std::time::Duration::from_secs(600));
         }
         other => {
-            eprintln!("subprocess_testbin: unknown mode {other:?}");
+            eprintln!("cosca_testbin: unknown mode {other:?}");
             exit(2);
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,19 +10,19 @@ use std::io::Read;
 use std::net::{TcpListener, TcpStream};
 
 pub fn testbin() -> &'static str {
-    env!("CARGO_BIN_EXE_subprocess_testbin")
+    env!("CARGO_BIN_EXE_cosca_testbin")
 }
 
 /// Spawn `mode <addr> [extra...]` as a control child that connects, writes a 1-byte tag,
 /// then blocks; returns the owned `Child` and the accepted socket (the tag read proves it
 /// is alive). `contain` applies `.contain()`. This is the canonical form; `tests/lifecycle.rs`
 /// now calls this instead of keeping its own copy.
-pub fn spawn_control(mode: &str, extra: &[&str], contain: bool) -> (subprocess::Child, TcpStream) {
+pub fn spawn_control(mode: &str, extra: &[&str], contain: bool) -> (cosca::Child, TcpStream) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let mut argv: Vec<String> = vec!["subprocess_testbin".into(), mode.into(), addr];
+    let mut argv: Vec<String> = vec!["cosca_testbin".into(), mode.into(), addr];
     argv.extend(extra.iter().map(|s| s.to_string()));
-    let mut cmd = subprocess::Command::new();
+    let mut cmd = cosca::Command::new();
     cmd.executable(testbin()).args(&argv);
     if contain {
         cmd.contain();
@@ -36,7 +36,7 @@ pub fn spawn_control(mode: &str, extra: &[&str], contain: bool) -> (subprocess::
 
 /// Convenience alias for the common `control-block` blocker (no `.contain()`). A one-line
 /// shortcut over `spawn_control`, NOT a second copy of the body.
-pub fn spawn_blocker() -> (subprocess::Child, TcpStream) {
+pub fn spawn_blocker() -> (cosca::Child, TcpStream) {
     spawn_control("control-block", &["R"], false)
 }
 
@@ -45,12 +45,11 @@ pub fn spawn_blocker() -> (subprocess::Child, TcpStream) {
 /// two tag reads prove the 2-level tree is alive). The tree dies — and both sockets EOF — only
 /// when the whole tree is torn down, so callers prove teardown by reading EOF on both, never by
 /// a timer.
-pub fn spawn_tree(mode: &str, contain: bool) -> (subprocess::Child, Vec<TcpStream>) {
+pub fn spawn_tree(mode: &str, contain: bool) -> (cosca::Child, Vec<TcpStream>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let mut cmd = subprocess::Command::new();
-    cmd.executable(testbin())
-        .args(["subprocess_testbin", mode, addr.as_str()]);
+    let mut cmd = cosca::Command::new();
+    cmd.executable(testbin()).args(["cosca_testbin", mode, addr.as_str()]);
     if contain {
         cmd.contain();
     }
@@ -75,19 +74,19 @@ pub fn spawn_tree(mode: &str, contain: bool) -> (subprocess::Child, Vec<TcpStrea
 }
 
 /// Spawn the `spawn-grandchild` helper tree.
-pub fn spawn_grandchild(contain: bool) -> (subprocess::Child, Vec<TcpStream>) {
+pub fn spawn_grandchild(contain: bool) -> (cosca::Child, Vec<TcpStream>) {
     spawn_tree("spawn-grandchild", contain)
 }
 
 /// Async analogue of `spawn_control`: spawn a testbin control child (it connects back and
 /// sends its tag before the helper returns), optionally contained.
 #[cfg(feature = "tokio")]
-pub fn spawn_control_async(mode: &str, extra: &[&str], contain: bool) -> (subprocess::tokio::Child, TcpStream) {
+pub fn spawn_control_async(mode: &str, extra: &[&str], contain: bool) -> (cosca::tokio::Child, TcpStream) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let mut argv: Vec<String> = vec!["subprocess_testbin".into(), mode.into(), addr];
+    let mut argv: Vec<String> = vec!["cosca_testbin".into(), mode.into(), addr];
     argv.extend(extra.iter().map(|s| s.to_string()));
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     if contain {
         // Load the testbin as argv[0] via the std path (mode/addr stay at args[1..], so it behaves
         // identically) — keeps this shared helper on one code path across OSes. The async raw
@@ -113,11 +112,11 @@ pub fn spawn_control_async(mode: &str, extra: &[&str], contain: bool) -> (subpro
 #[cfg(feature = "tokio")]
 pub fn spawn_tree_async(
     mode: &str,
-    configure: impl FnOnce(&mut subprocess::tokio::Command),
-) -> (subprocess::tokio::Child, TcpStream, TcpStream) {
+    configure: impl FnOnce(&mut cosca::tokio::Command),
+) -> (cosca::tokio::Child, TcpStream, TcpStream) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     // Load the testbin as argv[0] via the std path (mode/addr at args[1..], so it behaves
     // identically): these trees are usually contained and the sole uncontained caller is
     // backend-agnostic, so argv[0] keeps this helper on one code path across OSes. `configure`
@@ -146,24 +145,21 @@ pub fn spawn_tree_async(
 /// Async `control-block` blocker (uncontained): a child that connects, tags "R", and blocks on
 /// its socket. The accept/tag-read is sync std (the test side); the CHILD is async.
 #[cfg(feature = "tokio")]
-pub fn spawn_blocker_async() -> (subprocess::tokio::Child, TcpStream) {
+pub fn spawn_blocker_async() -> (cosca::tokio::Child, TcpStream) {
     spawn_control_async("control-block", &["R"], false)
 }
 
 /// Async analogue of `spawn_grandchild`, returning the root ("R") and grandchild ("G") control
 /// sockets identified by tag (accept order is not guaranteed).
 #[cfg(feature = "tokio")]
-pub fn spawn_grandchild_async(contain: bool) -> (subprocess::tokio::Child, TcpStream, TcpStream) {
+pub fn spawn_grandchild_async(contain: bool) -> (cosca::tokio::Child, TcpStream, TcpStream) {
     spawn_grandchild_async_with(contain, true)
 }
 
 /// `spawn_grandchild_async` with explicit `contain` and `kill_on_drop` flags, so a test can
 /// exercise the `kill_on_drop(false)` Drop early-return (attached still armed) without `detach()`.
 #[cfg(feature = "tokio")]
-pub fn spawn_grandchild_async_with(
-    contain: bool,
-    kill_on_drop: bool,
-) -> (subprocess::tokio::Child, TcpStream, TcpStream) {
+pub fn spawn_grandchild_async_with(contain: bool, kill_on_drop: bool) -> (cosca::tokio::Child, TcpStream, TcpStream) {
     spawn_tree_async("spawn-grandchild", |cmd| {
         if contain {
             cmd.contain();

--- a/tests/elevation.rs
+++ b/tests/elevation.rs
@@ -1,4 +1,4 @@
-//! Live elevation tier — gated behind SUBPROCESS_TEST_ELEVATION (cgroup precedent):
+//! Live elevation tier — gated behind COSCA_TEST_ELEVATION (cgroup precedent):
 //! a TRUE no-op when the var is absent, and FAILS LOUDLY when set but elevation is
 //! unavailable. The pure tiers cover all logic unconditionally; only the privilege-gain
 //! (and the cross-process controlling-terminal probes) run here.
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 fn gated() -> bool {
-    std::env::var_os("SUBPROCESS_TEST_ELEVATION").is_some()
+    std::env::var_os("COSCA_TEST_ELEVATION").is_some()
 }
 
 fn testbin() -> PathBuf {
@@ -16,9 +16,9 @@ fn testbin() -> PathBuf {
         p.pop();
     }
     p.push(if cfg!(windows) {
-        "subprocess_testbin.exe"
+        "cosca_testbin.exe"
     } else {
-        "subprocess_testbin"
+        "cosca_testbin"
     });
     p
 }
@@ -29,9 +29,9 @@ fn posix_elevated_child_runs_as_root_and_captures_uid() {
     if !gated() {
         return;
     }
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.args(["id", "-u"])
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+        .elevation_auth(cosca::elevation::Auth::NonInteractive);
     let out = c.output().expect("elevated output");
     assert!(out.status.success(), "elevated `id -u` failed: {out:?}");
     assert_eq!(
@@ -49,11 +49,11 @@ fn posix_child_self_detects_elevation() {
     }
     let exe = testbin();
     let exe_str = exe.clone().into_os_string();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     // executable() set AND argv[0] == the exe path, so no distinct-argv0 rejection.
     c.executable(&exe)
         .args([exe_str, "is-elevated-report".into()])
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+        .elevation_auth(cosca::elevation::Auth::NonInteractive);
     let s = c.read().expect("read");
     assert_eq!(s.trim(), "1", "elevated testbin did not self-detect elevation");
 }
@@ -75,13 +75,13 @@ fn controlling_terminal_probe_consults_ctty_not_stdin() {
     let slave_file = std::fs::File::from(slave);
 
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.args([exe.into_os_string(), "acquire-ctty-and-probe".into()]);
     // stdin = /dev/null: a buggy isatty(STDIN) probe would answer 0 here.
-    c.stdin(subprocess::Stdio::null()).unwrap();
-    c.stdout(subprocess::Stdio::pipe()).unwrap();
+    c.stdin(cosca::Stdio::null()).unwrap();
+    c.stdout(cosca::Stdio::pipe()).unwrap();
     // Pass the pty slave as fd 3; the child acquires it as its controlling terminal.
-    c.fd(3, subprocess::Stdio::from_file(slave_file)).unwrap();
+    c.fd(3, cosca::Stdio::from_file(slave_file)).unwrap();
     let mut ch = c.spawn().expect("spawn");
     let out = ch.communicate(None).expect("communicate");
     let _ = master.as_raw_fd(); // keep master owned until here
@@ -99,7 +99,7 @@ fn controlling_terminal_probe_consults_ctty_not_stdin() {
 #[test]
 fn controlling_terminal_probe_is_false_after_setsid() {
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.args(["setsid".into(), exe.into_os_string(), "controlling-terminal".into()]);
     let s = c.read().expect("read setsid child output");
     assert_eq!(
@@ -118,21 +118,21 @@ fn controlling_terminal_probe_is_false_after_setsid() {
 #[cfg(target_os = "linux")]
 #[test]
 fn run0_client_kill_propagates_to_the_transient_unit() {
-    if !gated() || std::env::var_os("SUBPROCESS_TEST_ELEVATION_RUN0").is_none() {
+    if !gated() || std::env::var_os("COSCA_TEST_ELEVATION_RUN0").is_none() {
         return; // requires run0 + a polkit-passwordless context that can spawn a transient unit.
     }
     let pidfile = std::env::temp_dir().join(format!("run0-payload-{}.pid", std::process::id()));
     let _ = std::fs::remove_file(&pidfile);
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(&exe)
         .args([
             exe.clone().into_os_string(),
             "write-pid-then-sleep".into(),
             pidfile.clone().into_os_string(),
         ])
-        .elevation_backend(subprocess::elevation::Backend::Run0)
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+        .elevation_backend(cosca::elevation::Backend::Run0)
+        .elevation_auth(cosca::elevation::Auth::NonInteractive);
     let child = c.spawn().expect("run0 spawn");
 
     // Wait for the payload to publish its pid on a real event (its file appears), not a timer.
@@ -178,14 +178,12 @@ fn posix_stdin_auth_reaches_root() {
     if !gated() {
         return;
     }
-    let pw = std::env::var("SUBPROCESS_TEST_ELEVATION_PASSWORD")
-        .expect("SUBPROCESS_TEST_ELEVATION_PASSWORD must hold the sudo password for the Auth::Stdin live test");
-    let mut c = subprocess::Command::new();
+    let pw = std::env::var("COSCA_TEST_ELEVATION_PASSWORD")
+        .expect("COSCA_TEST_ELEVATION_PASSWORD must hold the sudo password for the Auth::Stdin live test");
+    let mut c = cosca::Command::new();
     c.args(["id", "-u"])
-        .elevation_backend(subprocess::elevation::Backend::Sudo)
-        .elevation_auth(subprocess::elevation::Auth::Stdin(subprocess::elevation::Secret::new(
-            pw,
-        )));
+        .elevation_backend(cosca::elevation::Backend::Sudo)
+        .elevation_auth(cosca::elevation::Auth::Stdin(cosca::elevation::Secret::new(pw)));
     let out = c.output().expect("stdin-auth elevated output");
     assert!(out.status.success(), "sudo -S id failed: {out:?}");
     assert_eq!(
@@ -202,8 +200,8 @@ fn posix_askpass_auth_reaches_root() {
     if !gated() {
         return;
     }
-    let pw = std::env::var("SUBPROCESS_TEST_ELEVATION_PASSWORD")
-        .expect("SUBPROCESS_TEST_ELEVATION_PASSWORD must hold the sudo password for the Auth::Askpass live test");
+    let pw = std::env::var("COSCA_TEST_ELEVATION_PASSWORD")
+        .expect("COSCA_TEST_ELEVATION_PASSWORD must hold the sudo password for the Auth::Askpass live test");
     // A minimal askpass script that echoes the password.
     let dir = std::env::temp_dir().join(format!("askpass-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
@@ -213,10 +211,10 @@ fn posix_askpass_auth_reaches_root() {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.args(["id", "-u"])
-        .elevation_backend(subprocess::elevation::Backend::Sudo)
-        .elevation_auth(subprocess::elevation::Auth::Askpass(script.clone()));
+        .elevation_backend(cosca::elevation::Backend::Sudo)
+        .elevation_auth(cosca::elevation::Auth::Askpass(script.clone()));
     let out = c.output().expect("askpass elevated output");
     assert!(out.status.success(), "sudo -A id failed: {out:?}");
     assert_eq!(
@@ -246,14 +244,14 @@ fn posix_uncontained_elevated_child_is_unkillable_and_drop_does_not_hang() {
     let pidfile = std::env::temp_dir().join(format!("uncontained-payload-{}.pid", std::process::id()));
     let _ = std::fs::remove_file(&pidfile);
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(&exe)
         .args([
             exe.clone().into_os_string(),
             "write-pid-then-sleep".into(),
             pidfile.clone().into_os_string(),
         ])
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+        .elevation_auth(cosca::elevation::Auth::NonInteractive);
     let child = c.spawn().expect("elevated write-pid-then-sleep");
 
     // Wait for the payload to publish its pid on a real event (its file appears with parseable
@@ -281,8 +279,8 @@ fn posix_uncontained_elevated_child_is_unkillable_and_drop_does_not_hang() {
     // would be the real defect.
     match child.kill() {
         Ok(()) => {}
-        Err(subprocess::error::Error::Elevation {
-            kind: subprocess::error::ElevationErrorKind::Unkillable,
+        Err(cosca::error::Error::Elevation {
+            kind: cosca::error::ElevationErrorKind::Unkillable,
             ..
         }) => {}
         other => panic!("expected Ok (use_pty monitor) or typed Unkillable (direct exec), got {other:?}"),
@@ -297,16 +295,15 @@ fn posix_uncontained_elevated_child_is_unkillable_and_drop_does_not_hang() {
 #[cfg(unix)]
 #[test]
 fn already_elevated_inherit_spawn_reports_already_elevated() {
-    if !gated() || !subprocess::elevation::is_elevated() {
+    if !gated() || !cosca::elevation::is_elevated() {
         return; // deterministic only when the gated runner is itself elevated.
     }
-    let mut c = subprocess::Command::new();
-    c.args(["true"])
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+    let mut c = cosca::Command::new();
+    c.args(["true"]).elevation_auth(cosca::elevation::Auth::NonInteractive);
     let child = c.spawn().expect("spawn");
     assert_eq!(
         child.elevation().expect("elevation requested → Some").via,
-        subprocess::elevation::ElevatedVia::AlreadyElevated,
+        cosca::elevation::ElevatedVia::AlreadyElevated,
     );
     let _ = child.wait();
 }
@@ -317,12 +314,12 @@ fn windows_elevated_child_writes_admin_marker() {
     if !gated() {
         return;
     }
-    let dir = std::env::var_os("SUBPROCESS_TEST_ELEVATION_MARKER_DIR")
+    let dir = std::env::var_os("COSCA_TEST_ELEVATION_MARKER_DIR")
         .map(PathBuf::from)
-        .expect("SUBPROCESS_TEST_ELEVATION_MARKER_DIR must point at an admin-only writable dir");
+        .expect("COSCA_TEST_ELEVATION_MARKER_DIR must point at an admin-only writable dir");
     let marker = dir.join(format!("elev-{}.marker", std::process::id()));
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(&exe).args([
         exe.clone().into_os_string(),
         "write-marker".into(),
@@ -332,8 +329,8 @@ fn windows_elevated_child_writes_admin_marker() {
     let child = c.spawn().expect("runas spawn");
     // Honest report: WindowsUac + OwnConsole (never a faked shared stream).
     let report = child.elevation().unwrap();
-    assert_eq!(report.via, subprocess::elevation::ElevatedVia::WindowsUac);
-    assert_eq!(report.stdio, subprocess::elevation::ElevatedStdio::OwnConsole);
+    assert_eq!(report.via, cosca::elevation::ElevatedVia::WindowsUac);
+    assert_eq!(report.stdio, cosca::elevation::ElevatedStdio::OwnConsole);
     let status = child.wait().expect("wait");
     assert!(status.success(), "elevated marker write failed: {status:?}");
     assert!(marker.exists(), "elevated child did not create the admin-only marker");
@@ -346,9 +343,9 @@ async fn async_posix_elevated_child_runs_as_root() {
     if !gated() {
         return;
     }
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.args(["id", "-u"])
-        .elevation_auth(subprocess::elevation::Auth::NonInteractive);
+        .elevation_auth(cosca::elevation::Auth::NonInteractive);
     let out = c.output().await.expect("async elevated output");
     assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "0");
 }
@@ -362,15 +359,15 @@ fn windows_elevated_child_is_unkillable_and_drop_does_not_hang() {
         return;
     }
     let exe = testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     // A long-lived elevated child (ping loops ~50s).
     c.executable(&exe)
         .args([exe.clone().into_os_string(), "sleep-marker".into()])
         .elevate();
     let child = c.spawn().expect("runas spawn");
     match child.kill() {
-        Err(subprocess::error::Error::Elevation { kind, .. }) => {
-            assert_eq!(kind, subprocess::error::ElevationErrorKind::Unkillable);
+        Err(cosca::error::Error::Elevation { kind, .. }) => {
+            assert_eq!(kind, cosca::error::ElevationErrorKind::Unkillable);
         }
         // If the CI context runs the parent elevated too, the child is killable — accept Ok.
         Ok(()) => {}
@@ -387,12 +384,12 @@ async fn async_windows_elevated_child_writes_admin_marker() {
     if !gated() {
         return;
     }
-    let dir = std::env::var_os("SUBPROCESS_TEST_ELEVATION_MARKER_DIR")
+    let dir = std::env::var_os("COSCA_TEST_ELEVATION_MARKER_DIR")
         .map(PathBuf::from)
-        .expect("SUBPROCESS_TEST_ELEVATION_MARKER_DIR must point at an admin-only writable dir");
+        .expect("COSCA_TEST_ELEVATION_MARKER_DIR must point at an admin-only writable dir");
     let marker = dir.join(format!("elev-async-{}.marker", std::process::id()));
     let exe = testbin();
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(&exe).args([
         exe.clone().into_os_string(),
         "write-marker".into(),
@@ -401,8 +398,8 @@ async fn async_windows_elevated_child_writes_admin_marker() {
     c.elevate();
     let mut child = c.spawn().expect("async runas spawn");
     let report = child.elevation().unwrap();
-    assert_eq!(report.via, subprocess::elevation::ElevatedVia::WindowsUac);
-    assert_eq!(report.stdio, subprocess::elevation::ElevatedStdio::OwnConsole);
+    assert_eq!(report.via, cosca::elevation::ElevatedVia::WindowsUac);
+    assert_eq!(report.stdio, cosca::elevation::ElevatedStdio::OwnConsole);
     let status = child.wait().await.expect("wait");
     assert!(status.success(), "async elevated marker write failed: {status:?}");
     assert!(
@@ -423,14 +420,14 @@ async fn async_windows_elevated_child_is_unkillable_and_drop_does_not_hang() {
         return;
     }
     let exe = testbin();
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(&exe)
         .args([exe.clone().into_os_string(), "sleep-marker".into()])
         .elevate();
     let mut child = c.spawn().expect("async runas spawn");
     match child.kill() {
-        Err(subprocess::error::Error::Elevation { kind, .. }) => {
-            assert_eq!(kind, subprocess::error::ElevationErrorKind::Unkillable);
+        Err(cosca::error::Error::Elevation { kind, .. }) => {
+            assert_eq!(kind, cosca::error::ElevationErrorKind::Unkillable);
         }
         // If the manual runner is itself elevated, the child is killable — accept Ok.
         Ok(()) => {}

--- a/tests/foundation_smoke.rs
+++ b/tests/foundation_smoke.rs
@@ -1,8 +1,8 @@
-use subprocess::error::QuoteErrorKind;
-use subprocess::quote::posix;
-use subprocess::quote::windows;
-use subprocess::Command;
-use subprocess::Containment;
+use cosca::error::QuoteErrorKind;
+use cosca::quote::posix;
+use cosca::quote::windows;
+use cosca::Command;
+use cosca::Containment;
 
 #[test]
 fn public_surface_is_usable() {
@@ -39,9 +39,9 @@ fn public_surface_is_usable() {
 #[cfg(any(unix, windows))]
 #[test]
 fn containment_smoke() {
-    let tb = env!("CARGO_BIN_EXE_subprocess_testbin");
-    let mut cmd = subprocess::Command::new();
-    cmd.executable(tb).args(["subprocess_testbin", "exit", "0"]).contain();
+    let tb = env!("CARGO_BIN_EXE_cosca_testbin");
+    let mut cmd = cosca::Command::new();
+    cmd.executable(tb).args(["cosca_testbin", "exit", "0"]).contain();
     let child = cmd.spawn().expect("spawn contained child");
 
     // On every supported host (Unix + Windows) the strongest mechanism must
@@ -74,9 +74,9 @@ fn containment_smoke() {
 
 #[test]
 fn spawn_public_surface_is_usable() {
-    use subprocess::{run, Stdio};
+    use cosca::{run, Stdio};
     // run([...]) -> output() captures; status code reachable.
-    let out = run([env!("CARGO_BIN_EXE_subprocess_testbin"), "echo-argv", "hi"])
+    let out = run([env!("CARGO_BIN_EXE_cosca_testbin"), "echo-argv", "hi"])
         .output()
         .expect("output");
     assert!(out.status.success());

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -36,10 +36,7 @@ fn child_terminate_unsupported_on_windows() {
     let err = child
         .terminate()
         .expect_err("lone graceful terminate has no Windows primitive");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     let _ = child.wait();
 }
@@ -96,10 +93,7 @@ fn child_graceful_shutdown_unsupported_on_windows() {
     let err = child
         .graceful_shutdown(Duration::from_secs(1))
         .expect_err("no Windows lone graceful");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     let _ = child.wait();
 }
@@ -201,7 +195,7 @@ fn process_terminate_sends_sigterm() {
     use std::io::Read;
     use std::os::unix::process::ExitStatusExt;
     let (child, mut sock) = common::spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.terminate().expect("foreign terminate");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf); // dead — EOF
@@ -216,7 +210,7 @@ fn process_graceful_shutdown_graceful_path() {
     use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     let (child, mut sock) = common::spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.graceful_shutdown(Duration::from_secs(30)).expect("foreign graceful");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf);
@@ -233,7 +227,7 @@ fn process_graceful_shutdown_escalates() {
     // SIGTERM is ignored → SIGKILL is the only terminating signal the child can receive, so the
     // reaped status is unambiguously SIGKILL.
     let (child, mut sock) = common::spawn_control("control-block-ignore-term", &["R"], false);
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.graceful_shutdown(Duration::ZERO).expect("foreign escalates");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf);
@@ -246,14 +240,11 @@ fn process_graceful_shutdown_escalates() {
 fn process_lone_graceful_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
-    assert!(matches!(
-        p.terminate(),
-        Err(subprocess::error::Error::Unsupported { .. })
-    ));
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    assert!(matches!(p.terminate(), Err(cosca::error::Error::Unsupported { .. })));
     assert!(matches!(
         p.graceful_shutdown(Duration::from_secs(1)),
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     child.kill().expect("cleanup");
     let _ = child.wait();
@@ -265,7 +256,7 @@ fn process_kill_tree_tears_down_tree() {
     // An UNcontained 2-level tree (root R + grandchild G). Take the root foreign and kill_tree
     // it: the identity-walk (snapshot-then-kill) reaches both. Both sockets EOF. All OSes.
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.kill_tree().expect("kill_tree");
     for (i, s) in socks.iter_mut().enumerate() {
         let mut buf = [0u8; 1];
@@ -284,7 +275,7 @@ fn process_graceful_shutdown_tree_tears_down_tree() {
     use std::io::Read;
     use std::time::Duration;
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.graceful_shutdown_tree(Duration::from_secs(30))
         .expect("foreign tree graceful");
     for (i, s) in socks.iter_mut().enumerate() {
@@ -303,14 +294,14 @@ fn process_graceful_shutdown_tree_tears_down_tree() {
 fn process_soft_tree_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     assert!(matches!(
         p.terminate_tree(),
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     assert!(matches!(
         p.graceful_shutdown_tree(Duration::from_secs(1)),
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     child.kill().expect("cleanup");
     let _ = child.wait();

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -7,12 +7,12 @@ use std::io::Read;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime};
 
-use subprocess::identity::ProcessId;
+use cosca::identity::ProcessId;
 
 #[path = "common/mod.rs"]
 mod common;
 
-const BLOCK_VAR: &str = "SUBPROCESS_IDENTITY_TEST_BLOCK";
+const BLOCK_VAR: &str = "COSCA_IDENTITY_TEST_BLOCK";
 
 /// When this integration-test binary is re-spawned with `BLOCK_VAR` set, this
 /// "test" blocks reading stdin until the parent closes the pipe. In a normal

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::time::{Duration, Instant};
 
-use subprocess::Command;
+use cosca::Command;
 
 #[path = "common/mod.rs"]
 mod common;
@@ -106,18 +106,18 @@ fn child_is_send_and_sync() {
     // Load-bearing for `concurrent_wait_timeout_and_kill_is_safe` (shares &Child across
     // threads).
     fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<subprocess::Child>();
+    assert_send_sync::<cosca::Child>();
 }
 
 #[test]
 fn tree_ops_on_uncontained_child_are_unsupported() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "exit", "0"]);
     let child = cmd.spawn().expect("spawn");
-    assert_eq!(child.containment(), subprocess::Containment::None);
+    assert_eq!(child.containment(), cosca::Containment::None);
     for r in [child.kill_tree(), child.terminate_tree()] {
         assert!(
-            matches!(r, Err(subprocess::error::Error::Unsupported { .. })),
+            matches!(r, Err(cosca::error::Error::Unsupported { .. })),
             "uncontained _tree op must be Unsupported, got {r:?}"
         );
     }
@@ -135,7 +135,7 @@ fn nested_member_kill_tree_is_unsupported_end_to_end() {
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "report-nested-kill-tree", &addr])
+        .args(["cosca_testbin", "report-nested-kill-tree", &addr])
         .contain();
     let child = cmd.spawn().expect("spawn reporter");
     let (mut sock, _) = listener.accept().expect("accept");

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -12,7 +12,7 @@ use common::spawn_blocker;
 #[test]
 fn foreign_wait_returns_when_the_process_exits() {
     let (child, mut sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("foreign process resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("foreign process resolves");
     sock.write_all(b"x").expect("trigger child exit");
     p.wait().expect("foreign wait");
     // Prove the exit via a real event (the dead child's socket EOFs), not is_alive().
@@ -30,7 +30,7 @@ fn foreign_wait_timeout_times_out_on_a_live_process() {
     // The blocker is structurally wedged on its never-written socket, so it cannot
     // exit; wait_timeout returns Ok(false) regardless of the (short) duration.
     let (child, _sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     let exited = p.wait_timeout(Duration::from_millis(200)).expect("wait_timeout");
     assert!(
         !exited,
@@ -43,7 +43,7 @@ fn foreign_wait_timeout_times_out_on_a_live_process() {
 #[test]
 fn foreign_wait_timeout_observes_an_exit() {
     let (child, mut sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     sock.write_all(b"x").expect("trigger child exit");
     assert!(p.wait_timeout(Duration::from_secs(30)).expect("wait_timeout"));
     let _ = child.wait();
@@ -53,7 +53,7 @@ fn foreign_wait_timeout_observes_an_exit() {
 fn foreign_wait_timeout_zero_returns_immediately_on_a_live_process() {
     // ZERO is the poll-once edge in each backend; a wedged child must yield Ok(false).
     let (child, _sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     assert!(!p.wait_timeout(Duration::ZERO).expect("wait_timeout"));
     child.kill().expect("kill cleanup");
     let _ = child.wait();
@@ -64,7 +64,7 @@ fn foreign_wait_timeout_huge_duration_does_not_panic() {
     // Duration::MAX overflows Instant + Duration; the saturating deadline must make
     // it unbounded, not panic. Trigger the exit first so the wait completes.
     let (child, mut sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     sock.write_all(b"x").expect("trigger child exit");
     assert!(p.wait_timeout(Duration::MAX).expect("wait_timeout"));
     let _ = child.wait();
@@ -72,9 +72,9 @@ fn foreign_wait_timeout_huge_duration_does_not_panic() {
 
 #[test]
 fn current_and_from_id_round_trip() {
-    let me = subprocess::Process::current();
+    let me = cosca::Process::current();
     assert!(me.is_alive());
-    assert_eq!(subprocess::Process::from_id(me.id()).map(|p| p.id()), Some(me.id()));
+    assert_eq!(cosca::Process::from_id(me.id()).map(|p| p.id()), Some(me.id()));
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn from_pid_resolves_a_live_foreign_child_then_reports_it_dead() {
     // liveness check, distinct from the zombie-inclusive exists()). Death is proven by the
     // reap, never by sleep.
     let (child, _sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("live foreign child resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("live foreign child resolves");
     assert_eq!(p.id(), child.id());
     assert!(p.is_alive(), "a freshly spawned foreign child is alive");
     child.kill().expect("kill");
@@ -95,18 +95,12 @@ fn from_pid_resolves_a_live_foreign_child_then_reports_it_dead() {
 #[test]
 fn parent_and_children_resolve_the_spawned_tree() {
     let (child, mut sock) = spawn_blocker();
-    let me = subprocess::Process::current();
-    let kid = subprocess::Process::from_pid(child.id().pid()).expect("child resolves");
+    let me = cosca::Process::current();
+    let kid = cosca::Process::from_pid(child.id().pid()).expect("child resolves");
 
     assert_eq!(kid.parent().expect("child has a parent").id(), me.id());
-    assert!(me
-        .children(subprocess::Recursive::No)
-        .iter()
-        .any(|p| p.id() == kid.id()));
-    assert!(me
-        .children(subprocess::Recursive::Yes)
-        .iter()
-        .any(|p| p.id() == kid.id()));
+    assert!(me.children(cosca::Recursive::No).iter().any(|p| p.id() == kid.id()));
+    assert!(me.children(cosca::Recursive::Yes).iter().any(|p| p.id() == kid.id()));
 
     sock.write_all(b"x").expect("release child");
     let _ = child.wait();
@@ -121,9 +115,9 @@ fn children_recursive_distinguishes_direct_from_descendant() {
     // one-level-vs-recursive distinction a No<->Yes arm swap would otherwise pass silently.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let mut cmd = subprocess::Command::new();
+    let mut cmd = cosca::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "spawn-grandchild", &addr]);
+        .args(["cosca_testbin", "spawn-grandchild", &addr]);
     let child = cmd.spawn().expect("spawn tree");
     let mut socks = Vec::new();
     for _ in 0..2 {
@@ -132,10 +126,10 @@ fn children_recursive_distinguishes_direct_from_descendant() {
         s.read_exact(&mut tag).expect("read tag");
         socks.push(s);
     }
-    let me = subprocess::Process::current();
-    let kid = subprocess::Process::from_pid(child.id().pid()).expect("child resolves");
+    let me = cosca::Process::current();
+    let kid = cosca::Process::from_pid(child.id().pid()).expect("child resolves");
     // The grandchild is kid's only direct child — use it to learn the grandchild's identity.
-    let grandkids = kid.children(subprocess::Recursive::No);
+    let grandkids = kid.children(cosca::Recursive::No);
     assert_eq!(
         grandkids.len(),
         1,
@@ -143,7 +137,7 @@ fn children_recursive_distinguishes_direct_from_descendant() {
     );
     let grandkid = grandkids[0];
 
-    let direct = me.children(subprocess::Recursive::No);
+    let direct = me.children(cosca::Recursive::No);
     assert!(
         direct.iter().any(|p| p.id() == kid.id()),
         "Recursive::No must include the direct child"
@@ -152,7 +146,7 @@ fn children_recursive_distinguishes_direct_from_descendant() {
         !direct.iter().any(|p| p.id() == grandkid.id()),
         "Recursive::No must EXCLUDE the grandchild"
     );
-    let all = me.children(subprocess::Recursive::Yes);
+    let all = me.children(cosca::Recursive::Yes);
     assert!(
         all.iter().any(|p| p.id() == kid.id()),
         "Recursive::Yes must include the child"
@@ -171,7 +165,7 @@ fn children_recursive_distinguishes_direct_from_descendant() {
 #[test]
 fn foreign_kill_terminates_the_process() {
     let (child, mut sock) = spawn_blocker();
-    let p = subprocess::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
     p.kill().expect("kill");
     let mut buf = [0u8; 1];
     match sock.read(&mut buf) {
@@ -193,7 +187,7 @@ fn foreign_kill_terminates_the_process() {
 #[cfg(unix)]
 #[test]
 fn foreign_kill_surfaces_permission_denied() {
-    let init = subprocess::Process::from_pid(1).expect("pid 1 resolves");
+    let init = cosca::Process::from_pid(1).expect("pid 1 resolves");
     assert!(init.is_alive(), "init must be alive");
     // SAFETY: geteuid() takes no arguments and is always safe.
     let root = unsafe { libc::geteuid() } == 0;
@@ -208,7 +202,7 @@ fn foreign_kill_surfaces_permission_denied() {
     let r = init.kill();
     if !root {
         assert!(
-            matches!(r, Err(subprocess::error::Error::Io(_))),
+            matches!(r, Err(cosca::error::Error::Io(_))),
             "non-root kill of init must surface EPERM as Err, got {r:?}"
         );
     } else {
@@ -229,7 +223,7 @@ fn is_alive_is_false_for_a_real_zombie() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
     // RAW std::process::Command: argv[0] is the exe path, so the testbin mode is args[1] —
-    // do NOT prepend "subprocess_testbin" the way the crate's Command requires.
+    // do NOT prepend "cosca_testbin" the way the crate's Command requires.
     let mut raw = std::process::Command::new(common::testbin())
         .args(["control-block", &addr, "Z"])
         .spawn()
@@ -238,7 +232,7 @@ fn is_alive_is_false_for_a_real_zombie() {
     let mut tag = [0u8; 1];
     sock.read_exact(&mut tag).expect("read tag");
 
-    let p = subprocess::Process::from_pid(raw.id()).expect("raw child resolves");
+    let p = cosca::Process::from_pid(raw.id()).expect("raw child resolves");
     sock.write_all(b"x").expect("trigger exit");
     p.wait().expect("death-watch"); // returns at the zombie instant (no reap yet)
 
@@ -246,7 +240,7 @@ fn is_alive_is_false_for_a_real_zombie() {
     // exists() is zombie-inclusive on ALL Unixes: Linux `/proc` persists, and macOS
     // resolves zombies via `sysctl KERN_PROC` (identity.rs).
     assert!(
-        subprocess::Process::from_id(p.id()).is_some(),
+        cosca::Process::from_id(p.id()).is_some(),
         "a zombie identity still resolves"
     );
     raw.wait().expect("reap the zombie");

--- a/tests/raw_windows.rs
+++ b/tests/raw_windows.rs
@@ -13,8 +13,8 @@ mod common;
 
 /// `argv0-report` emits both an `argv0=` and an `image=` line. Spawned via a RAW
 /// `std::process::Command`, so argv[0] is the exe path and the mode is `args[0]` — do NOT
-/// prepend "subprocess_testbin" (that convention is the crate's own `Command`). This asserts
-/// only that the mode works; the argv[0]≠exe behavior is proven later via `subprocess::Command`.
+/// prepend "cosca_testbin" (that convention is the crate's own `Command`). This asserts
+/// only that the mode works; the argv[0]≠exe behavior is proven later via `cosca::Command`.
 #[test]
 fn testbin_argv0_report_emits_argv0_and_image() {
     let out = Command::new(common::testbin())
@@ -78,10 +78,10 @@ fn testbin_isatty_fd_reports_zero_for_a_pipe() {
 #[test]
 fn executable_independent_of_argv0_on_windows() {
     let exe = common::testbin();
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(exe)
         .commandline("pretend-name argv0-report")
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
     let mut s = String::new();
@@ -97,23 +97,23 @@ fn executable_independent_of_argv0_on_windows() {
 /// wide buffer); the raw backend rejects it up front as an `Io` error.
 #[test]
 fn embedded_nul_in_commandline_is_rejected() {
-    let e = subprocess::Command::new()
+    let e = cosca::Command::new()
         .executable(common::testbin())
         .commandline("a\u{0}b")
         .spawn()
         .unwrap_err();
-    assert!(matches!(e, subprocess::error::Error::Io(_)), "{e:?}");
+    assert!(matches!(e, cosca::error::Error::Io(_)), "{e:?}");
 }
 
 /// An embedded NUL in the working directory is rejected the same way (it would truncate the
 /// wide `lpCurrentDirectory`).
 #[test]
 fn embedded_nul_in_cwd_is_rejected() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
         .commandline("x argv0-report")
         .current_dir(std::path::PathBuf::from("a\u{0}b"));
-    assert!(matches!(c.spawn().unwrap_err(), subprocess::error::Error::Io(_)));
+    assert!(matches!(c.spawn().unwrap_err(), cosca::error::Error::Io(_)));
 }
 
 /// A `.bat`/`.cmd` reached via `executable()` is rejected BEFORE resolution (CVE-2024-24576): a
@@ -123,12 +123,12 @@ fn batch_script_via_executable_is_unsupported() {
     let dir = tempfile::tempdir().unwrap();
     let bat = dir.path().join("x.bat");
     std::fs::write(&bat, b"@echo off\n").unwrap();
-    let e = subprocess::Command::new()
+    let e = cosca::Command::new()
         .executable(&bat)
         .commandline("x.bat")
         .spawn()
         .unwrap_err();
-    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+    assert!(matches!(e, cosca::error::Error::Unsupported { .. }), "{e:?}");
 }
 
 // Raw backend, sync fd >= 3 via the MSVCRT lpReserved2 table (Plan 12 Task 5) =====
@@ -138,14 +138,14 @@ fn batch_script_via_executable_is_unsupported() {
 /// closing fd 3 on exit) bounds the read; no timer.
 #[test]
 fn fd3_pipe_out_delivers_child_bytes() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "write-fd", "3", "hi-fd3"])
-        .fd(3, subprocess::Stdio::pipe_out())
+        .args(["cosca_testbin", "write-fd", "3", "hi-fd3"])
+        .fd(3, cosca::Stdio::pipe_out())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
     let mut s = String::new();
-    std::io::Read::read_to_string(&mut child.fd_read_end(subprocess::Fd::from(3)).unwrap(), &mut s).unwrap();
+    std::io::Read::read_to_string(&mut child.fd_read_end(cosca::Fd::from(3)).unwrap(), &mut s).unwrap();
     child.wait().unwrap();
     assert_eq!(s, "hi-fd3");
 }
@@ -154,15 +154,15 @@ fn fd3_pipe_out_delivers_child_bytes() {
 /// parent's write end (EOF) makes the child echo exactly what was written. EOF bounds both reads.
 #[test]
 fn fd3_pipe_in_feeds_child() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "read-fd", "3"])
-        .fd(3, subprocess::Stdio::pipe_in())
+        .args(["cosca_testbin", "read-fd", "3"])
+        .fd(3, cosca::Stdio::pipe_in())
         .unwrap()
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
-    let mut w = child.fd_write_end(subprocess::Fd::from(3)).unwrap();
+    let mut w = child.fd_write_end(cosca::Fd::from(3)).unwrap();
     std::io::Write::write_all(&mut w, b"ping3").unwrap();
     drop(w); // child reads to EOF, copies, exits
     let mut s = String::new();
@@ -175,14 +175,14 @@ fn fd3_pipe_in_feeds_child() {
 /// the hardened `inherit_end` arm.
 #[test]
 fn inherit_on_fd3_is_unsupported() {
-    let e = subprocess::Command::new()
+    let e = cosca::Command::new()
         .executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "0"])
-        .fd(3, subprocess::Stdio::inherit())
+        .args(["cosca_testbin", "exit", "0"])
+        .fd(3, cosca::Stdio::inherit())
         .unwrap()
         .spawn()
         .unwrap_err();
-    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+    assert!(matches!(e, cosca::error::Error::Unsupported { .. }), "{e:?}");
 }
 
 /// A regular file on fd 3 classifies as a disk file (`FILE_TYPE_DISK` -> no `FDEV`), so the child's
@@ -190,12 +190,12 @@ fn inherit_on_fd3_is_unsupported() {
 #[test]
 fn fd3_file_is_not_a_tty() {
     let f = tempfile::tempfile().expect("tempfile");
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "isatty-fd", "3"])
-        .fd(3, subprocess::Stdio::from_file(f))
+        .args(["cosca_testbin", "isatty-fd", "3"])
+        .fd(3, cosca::Stdio::from_file(f))
         .unwrap()
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
     let mut s = String::new();
@@ -209,12 +209,12 @@ fn fd3_file_is_not_a_tty() {
 /// still returns 0). Deterministic `CharDev` coverage without allocating a real console.
 #[test]
 fn fd3_nul_is_a_char_device() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "isatty-fd", "3"])
-        .fd(3, subprocess::Stdio::null())
+        .args(["cosca_testbin", "isatty-fd", "3"])
+        .fd(3, cosca::Stdio::null())
         .unwrap()
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
     let mut s = String::new();
@@ -232,14 +232,14 @@ fn fd3_nul_is_a_char_device() {
 /// up front (before any allocation), as `Unsupported`.
 #[test]
 fn oversized_fd_is_unsupported() {
-    let e = subprocess::Command::new()
+    let e = cosca::Command::new()
         .executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "0"])
-        .fd(70_000, subprocess::Stdio::null())
+        .args(["cosca_testbin", "exit", "0"])
+        .fd(70_000, cosca::Stdio::null())
         .unwrap()
         .spawn()
         .unwrap_err();
-    assert!(matches!(e, subprocess::error::Error::Unsupported { .. }), "{e:?}");
+    assert!(matches!(e, cosca::error::Error::Unsupported { .. }), "{e:?}");
 }
 
 // Containment over the raw backend (Plan 12 Task 6) =====
@@ -251,18 +251,18 @@ fn oversized_fd_is_unsupported() {
 /// the read; no timer.
 #[test]
 fn contained_raw_child_is_in_our_job_and_kill_tree_reaps() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "write-fd", "3", "x"])
-        .fd(3, subprocess::Stdio::pipe_out())
+        .args(["cosca_testbin", "write-fd", "3", "x"])
+        .fd(3, cosca::Stdio::pipe_out())
         .unwrap()
         .contain();
     let mut child = c.spawn().expect("contained raw spawn");
     // Fixed at spawn (run-state-independent): the achieved mechanism is the Job Object.
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
     assert!(child.test_job_handle_contains_self(), "child must be inside OUR job");
     let mut s = String::new();
-    std::io::Read::read_to_string(&mut child.fd_read_end(subprocess::Fd::from(3)).unwrap(), &mut s).unwrap();
+    std::io::Read::read_to_string(&mut child.fd_read_end(cosca::Fd::from(3)).unwrap(), &mut s).unwrap();
     assert_eq!(s, "x");
     child.kill_tree().expect("kill_tree");
 }
@@ -271,13 +271,10 @@ fn contained_raw_child_is_in_our_job_and_kill_tree_reaps() {
 /// wires containment only when requested; without it the child is a lone process.
 #[test]
 fn uncontained_raw_child_has_no_containment() {
-    let mut c = subprocess::Command::new();
+    let mut c = cosca::Command::new();
     c.executable(common::testbin())
         .commandline("x argv0-report")
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
-    assert!(matches!(
-        c.spawn().unwrap().containment(),
-        subprocess::Containment::None
-    ));
+    assert!(matches!(c.spawn().unwrap().containment(), cosca::Containment::None));
 }

--- a/tests/raw_windows_async.rs
+++ b/tests/raw_windows_async.rs
@@ -14,10 +14,10 @@ mod common;
 #[tokio::test]
 async fn async_executable_independent_of_argv0() {
     let exe = common::testbin();
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(exe)
         .commandline("pretend-name argv0-report")
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
     let mut s = String::new();
@@ -36,13 +36,13 @@ async fn async_executable_independent_of_argv0() {
 /// child's CRT; EOF (child closing fd 3 on exit) bounds the read — no timer.
 #[tokio::test]
 async fn async_fd3_pipe_out_delivers_child_bytes() {
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "write-fd", "3", "hi-fd3"])
-        .fd(3, subprocess::Stdio::pipe_out())
+        .args(["cosca_testbin", "write-fd", "3", "hi-fd3"])
+        .fd(3, cosca::Stdio::pipe_out())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
-    let mut r = child.fd_read_end(subprocess::Fd::from(3)).expect("fd 3 reader");
+    let mut r = child.fd_read_end(cosca::Fd::from(3)).expect("fd 3 reader");
     let mut s = String::new();
     r.read_to_string(&mut s).await.unwrap();
     child.wait().await.unwrap();
@@ -54,15 +54,15 @@ async fn async_fd3_pipe_out_delivers_child_bytes() {
 /// makes it echo exactly what was written. EOF bounds both reads — no timer.
 #[tokio::test]
 async fn async_fd3_pipe_in_feeds_child() {
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "read-fd", "3"])
-        .fd(3, subprocess::Stdio::pipe_in())
+        .args(["cosca_testbin", "read-fd", "3"])
+        .fd(3, cosca::Stdio::pipe_in())
         .unwrap()
-        .stdout(subprocess::Stdio::pipe())
+        .stdout(cosca::Stdio::pipe())
         .unwrap();
     let mut child = c.spawn().expect("raw spawn");
-    let mut w = child.fd_write_end(subprocess::Fd::from(3)).expect("fd 3 writer");
+    let mut w = child.fd_write_end(cosca::Fd::from(3)).expect("fd 3 writer");
     w.write_all(b"ping3").await.unwrap();
     drop(w); // child reads to EOF, copies, exits
     let mut s = String::new();
@@ -80,17 +80,17 @@ async fn async_fd3_pipe_in_feeds_child() {
 /// EOF (child closing fd 3 on exit) bounds the read — no timer.
 #[tokio::test]
 async fn async_contained_raw_child_is_in_our_job() {
-    let mut c = subprocess::tokio::Command::new();
+    let mut c = cosca::tokio::Command::new();
     c.executable(common::testbin())
-        .args(["subprocess_testbin", "write-fd", "3", "x"])
-        .fd(3, subprocess::Stdio::pipe_out())
+        .args(["cosca_testbin", "write-fd", "3", "x"])
+        .fd(3, cosca::Stdio::pipe_out())
         .unwrap()
         .contain();
     let mut child = c.spawn().expect("contained raw spawn");
     // Fixed at spawn (run-state-independent): the achieved mechanism is the Job Object.
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
     assert!(child.test_job_handle_contains_self(), "child must be inside OUR job");
-    let mut r = child.fd_read_end(subprocess::Fd::from(3)).expect("fd 3 reader");
+    let mut r = child.fd_read_end(cosca::Fd::from(3)).expect("fd 3 reader");
     let mut s = String::new();
     r.read_to_string(&mut s).await.unwrap();
     assert_eq!(s, "x");

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -1,9 +1,9 @@
 use std::io::{Read, Write};
 
-use subprocess::{Command, Fd, Stdio};
+use cosca::{Command, Fd, Stdio};
 
 fn testbin() -> &'static str {
-    env!("CARGO_BIN_EXE_subprocess_testbin")
+    env!("CARGO_BIN_EXE_cosca_testbin")
 }
 
 // Basics =====
@@ -11,7 +11,7 @@ fn testbin() -> &'static str {
 #[test]
 fn spawn_and_status_exit_code() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "7"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "exit", "7"]);
     let child = cmd.spawn().expect("spawn");
     let status = child.wait().expect("wait");
     assert_eq!(status.code(), Some(7));
@@ -20,7 +20,7 @@ fn spawn_and_status_exit_code() {
 #[test]
 fn spawned_child_has_live_identity() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "exit", "0"]);
     let child = cmd.spawn().expect("spawn");
     // id() is stable across two calls.
     assert_eq!(child.id().pid(), child.id().pid());
@@ -33,7 +33,7 @@ fn try_wait_returns_none_before_exit_and_some_after() {
     // tee-both blocks on stdin — the child won't exit until stdin is closed.
     // Null stdout/stderr so tee-both doesn't panic on broken pipe.
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "tee-both"])
+        .args(["cosca_testbin", "tee-both"])
         .stdin(Stdio::pipe())
         .expect("stdin pipe")
         .stdout(Stdio::null())
@@ -62,7 +62,7 @@ fn kill_terminates_running_child() {
     let mut cmd = Command::new();
     // tee-both blocks indefinitely on stdin.
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "tee-both"])
+        .args(["cosca_testbin", "tee-both"])
         .stdin(Stdio::pipe())
         .expect("stdin pipe");
     let mut child = cmd.spawn().expect("spawn");
@@ -80,7 +80,7 @@ fn kill_terminates_running_child() {
 fn stdout_pipe_captures_output() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "emit", "5", "0"])
+        .args(["cosca_testbin", "emit", "5", "0"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe");
     let mut child = cmd.spawn().expect("spawn");
@@ -98,7 +98,7 @@ fn stdout_pipe_captures_output() {
 fn stderr_pipe_captures_output() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "emit", "0", "3"])
+        .args(["cosca_testbin", "emit", "0", "3"])
         .stderr(Stdio::pipe())
         .expect("stderr pipe");
     let mut child = cmd.spawn().expect("spawn");
@@ -118,7 +118,7 @@ fn stdin_pipe_is_writable() {
     // tee-both reads stdin and copies to stdout+stderr; we just need to confirm
     // the write end is usable. Wire stdout to null to avoid a broken-pipe panic.
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "tee-both"])
+        .args(["cosca_testbin", "tee-both"])
         .stdin(Stdio::pipe())
         .expect("stdin pipe")
         .stdout(Stdio::null())
@@ -141,10 +141,10 @@ fn merge_stderr_onto_stdout_combines_output() {
     // emit 3 bytes to stdout, 2 to stderr; merge stderr→stdout so both come
     // through the single stdout pipe.
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "emit", "3", "2"])
+        .args(["cosca_testbin", "emit", "3", "2"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe")
-        .stderr(Stdio::merge(subprocess::Fd::STDOUT))
+        .stderr(Stdio::merge(cosca::Fd::STDOUT))
         .expect("stderr merge");
     let mut child = cmd.spawn().expect("spawn");
     let mut reader = child.stdout().expect("stdout reader");
@@ -165,7 +165,7 @@ fn merge_stderr_onto_stdout_combines_output() {
 fn null_stdout_discards_output() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "emit", "100", "0"])
+        .args(["cosca_testbin", "emit", "100", "0"])
         .stdout(Stdio::null())
         .expect("null stdout");
     let child = cmd.spawn().expect("spawn");
@@ -180,12 +180,12 @@ fn null_stdout_discards_output() {
 fn merge_to_merge_is_rejected() {
     // stdout -> merge(stderr), stderr -> merge(stdout): chained merge.
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
-    cmd.stderr(Stdio::merge(subprocess::Fd::STDOUT)).expect("stderr merge");
-    cmd.stdout(Stdio::merge(subprocess::Fd::STDERR)).expect("stdout merge");
+    cmd.executable(testbin()).args(["cosca_testbin", "exit", "0"]);
+    cmd.stderr(Stdio::merge(cosca::Fd::STDOUT)).expect("stderr merge");
+    cmd.stdout(Stdio::merge(cosca::Fd::STDERR)).expect("stdout merge");
     let err = cmd.spawn().expect_err("should reject merge-to-merge");
     assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
+        matches!(err, cosca::error::Error::Unsupported { .. }),
         "expected Unsupported for chained merge, got {err:?}"
     );
 }
@@ -196,8 +196,8 @@ fn merge_to_merge_is_rejected() {
 fn env_variable_reaches_child() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "env", "SUBPROCESS_TEST_VAR"])
-        .env("SUBPROCESS_TEST_VAR", "hello123")
+        .args(["cosca_testbin", "env", "COSCA_TEST_VAR"])
+        .env("COSCA_TEST_VAR", "hello123")
         .stdout(Stdio::pipe())
         .expect("stdout pipe");
     let mut child = cmd.spawn().expect("spawn");
@@ -206,7 +206,7 @@ fn env_variable_reaches_child() {
     reader.read_to_string(&mut out).expect("read");
     drop(reader);
     let _ = child.wait();
-    assert_eq!(out.trim(), "SUBPROCESS_TEST_VAR=hello123");
+    assert_eq!(out.trim(), "COSCA_TEST_VAR=hello123");
 }
 
 #[test]
@@ -215,7 +215,7 @@ fn current_dir_sets_working_directory() {
     let mut cmd = Command::new();
     // Use exit 0 — simplest child that honors cwd without writing to stdout.
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "exit", "0"])
+        .args(["cosca_testbin", "exit", "0"])
         .current_dir(&tmpdir);
     let child = cmd.spawn().expect("spawn with cwd");
     let status = child.wait().expect("wait");
@@ -269,7 +269,7 @@ fn communicate_does_not_deadlock_on_large_bidirectional_io() {
     // A non-concurrent pump would deadlock here.
     let input = vec![b'x'; 512 * 1024];
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "tee-both"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "tee-both"]);
     cmd.stdin(Stdio::pipe()).unwrap();
     cmd.stdout(Stdio::pipe()).unwrap();
     cmd.stderr(Stdio::pipe()).unwrap();
@@ -283,7 +283,7 @@ fn communicate_does_not_deadlock_on_large_bidirectional_io() {
 #[test]
 fn output_captures_stdout_and_stderr_with_sizes() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "emit", "5", "3"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "emit", "5", "3"]);
     let out = cmd.output().expect("output");
     assert!(out.status.success());
     assert_eq!(out.stdout, b"ooooo");
@@ -293,8 +293,7 @@ fn output_captures_stdout_and_stderr_with_sizes() {
 #[test]
 fn read_returns_verbatim_utf8() {
     let mut cmd = Command::new();
-    cmd.executable(testbin())
-        .args(["subprocess_testbin", "echo-argv", "hello"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "echo-argv", "hello"]);
     let s = cmd.read().expect("read");
     assert_eq!(s, "hello\n"); // verbatim: trailing newline preserved
 }
@@ -306,14 +305,14 @@ fn commandline_round_trips_through_split_or_passthrough() {
     // the first token (the args-only raw_arg fix — a duplicated program token
     // would make the child print the wrong argv or error).
     let line = format!(r#""{}" echo-argv hello"#, testbin());
-    let s = subprocess::run_line(line).read().expect("read");
+    let s = cosca::run_line(line).read().expect("read");
     assert_eq!(s, "hello\n");
 }
 
 #[test]
 fn merge_stderr_into_stdout() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "emit", "4", "4"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "emit", "4", "4"]);
     cmd.stdout(Stdio::pipe()).unwrap();
     cmd.stderr(Stdio::merge(Fd::STDOUT)).unwrap();
     let mut child = cmd.spawn().expect("spawn");
@@ -328,8 +327,7 @@ fn merge_stderr_into_stdout() {
 #[test]
 fn null_stdout_discards() {
     let mut cmd = Command::new();
-    cmd.executable(testbin())
-        .args(["subprocess_testbin", "emit", "100", "0"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "emit", "100", "0"]);
     cmd.stdout(Stdio::null()).unwrap();
     let status = cmd.status().expect("status");
     assert!(status.success());
@@ -346,7 +344,7 @@ fn null_stdout_discards() {
 fn unix_fd3_pipe_round_trips() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "fd3-echo"])
+        .args(["cosca_testbin", "fd3-echo"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe")
         // pipe_in: child reads, parent holds the write end.
@@ -375,7 +373,7 @@ fn unix_fd3_pipe_round_trips() {
 fn unix_fd3_null_is_accepted() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "fd3-echo"])
+        .args(["cosca_testbin", "fd3-echo"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe")
         .fd(3, Stdio::null())
@@ -399,12 +397,12 @@ fn unix_fd3_null_is_accepted() {
 fn unix_fd3_inherit_is_rejected() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "exit", "0"])
+        .args(["cosca_testbin", "exit", "0"])
         .fd(3, Stdio::inherit())
         .expect("fd attach ok");
     let err = cmd.spawn().expect_err("inherit on fd 3 should be rejected");
     assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
+        matches!(err, cosca::error::Error::Unsupported { .. }),
         "expected Unsupported, got {err:?}"
     );
 }
@@ -425,7 +423,7 @@ fn unix_fd3_file_round_trips() {
 
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "fd3-echo"])
+        .args(["cosca_testbin", "fd3-echo"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe")
         .fd(3, Stdio::from_file(tmp.try_clone().expect("clone file")))
@@ -451,7 +449,7 @@ fn unix_fd3_file_round_trips() {
 /// containment OR writing the cgroup's "0" into the user's fd 3 (corruption).
 /// We assert the parent reads EXACTLY the child-written token (no inserted "0",
 /// no broken pipe) AND that containment was actually established. Under a real
-/// delegated cgroup (SUBPROCESS_TEST_CGROUP set) we additionally assert the
+/// delegated cgroup (COSCA_TEST_CGROUP set) we additionally assert the
 /// achieved mechanism is CgroupV2 — proof the cgroup write was not clobbered.
 /// Read to EOF; no timers.
 #[cfg(target_os = "linux")]
@@ -459,7 +457,7 @@ fn unix_fd3_file_round_trips() {
 fn linux_contain_with_fd3_does_not_clobber_cgroup_procs_fd() {
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "fd3-write", "FD3PAYLOAD"])
+        .args(["cosca_testbin", "fd3-write", "FD3PAYLOAD"])
         // pipe_out: child writes, parent holds the read end.
         .fd(3, Stdio::pipe_out())
         .expect("fd 3 pipe_out");
@@ -470,15 +468,15 @@ fn linux_contain_with_fd3_does_not_clobber_cgroup_procs_fd() {
     // downgrade CgroupV2 -> ProcessGroup; None would mean containment vanished).
     assert_ne!(
         child.containment(),
-        subprocess::Containment::None,
+        cosca::Containment::None,
         "contain() + fd(3) must still establish containment"
     );
     // When a delegated cgroup is provisioned, the write must have landed in
     // cgroup.procs (not been clobbered by command-fds' dup2): CgroupV2 achieved.
-    if std::env::var_os("SUBPROCESS_TEST_CGROUP").is_some() {
+    if std::env::var_os("COSCA_TEST_CGROUP").is_some() {
         assert_eq!(
             child.containment(),
-            subprocess::Containment::CgroupV2,
+            cosca::Containment::CgroupV2,
             "cgroup write must not be clobbered by command-fds dup2; got {:?}",
             child.containment()
         );
@@ -499,7 +497,7 @@ fn linux_contain_with_fd3_does_not_clobber_cgroup_procs_fd() {
 
 #[test]
 fn run_free_fn_builds_command_from_args() {
-    let s = subprocess::run([testbin(), "echo-argv", "world"]).read().expect("read");
+    let s = cosca::run([testbin(), "echo-argv", "world"]).read().expect("read");
     assert_eq!(s, "world\n");
 }
 
@@ -507,10 +505,10 @@ fn run_free_fn_builds_command_from_args() {
 fn read_errors_on_invalid_utf8() {
     let mut cmd = Command::new();
     // 0xff is not valid UTF-8.
-    cmd.executable(testbin()).args(["subprocess_testbin", "emit-raw", "ff"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "emit-raw", "ff"]);
     let err = cmd.read().expect_err("should fail on invalid UTF-8");
     assert!(
-        matches!(err, subprocess::error::Error::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData),
+        matches!(err, cosca::error::Error::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData),
         "expected Io(InvalidData), got {err:?}"
     );
 }
@@ -522,7 +520,7 @@ fn drop_kills_and_reaps_the_child() {
     let mut cmd = Command::new();
     // tee-both with a piped (but never-written, never-closed) stdin blocks the
     // child reading stdin -> it stays alive until we drop the Child.
-    cmd.executable(testbin()).args(["subprocess_testbin", "tee-both"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "tee-both"]);
     cmd.stdin(Stdio::pipe()).unwrap();
     let child = cmd.spawn().expect("spawn");
     let id = child.id();
@@ -534,7 +532,7 @@ fn drop_kills_and_reaps_the_child() {
 #[test]
 fn detach_leaves_the_child_running() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "tee-both"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "tee-both"]);
     cmd.stdin(Stdio::pipe()).unwrap();
     let mut child = cmd.spawn().expect("spawn");
     let id = child.id();
@@ -561,9 +559,9 @@ fn detach_leaves_the_child_running() {
 #[test]
 fn uncontained_child_reports_containment_none() {
     let mut cmd = Command::new();
-    cmd.executable(testbin()).args(["subprocess_testbin", "exit", "0"]);
+    cmd.executable(testbin()).args(["cosca_testbin", "exit", "0"]);
     let child = cmd.spawn().expect("spawn");
-    assert_eq!(child.containment(), subprocess::Containment::None);
+    assert_eq!(child.containment(), cosca::Containment::None);
     let _ = child.wait();
 }
 
@@ -571,13 +569,13 @@ fn uncontained_child_reports_containment_none() {
 /// The grandchild's connected socket is proof it is alive; reading it to EOF
 /// later is the deterministic proof it died.
 #[cfg_attr(not(any(unix, windows)), allow(dead_code))]
-fn spawn_contained_tree() -> (subprocess::Child, std::net::TcpStream) {
+fn spawn_contained_tree() -> (cosca::Child, std::net::TcpStream) {
     use std::net::TcpListener;
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind control listener");
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "spawn-grandchild", &addr]);
+        .args(["cosca_testbin", "spawn-grandchild", &addr]);
     cmd.contain();
     let child = cmd.spawn().expect("spawn");
     // Accept both connections; keep the grandchild's (tag 'G'). Accepting it is
@@ -598,7 +596,7 @@ fn spawn_contained_tree() -> (subprocess::Child, std::net::TcpStream) {
 #[test]
 fn unix_kill_tree_reaps_the_grandchild() {
     let (child, mut gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::ProcessGroup);
+    assert_eq!(child.containment(), cosca::Containment::ProcessGroup);
 
     child.kill_tree().expect("kill_tree");
     let _ = child.wait(); // reap the root
@@ -615,7 +613,7 @@ fn unix_kill_tree_reaps_the_grandchild() {
 #[test]
 fn unix_terminate_tree_reaps_the_grandchild() {
     let (child, mut gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::ProcessGroup);
+    assert_eq!(child.containment(), cosca::Containment::ProcessGroup);
 
     child.terminate_tree().expect("terminate_tree");
     let _ = child.wait(); // reap the root
@@ -642,7 +640,7 @@ fn unix_terminate_tree_reaps_the_grandchild() {
 #[test]
 fn windows_kill_tree_reaps_the_grandchild() {
     let (child, mut gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
 
     child.kill_tree().expect("kill_tree");
     let _ = child.wait(); // reap the root
@@ -669,7 +667,7 @@ fn windows_kill_tree_reaps_the_grandchild() {
 #[test]
 fn windows_terminate_tree_reaps_the_grandchild() {
     let (child, mut gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
 
     child.terminate_tree().expect("terminate_tree");
     let _ = child.wait(); // reap the root
@@ -690,7 +688,7 @@ fn windows_terminate_tree_reaps_the_grandchild() {
 #[test]
 fn windows_child_is_inside_our_job_after_spawn() {
     let (child, _gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
 
     // test_job_handle_contains_self() is cfg(all(windows,test)) — confirms the job we hold.
     let in_job = child.test_job_handle_contains_self();
@@ -711,7 +709,7 @@ fn windows_child_is_inside_our_job_after_spawn() {
 #[test]
 fn windows_detach_leaves_the_tree_running() {
     let (child, mut gc_stream) = spawn_contained_tree();
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
 
     // detach() must clear KILL_ON_JOB_CLOSE before closing the job handle.
     child.detach();
@@ -741,14 +739,14 @@ fn windows_detach_leaves_the_tree_running() {
 /// This is separate from `spawn_contained_tree` (which uses `contain()` =
 /// `Strongest`) so the two modes are tested independently.
 #[cfg(unix)]
-fn spawn_session_tree() -> (subprocess::Child, std::net::TcpStream) {
+fn spawn_session_tree() -> (cosca::Child, std::net::TcpStream) {
     use std::net::TcpListener;
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind control listener");
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "spawn-grandchild", &addr]);
-    cmd.contain_with(subprocess::ContainMode::Session);
+        .args(["cosca_testbin", "spawn-grandchild", &addr]);
+    cmd.contain_with(cosca::ContainMode::Session);
     let child = cmd.spawn().expect("spawn session-contained tree");
     let mut gc = None;
     for _ in 0..2 {
@@ -766,7 +764,7 @@ fn spawn_session_tree() -> (subprocess::Child, std::net::TcpStream) {
 #[test]
 fn unix_session_containment_reports_session() {
     let (child, mut gc_stream) = spawn_session_tree();
-    assert_eq!(child.containment(), subprocess::Containment::Session);
+    assert_eq!(child.containment(), cosca::Containment::Session);
 
     child.kill_tree().expect("kill_tree");
     let _ = child.wait();
@@ -788,12 +786,12 @@ fn unix_session_child_is_own_session_leader() {
 
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "sid-report"])
+        .args(["cosca_testbin", "sid-report"])
         .stdout(Stdio::pipe())
         .expect("stdout pipe")
-        .contain_with(subprocess::ContainMode::Session);
+        .contain_with(cosca::ContainMode::Session);
     let mut child = cmd.spawn().expect("spawn sid-report");
-    assert_eq!(child.containment(), subprocess::Containment::Session);
+    assert_eq!(child.containment(), cosca::Containment::Session);
 
     let mut reader = child.stdout().expect("stdout reader");
     let mut out = String::new();
@@ -827,14 +825,14 @@ fn unix_session_child_is_own_session_leader() {
 /// cgroup / job) are reparenting-immune, so `spawn_contained_tree` need not do
 /// this; TreeWalk specifically does.
 #[cfg(any(unix, windows))]
-fn spawn_treewalk_tree() -> (subprocess::Child, std::net::TcpStream, std::net::TcpStream) {
+fn spawn_treewalk_tree() -> (cosca::Child, std::net::TcpStream, std::net::TcpStream) {
     use std::net::TcpListener;
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind control listener");
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "spawn-grandchild", &addr]);
-    cmd.contain_with(subprocess::ContainMode::TreeWalk);
+        .args(["cosca_testbin", "spawn-grandchild", &addr]);
+    cmd.contain_with(cosca::ContainMode::TreeWalk);
     let child = cmd.spawn().expect("spawn tree-walk-contained tree");
     let mut gc = None;
     let mut root = None;
@@ -861,7 +859,7 @@ fn treewalk_kill_tree_reaps_the_grandchild() {
     // Hold `_root_stream` for the whole test: it keeps the root alive so TreeWalk
     // enumerates the grandchild as a live descendant (not a reparented orphan).
     let (child, mut gc_stream, _root_stream) = spawn_treewalk_tree();
-    assert_eq!(child.containment(), subprocess::Containment::TreeWalk);
+    assert_eq!(child.containment(), cosca::Containment::TreeWalk);
 
     child.kill_tree().expect("kill_tree");
     let _ = child.wait(); // reap the root
@@ -891,7 +889,7 @@ fn treewalk_terminate_tree_reaps_the_grandchild() {
     // Hold `_root_stream` so the root stays alive through teardown (see
     // spawn_treewalk_tree): TreeWalk must enumerate a live root's descendants.
     let (child, mut gc_stream, _root_stream) = spawn_treewalk_tree();
-    assert_eq!(child.containment(), subprocess::Containment::TreeWalk);
+    assert_eq!(child.containment(), cosca::Containment::TreeWalk);
 
     child.terminate_tree().expect("terminate_tree");
     let _ = child.wait(); // reap the root
@@ -919,10 +917,10 @@ fn treewalk_kills_process_group_escapee() {
     let addr = listener.local_addr().unwrap().to_string();
     let mut cmd = Command::new();
     cmd.executable(testbin())
-        .args(["subprocess_testbin", "spawn-grandchild-escapee", &addr]);
-    cmd.contain_with(subprocess::ContainMode::TreeWalk);
+        .args(["cosca_testbin", "spawn-grandchild-escapee", &addr]);
+    cmd.contain_with(cosca::ContainMode::TreeWalk);
     let child = cmd.spawn().expect("spawn tree-walk escapee tree");
-    assert_eq!(child.containment(), subprocess::Containment::TreeWalk);
+    assert_eq!(child.containment(), cosca::Containment::TreeWalk);
 
     let mut gc = None;
     let mut root = None;
@@ -965,16 +963,16 @@ fn drop_kills_contained_tree() {
     // (Strongest), so the achieved mechanism is the host's strongest.
     assert_ne!(
         child.containment(),
-        subprocess::Containment::None,
+        cosca::Containment::None,
         "drop test requires real containment; got None"
     );
     #[cfg(windows)]
-    assert_eq!(child.containment(), subprocess::Containment::JobObject);
+    assert_eq!(child.containment(), cosca::Containment::JobObject);
     #[cfg(target_os = "linux")]
     assert!(
         matches!(
             child.containment(),
-            subprocess::Containment::CgroupV2 | subprocess::Containment::ProcessGroup
+            cosca::Containment::CgroupV2 | cosca::Containment::ProcessGroup
         ),
         "Linux must use CgroupV2 or ProcessGroup, got {:?}",
         child.containment()
@@ -983,7 +981,7 @@ fn drop_kills_contained_tree() {
     assert!(
         matches!(
             child.containment(),
-            subprocess::Containment::ProcessGroup | subprocess::Containment::Session
+            cosca::Containment::ProcessGroup | cosca::Containment::Session
         ),
         "macOS/BSD must use ProcessGroup or Session, got {:?}",
         child.containment()
@@ -1003,24 +1001,24 @@ fn drop_kills_contained_tree() {
 
 // cgroup v2 integration test =====
 // Runs only on Linux, and only when the CI provisions a delegated cgroup
-// (SUBPROCESS_TEST_CGROUP=1). The env guard means this is a true no-op when
+// (COSCA_TEST_CGROUP=1). The env guard means this is a true no-op when
 // unprovisioned, but FAILS loudly when the marker is set but the cgroup is
 // unavailable (the test asserts CgroupV2, so it won't silently pass).
 #[cfg(target_os = "linux")]
 #[test]
 fn linux_cgroup_v2_kill_tree_reaps_the_grandchild() {
-    if std::env::var_os("SUBPROCESS_TEST_CGROUP").is_none() {
+    if std::env::var_os("COSCA_TEST_CGROUP").is_none() {
         // Unprovisioned: skip (not CI-cgroup environment). The live cgroup test
-        // requires SUBPROCESS_TEST_CGROUP=1 and a delegated cgroup slice.
+        // requires COSCA_TEST_CGROUP=1 and a delegated cgroup slice.
         return;
     }
-    // SUBPROCESS_TEST_CGROUP is set: a usable delegated cgroup must exist.
+    // COSCA_TEST_CGROUP is set: a usable delegated cgroup must exist.
     // If try_create_leaf() returns None, containment falls back to ProcessGroup
     // and the assert below will fail loudly — that's intentional.
     let (child, mut gc_stream) = spawn_contained_tree();
     assert_eq!(
         child.containment(),
-        subprocess::Containment::CgroupV2,
+        cosca::Containment::CgroupV2,
         "expected CgroupV2 containment but got {:?}; \
          is a delegated cgroup v2 slice available?",
         child.containment()
@@ -1038,19 +1036,19 @@ fn linux_cgroup_v2_kill_tree_reaps_the_grandchild() {
 /// `terminate_tree` under cgroup v2 containment. Mirrors the kill_tree cgroup
 /// test but exercises the SIGTERM path (`CgroupLeaf::terminate` SIGTERMs every
 /// pid in cgroup.procs). The control-block grandchild has no SIGTERM handler so
-/// the default action kills it. Gated on SUBPROCESS_TEST_CGROUP — a true no-op
+/// the default action kills it. Gated on COSCA_TEST_CGROUP — a true no-op
 /// when unprovisioned, but FAILS loudly (CgroupV2 assertion) when the marker is
 /// set without a usable delegated cgroup. Proof of death: grandchild socket EOF.
 #[cfg(target_os = "linux")]
 #[test]
 fn linux_cgroup_v2_terminate_tree_reaps_the_grandchild() {
-    if std::env::var_os("SUBPROCESS_TEST_CGROUP").is_none() {
+    if std::env::var_os("COSCA_TEST_CGROUP").is_none() {
         return; // unprovisioned: not a CI-cgroup environment.
     }
     let (child, mut gc_stream) = spawn_contained_tree();
     assert_eq!(
         child.containment(),
-        subprocess::Containment::CgroupV2,
+        cosca::Containment::CgroupV2,
         "expected CgroupV2 containment but got {:?}; \
          is a delegated cgroup v2 slice available?",
         child.containment()

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -49,15 +49,9 @@ async fn async_kill_on_exited_unreaped_child_is_ok() {
 async fn async_tree_ops_unsupported_when_uncontained() {
     let (mut child, mut sock) = common::spawn_blocker_async();
     let err = child.kill_tree().expect_err("uncontained kill_tree");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     let err = child.terminate_tree().expect_err("uncontained terminate_tree");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await;
@@ -98,10 +92,10 @@ async fn async_contain_with_treewalk_tears_down_tree() {
     // (no kernel group needed). The builder mirror's value-sensitivity is the unit test's job
     // (src/tokio/command_tests.rs).
     let (mut child, mut root, mut grand) = common::spawn_tree_async("spawn-grandchild", |cmd| {
-        cmd.contain_with(subprocess::ContainMode::TreeWalk)
-            .nesting(subprocess::containment::Nesting::Opaque);
+        cmd.contain_with(cosca::ContainMode::TreeWalk)
+            .nesting(cosca::containment::Nesting::Opaque);
     });
-    assert_eq!(child.containment(), subprocess::Containment::TreeWalk);
+    assert_eq!(child.containment(), cosca::Containment::TreeWalk);
     child.kill_tree().expect("treewalk kill_tree");
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);
@@ -132,10 +126,7 @@ async fn async_terminate_unsupported_on_windows() {
     let err = child
         .terminate()
         .expect_err("lone graceful terminate has no Windows primitive");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await;
@@ -308,10 +299,7 @@ async fn async_graceful_shutdown_unsupported_on_windows() {
         .graceful_shutdown(Duration::from_secs(1))
         .await
         .expect_err("no Windows lone graceful");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await;
@@ -408,10 +396,7 @@ async fn async_graceful_tree_unsupported_when_uncontained() {
         .graceful_shutdown_tree(Duration::from_secs(1))
         .await
         .expect_err("uncontained tree graceful");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await;

--- a/tests/tokio_foreign.rs
+++ b/tests/tokio_foreign.rs
@@ -8,7 +8,7 @@ mod common;
 
 use std::io::Read;
 
-use subprocess::tokio::Process;
+use cosca::tokio::Process;
 
 fn expect_eof(who: &str, s: &mut std::net::TcpStream) {
     let mut buf = [0u8; 1];
@@ -163,21 +163,18 @@ async fn async_foreign_unix_only_ops_are_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
     let p = Process::from_pid(child.id().pid()).expect("resolves");
-    assert!(matches!(
-        p.terminate(),
-        Err(subprocess::error::Error::Unsupported { .. })
-    ));
+    assert!(matches!(p.terminate(), Err(cosca::error::Error::Unsupported { .. })));
     assert!(matches!(
         p.graceful_shutdown(Duration::from_secs(1)).await,
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     assert!(matches!(
         p.terminate_tree(),
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     assert!(matches!(
         p.graceful_shutdown_tree(Duration::from_secs(1)).await,
-        Err(subprocess::error::Error::Unsupported { .. })
+        Err(cosca::error::Error::Unsupported { .. })
     ));
     child.kill().expect("cleanup");
     let _ = child.wait();

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -6,9 +6,8 @@ mod common;
 
 #[tokio::test]
 async fn async_spawn_status_reports_exit_code() {
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "7"]);
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "exit", "7"]);
     assert_eq!(cmd.status().await.expect("status").code(), Some(7));
 }
 
@@ -20,7 +19,7 @@ async fn async_id_is_a_real_stable_identity() {
     let (mut child, mut sock) = common::spawn_blocker_async();
     let id = child.id();
     assert_eq!(
-        subprocess::Process::from_id(id).map(|p| p.id()),
+        cosca::Process::from_id(id).map(|p| p.id()),
         Some(id),
         "id() is a resolvable identity"
     );
@@ -48,9 +47,9 @@ async fn async_try_wait_is_none_before_exit_then_some_after() {
 
 #[tokio::test]
 async fn async_env_reaches_child() {
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "env", "SP_PLAN8"])
+        .args(["cosca_testbin", "env", "SP_PLAN8"])
         .env("SP_PLAN8", "async");
     let out = cmd.output().await.expect("output");
     assert_eq!(out.stdout, b"SP_PLAN8=async\n");
@@ -58,9 +57,9 @@ async fn async_env_reaches_child() {
 
 #[tokio::test]
 async fn async_output_captures_streams() {
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "5", "3"]);
+        .args(["cosca_testbin", "emit", "5", "3"]);
     let out = cmd.output().await.expect("output");
     assert_eq!(out.stdout, vec![b'o'; 5]);
     assert_eq!(out.stderr, vec![b'e'; 3]);
@@ -71,12 +70,11 @@ async fn async_output_captures_streams() {
 async fn async_communicate_is_deadlock_free() {
     // tee-both copies stdin to BOTH stdout and stderr; a non-concurrent reader would deadlock
     // once a pipe buffer fills. Concurrent try_join! must complete with all bytes on both.
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "tee-both"]);
-    cmd.stdin(subprocess::Stdio::pipe()).unwrap();
-    cmd.stdout(subprocess::Stdio::pipe()).unwrap();
-    cmd.stderr(subprocess::Stdio::pipe()).unwrap();
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "tee-both"]);
+    cmd.stdin(cosca::Stdio::pipe()).unwrap();
+    cmd.stdout(cosca::Stdio::pipe()).unwrap();
+    cmd.stderr(cosca::Stdio::pipe()).unwrap();
     let mut child = cmd.spawn().expect("spawn");
     let payload = vec![b'z'; 4 * 1024 * 1024];
     let out = child.communicate(Some(payload.clone())).await.expect("communicate");
@@ -88,11 +86,11 @@ async fn async_communicate_is_deadlock_free() {
 async fn async_communicate_tolerates_early_stdin_close() {
     // A child that exits without reading all of stdin closes the pipe early; write_all then
     // yields BrokenPipe. communicate must treat that as EOF and still return captured output.
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "2", "0"]); // never reads stdin
-    cmd.stdin(subprocess::Stdio::pipe()).unwrap();
-    cmd.stdout(subprocess::Stdio::pipe()).unwrap();
+        .args(["cosca_testbin", "emit", "2", "0"]); // never reads stdin
+    cmd.stdin(cosca::Stdio::pipe()).unwrap();
+    cmd.stdout(cosca::Stdio::pipe()).unwrap();
     let mut child = cmd.spawn().expect("spawn");
     // 4 MiB > any pipe buffer, so write_all is still in flight when `emit` exits and closes its
     // stdin read end — deterministically forcing the BrokenPipe the tolerance branch handles.
@@ -109,12 +107,11 @@ async fn async_communicate_none_with_piped_stdin_signals_eof() {
     // Piped stdin + no input: the write future takes `Some(writer)`, skips the write, and drops the
     // writer to signal EOF. `tee-both` reads stdin to EOF, so with no input it must complete rather
     // than hang waiting on a stdin that never closes.
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "tee-both"]);
-    cmd.stdin(subprocess::Stdio::pipe()).unwrap();
-    cmd.stdout(subprocess::Stdio::pipe()).unwrap();
-    cmd.stderr(subprocess::Stdio::pipe()).unwrap();
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "tee-both"]);
+    cmd.stdin(cosca::Stdio::pipe()).unwrap();
+    cmd.stdout(cosca::Stdio::pipe()).unwrap();
+    cmd.stderr(cosca::Stdio::pipe()).unwrap();
     let mut child = cmd.spawn().expect("spawn");
     let out = child
         .communicate(None)
@@ -129,20 +126,19 @@ async fn async_communicate_none_with_piped_stdin_signals_eof() {
 
 #[tokio::test]
 async fn async_read_errors_on_invalid_utf8() {
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit-raw", "61", "ff", "62"]);
+        .args(["cosca_testbin", "emit-raw", "61", "ff", "62"]);
     let err = cmd.read().await.expect_err("invalid utf-8 must error");
-    assert!(matches!(err, subprocess::error::Error::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData));
+    assert!(matches!(err, cosca::error::Error::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData));
 }
 
 #[test] // NOT #[tokio::test] — verifies the no-runtime guard returns Err (not panic / deferred failure)
 fn async_spawn_outside_runtime_errors() {
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "0"]);
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "exit", "0"]);
     let err = cmd.spawn().expect_err("spawn outside a tokio runtime must Err");
-    assert!(matches!(err, subprocess::error::Error::Io(_)), "got {err:?}");
+    assert!(matches!(err, cosca::error::Error::Io(_)), "got {err:?}");
 }
 
 // An IO-disabled runtime is tokio's business and platform-specific (we cannot preflight it, so we
@@ -157,9 +153,8 @@ fn async_spawn_on_io_disabled_runtime_panics_on_unix() {
         .expect("build an IO-disabled current-thread runtime");
     let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         rt.block_on(async {
-            let mut cmd = subprocess::tokio::Command::new();
-            cmd.executable(common::testbin())
-                .args(["subprocess_testbin", "exit", "0"]);
+            let mut cmd = cosca::tokio::Command::new();
+            cmd.executable(common::testbin()).args(["cosca_testbin", "exit", "0"]);
             let _ = cmd.spawn();
         })
     }))
@@ -184,9 +179,8 @@ fn async_spawn_on_io_disabled_runtime_succeeds_on_windows() {
         .build()
         .expect("build an IO-disabled current-thread runtime");
     let spawned = rt.block_on(async {
-        let mut cmd = subprocess::tokio::Command::new();
-        cmd.executable(common::testbin())
-            .args(["subprocess_testbin", "exit", "0"]);
+        let mut cmd = cosca::tokio::Command::new();
+        cmd.executable(common::testbin()).args(["cosca_testbin", "exit", "0"]);
         cmd.spawn().is_ok()
     });
     assert!(
@@ -199,22 +193,18 @@ fn async_spawn_on_io_disabled_runtime_succeeds_on_windows() {
 async fn async_chained_merge_is_unsupported() {
     // A merge whose target is itself a merge → Unsupported (mirrors the sync chained-merge test):
     // stderr -> stdout, and stdout -> stdin, so stdout's resolved kind is Merge.
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "exit", "0"]);
-    cmd.stdout(subprocess::Stdio::merge(subprocess::Fd::STDIN)).unwrap();
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDOUT)).unwrap();
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "exit", "0"]);
+    cmd.stdout(cosca::Stdio::merge(cosca::Fd::STDIN)).unwrap();
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDOUT)).unwrap();
     let err = cmd.spawn().expect_err("chained merges are unsupported");
-    assert!(
-        matches!(err, subprocess::error::Error::Unsupported { .. }),
-        "got {err:?}"
-    );
+    assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
 }
 
 #[tokio::test]
 async fn async_run_builds_command_from_args() {
     // `run([...])` derives the program from the first arg (mirrors the sync run free fn).
-    let s = subprocess::tokio::run([common::testbin(), "echo-argv", "world"])
+    let s = cosca::tokio::run([common::testbin(), "echo-argv", "world"])
         .read()
         .await
         .expect("read");
@@ -226,7 +216,7 @@ async fn async_run_line_round_trips() {
     // `run_line(line)` routes through `.commandline()`: POSIX splits via shlex, Windows passes the
     // line through and derives the program from the first token (mirrors the sync round-trip test).
     let line = format!(r#""{}" echo-argv hello"#, common::testbin());
-    let s = subprocess::tokio::run_line(line).read().await.expect("read");
+    let s = cosca::tokio::run_line(line).read().await.expect("read");
     assert_eq!(s, "hello\n");
 }
 
@@ -237,7 +227,7 @@ async fn async_drop_tears_down_a_contained_tree() {
     // The containment assert guards the EOFs below from passing for unrelated reasons.
     assert_ne!(
         child.containment(),
-        subprocess::Containment::None,
+        cosca::Containment::None,
         "contained spawn must engage a mechanism"
     );
     let root_id = child.id();
@@ -336,7 +326,7 @@ async fn async_drop_leaves_no_zombie() {
     let id = child.id();
     drop(child);
     assert_ne!(
-        subprocess::identity::ProcessId::of(id.pid()),
+        cosca::identity::ProcessId::of(id.pid()),
         Some(id),
         "Drop must fully reap the child (no lingering process/zombie at its identity)"
     );
@@ -351,14 +341,13 @@ async fn async_drop_leaves_no_zombie() {
 #[tokio::test]
 async fn async_unix_fd3_pipe_round_trips() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-echo"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.fd(3, subprocess::Stdio::pipe_in()).expect("fd 3 pipe_in");
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "fd3-echo"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.fd(3, cosca::Stdio::pipe_in()).expect("fd 3 pipe_in");
     let mut child = cmd.spawn().expect("spawn with fd 3");
     let mut stdout = child.stdout().expect("stdout reader");
-    let mut fd3_writer = child.fd_write_end(subprocess::Fd::from(3)).expect("fd 3 writer");
+    let mut fd3_writer = child.fd_write_end(cosca::Fd::from(3)).expect("fd 3 writer");
 
     fd3_writer.write_all(b"hello fd3").await.expect("write to fd 3");
     drop(fd3_writer); // EOF on the child's fd 3 read end
@@ -377,11 +366,10 @@ async fn async_unix_fd3_pipe_round_trips() {
 #[tokio::test]
 async fn async_unix_fd3_null_is_accepted() {
     use tokio::io::AsyncReadExt;
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-echo"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.fd(3, subprocess::Stdio::null()).expect("fd 3 null");
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "fd3-echo"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.fd(3, cosca::Stdio::null()).expect("fd 3 null");
     let mut child = cmd.spawn().expect("spawn with null fd 3");
     let mut stdout = child.stdout().expect("stdout reader");
     let mut buf = Vec::new();
@@ -402,12 +390,12 @@ async fn async_unix_fd3_null_is_accepted() {
 #[tokio::test]
 async fn async_unix_fd3_pipe_out_delivers_child_bytes() {
     use tokio::io::AsyncReadExt;
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-write", "fd3-token"]);
-    cmd.fd(3, subprocess::Stdio::pipe_out()).expect("fd 3 pipe_out");
+        .args(["cosca_testbin", "fd3-write", "fd3-token"]);
+    cmd.fd(3, cosca::Stdio::pipe_out()).expect("fd 3 pipe_out");
     let mut child = cmd.spawn().expect("spawn with fd 3 out");
-    let mut fd3_reader = child.fd_read_end(subprocess::Fd::from(3)).expect("fd 3 reader");
+    let mut fd3_reader = child.fd_read_end(cosca::Fd::from(3)).expect("fd 3 reader");
     let mut buf = Vec::new();
     fd3_reader.read_to_end(&mut buf).await.expect("read fd 3");
     let _ = child.wait().await;
@@ -422,18 +410,17 @@ async fn async_unix_fd3_pipe_out_delivers_child_bytes() {
 async fn async_fd3_wrong_direction_take_puts_the_end_back() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     // pipe_in: the read-accessor first (wrong) must not lose the write end.
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-echo"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.fd(3, subprocess::Stdio::pipe_in()).expect("fd 3 pipe_in");
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "fd3-echo"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.fd(3, cosca::Stdio::pipe_in()).expect("fd 3 pipe_in");
     let mut child = cmd.spawn().expect("spawn");
     assert!(
-        child.fd_read_end(subprocess::Fd::from(3)).is_none(),
+        child.fd_read_end(cosca::Fd::from(3)).is_none(),
         "wrong direction is None"
     );
     let mut w = child
-        .fd_write_end(subprocess::Fd::from(3))
+        .fd_write_end(cosca::Fd::from(3))
         .expect("the write end survives the wrong-direction take");
     w.write_all(b"put-back").await.expect("write");
     drop(w);
@@ -448,17 +435,17 @@ async fn async_fd3_wrong_direction_take_puts_the_end_back() {
     assert_eq!(buf, b"put-back");
 
     // pipe_out: the write-accessor first (wrong) must not lose the read end.
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-write", "still-here"]);
-    cmd.fd(3, subprocess::Stdio::pipe_out()).expect("fd 3 pipe_out");
+        .args(["cosca_testbin", "fd3-write", "still-here"]);
+    cmd.fd(3, cosca::Stdio::pipe_out()).expect("fd 3 pipe_out");
     let mut child = cmd.spawn().expect("spawn");
     assert!(
-        child.fd_write_end(subprocess::Fd::from(3)).is_none(),
+        child.fd_write_end(cosca::Fd::from(3)).is_none(),
         "wrong direction is None"
     );
     let mut r = child
-        .fd_read_end(subprocess::Fd::from(3))
+        .fd_read_end(cosca::Fd::from(3))
         .expect("the read end survives the wrong-direction take");
     let mut buf = Vec::new();
     r.read_to_end(&mut buf).await.expect("read fd 3");
@@ -471,13 +458,13 @@ async fn async_fd3_wrong_direction_take_puts_the_end_back() {
 #[tokio::test]
 async fn async_merge_stderr_onto_stdout_combines_output() {
     use tokio::io::AsyncReadExt;
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     // Same scenario as sync merge_stderr_onto_stdout_combines_output (tests/spawn_io.rs):
     // emit 3 bytes to stdout, 2 to stderr; merged, all 5 arrive on the one stdout pipe.
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "3", "2"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDOUT))
+        .args(["cosca_testbin", "emit", "3", "2"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDOUT))
         .expect("stderr merge");
     let mut child = cmd.spawn().expect("spawn merged");
     let mut reader = child.stdout().expect("merged stdout reader");
@@ -507,11 +494,11 @@ async fn async_merge_stderr_onto_stdout_combines_output() {
 #[tokio::test]
 async fn async_merge_into_unpiped_targets_still_works() {
     // Regression: merge into null stays on the existing (non-owned) path.
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "3", "2"]);
-    cmd.stdout(subprocess::Stdio::null()).expect("stdout null");
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDOUT))
+        .args(["cosca_testbin", "emit", "3", "2"]);
+    cmd.stdout(cosca::Stdio::null()).expect("stdout null");
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDOUT))
         .expect("stderr merge");
     let mut child = cmd.spawn().expect("spawn");
     let status = child.wait().await.expect("reap");
@@ -520,11 +507,11 @@ async fn async_merge_into_unpiped_targets_still_works() {
 
 #[tokio::test]
 async fn async_communicate_reads_a_merged_stream() {
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "3", "2"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDOUT))
+        .args(["cosca_testbin", "emit", "3", "2"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDOUT))
         .expect("stderr merge");
     let mut child = cmd.spawn().expect("spawn");
     let out = child.communicate(None).await.expect("communicate");
@@ -541,11 +528,11 @@ async fn async_communicate_reads_a_merged_stream() {
 async fn async_merged_stream_accessor_has_take_semantics() {
     // stdout() as a piped merge target: first take yields the reader, second is None
     // (take semantics, matching the tokio-owned branch).
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "3", "2"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDOUT))
+        .args(["cosca_testbin", "emit", "3", "2"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDOUT))
         .expect("stderr merge");
     let mut child = cmd.spawn().expect("spawn");
     let first = child.stdout();
@@ -564,12 +551,12 @@ async fn async_merged_stream_accessor_has_take_semantics() {
 async fn async_non_merged_stream_accessor_has_take_semantics() {
     // Regression: the pre-pass skips slots it does not assign, so stdin/stdout/stderr keep
     // plain take-semantics in a non-merge config.
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "5", "0"]);
-    cmd.stdin(subprocess::Stdio::pipe()).expect("stdin pipe");
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.stderr(subprocess::Stdio::null()).expect("stderr null");
+        .args(["cosca_testbin", "emit", "5", "0"]);
+    cmd.stdin(cosca::Stdio::pipe()).expect("stdin pipe");
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.stderr(cosca::Stdio::null()).expect("stderr null");
     let mut child = cmd.spawn().expect("spawn");
 
     assert!(child.stdin().is_some(), "first stdin() take");
@@ -585,10 +572,10 @@ async fn async_non_merged_stream_accessor_has_take_semantics() {
 async fn async_plain_piped_stream_accessor_has_take_semantics() {
     // The tokio-owned (non-merge) branch's take-semantics: stdout piped (no merge), so
     // tokio owns the internal pipe. Verifies parity with the merge-owned case above.
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "emit", "3", "0"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
+        .args(["cosca_testbin", "emit", "3", "0"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
     let mut child = cmd.spawn().expect("spawn");
     let first = child.stdout();
     assert!(first.is_some(), "first take yields the tokio-owned reader");
@@ -606,12 +593,12 @@ async fn async_plain_piped_stream_accessor_has_take_semantics() {
 #[tokio::test]
 async fn async_merge_into_piped_stdin_feeds_the_merged_child() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "stdin-split-echo", "3"]);
-    cmd.stdin(subprocess::Stdio::pipe()).expect("stdin pipe");
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.stderr(subprocess::Stdio::merge(subprocess::Fd::STDIN))
+        .args(["cosca_testbin", "stdin-split-echo", "3"]);
+    cmd.stdin(cosca::Stdio::pipe()).expect("stdin pipe");
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.stderr(cosca::Stdio::merge(cosca::Fd::STDIN))
         .expect("stderr merges into stdin");
     let mut child = cmd.spawn().expect("spawn merged-stdin child");
     let mut stdin = child.stdin().expect("owned stdin writer");
@@ -635,11 +622,11 @@ async fn async_merge_into_piped_stdin_feeds_the_merged_child() {
 #[tokio::test]
 async fn async_fd3_source_merges_into_piped_stdout() {
     use tokio::io::AsyncReadExt;
-    let mut cmd = subprocess::tokio::Command::new();
+    let mut cmd = cosca::tokio::Command::new();
     cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-write", "fd3-merged"]);
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.fd(3, subprocess::Stdio::merge(subprocess::Fd::STDOUT))
+        .args(["cosca_testbin", "fd3-write", "fd3-merged"]);
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.fd(3, cosca::Stdio::merge(cosca::Fd::STDOUT))
         .expect("fd 3 merges into stdout");
     let mut child = cmd.spawn().expect("spawn");
     let mut buf = Vec::new();
@@ -660,12 +647,11 @@ async fn async_fd3_source_merges_into_piped_stdout() {
 #[tokio::test]
 async fn async_fd3_source_merges_into_piped_stdin() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let mut cmd = subprocess::tokio::Command::new();
-    cmd.executable(common::testbin())
-        .args(["subprocess_testbin", "fd3-echo"]);
-    cmd.stdin(subprocess::Stdio::pipe()).expect("stdin pipe");
-    cmd.stdout(subprocess::Stdio::pipe()).expect("stdout pipe");
-    cmd.fd(3, subprocess::Stdio::merge(subprocess::Fd::STDIN))
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(common::testbin()).args(["cosca_testbin", "fd3-echo"]);
+    cmd.stdin(cosca::Stdio::pipe()).expect("stdin pipe");
+    cmd.stdout(cosca::Stdio::pipe()).expect("stdout pipe");
+    cmd.fd(3, cosca::Stdio::merge(cosca::Fd::STDIN))
         .expect("fd 3 merges into stdin");
     let mut child = cmd.spawn().expect("spawn");
     let mut stdin = child.stdin().expect("stdin writer");
@@ -690,7 +676,7 @@ async fn async_windows_contained_spawn_runs_then_job_tears_down() {
     let (child, mut root, mut grand) = common::spawn_grandchild_async(true);
     assert_eq!(
         child.containment(),
-        subprocess::Containment::JobObject,
+        cosca::Containment::JobObject,
         "Windows Strongest => JobObject"
     );
     let root_id = child.id();


### PR DESCRIPTION
`subprocess` is taken on crates.io and was never publishable. The crate is now **`cosca`**, which is unregistered.

**Package and paths.** `name`, `Cargo.lock`, the testbin (`subprocess_testbin` -> `cosca_testbin`, and the `CARGO_BIN_EXE_*` lookup that resolves it), and ~300 `subprocess::` paths across `src/` and `tests/` including doc-links, `compile_error!` messages, and panic strings.

**Branded runtime surface.** Nothing is published, so none of this needs a compatibility story:

- `SUBPROCESS_TEST_*` -> `COSCA_TEST_*`, plus `SUBPROCESS_IDENTITY_TEST_BLOCK` -> `COSCA_IDENTITY_TEST_BLOCK` (that one does not share the `SUBPROCESS_TEST_` prefix and is easy to miss).
- `__SUBPROCESS_GROUP_ROOT` -> `__COSCA_GROUP_ROOT`, the inherited nesting marker. The design commits to honoring legacy names forever *once published*; this lands before that obligation attaches.
- The cgroup leaf name, the Windows merge-target pipe name, and the `/sys/fs/cgroup/subprocess-ci` path in CI, alongside its `COSCA_TEST_CGROUP` gate.

**Deliberately not renamed:** "subprocess" as the English domain word. The crate manages subprocesses, so `Cargo.toml`'s description, the README tagline, and the `src/lib.rs` module doc keep it. The README's `#30` link still points at the old repo path, which GitHub redirects once the repository itself is renamed.

Also folds in the one-line fix to `Cargo.toml`'s description, which still said elevation was coming "later" after it shipped in #7. And `publish = false` keeps its marker but loses the "working name" justification, which no longer holds.

**On the diff size:** `cosca::` is five characters shorter than `subprocess::`, so rustfmt re-wraps lines that were previously split at max_width. Most of the churn is that reflow, not hand edits.

A rename is behavior-preserving, so the suite is the oracle: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all-features` (14 suites, 510 tests) all pass locally.

Closes #21.