### PR TITLE
docs: describe code rather than the plan that produced it

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -65,8 +65,7 @@ impl Child {
         }
     }
 
-    // Consumed by the sync spawn arms (POSIX `spawn`, Windows `spawn_elevated`); the async
-    // arm follows in a later task.
+    // Set by the elevation spawn arms.
     pub(crate) fn set_elevation(&mut self, report: Option<crate::elevation::ElevationReport>) {
         self.elevation = report;
     }
@@ -95,7 +94,8 @@ impl Child {
         self.id
     }
 
-    /// Whether the child is still running.
+    /// Whether the child is still running — re-checked via its stable identity,
+    /// so a recycled pid never reads as alive.
     pub fn is_alive(&self) -> bool {
         self.id.is_alive()
     }
@@ -220,9 +220,8 @@ impl Child {
         take_reader(&mut self.pipes, fd)
     }
 
-    /// Test-only: return whether this child is inside our Job Object (via `IsProcessInJob` against
-    /// the handle we hold, not "any job"). Exposed outside `cfg(test)` so integration tests (a
-    /// separate compilation unit) can call it.
+    /// Test-only: whether this child is inside the crate's Job Object (`IsProcessInJob`
+    /// against the held handle, not "any job"). `pub` so integration tests can call it.
     #[cfg(windows)]
     pub fn test_job_handle_contains_self(&self) -> bool {
         crate::containment::windows::job_contains_pid(&self.attached, self.proc.id())

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -1,5 +1,5 @@
-//! std-only spawn: resolve our Stdio model onto `std::process::Command`, wire
-//! the program/args via the Plan-1 quoters, and spawn through `shared_child`.
+//! std-only spawn: resolve the crate's `Stdio` model onto `std::process::Command`,
+//! wire the program/args via the `quote` module, and spawn through `shared_child`.
 
 use std::collections::BTreeMap;
 use std::process::Stdio as StdStdio;
@@ -101,10 +101,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
 pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<Child, Error> {
     let fds = std::mem::take(cmd.fds_mut());
 
-    // Windows routing. The raw `CreateProcessW` backend (Plan 12) owns the cases std cannot
+    // Windows routing. The raw `CreateProcessW` backend owns the cases std cannot
     // express: an `executable()` loaded independently of argv[0], and arbitrary descriptors
-    // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It handles both uncontained and CONTAINED
-    // children (Task 6 wired containment — Job Object / TreeWalk — into the raw path).
+    // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It handles both uncontained and
+    // CONTAINED children (Job Object / TreeWalk).
     #[cfg(windows)]
     {
         let has_high_fd = fds.keys().any(|slot| slot.raw() >= 3);
@@ -187,7 +187,7 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         }
     }
 
-    // We own the std Child so containment can job-assign + resume it (Task 5). Serialize the
+    // The std Child is owned here so containment can job-assign + resume it. Serialize the
     // spawn against the raw backend's inheritable-handle window via the shared spawn lock: std's
     // own handle-inheritance marking must not overlap a raw spawn on another thread.
     let mut child = {
@@ -243,9 +243,8 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
             )));
         }
     };
-    // Adopt AFTER the identity read (and after Task-5 resume) so SharedChild's
-    // internal try_wait can reap-or-track without losing the identity; the whole
-    // Plan-3 wait/kill/identity/pump model is preserved.
+    // Adopt AFTER the identity read (and after the containment resume) so
+    // SharedChild's internal try_wait can reap-or-track without losing the identity.
     let shared = SharedChild::new(child).map_err(Error::Io)?;
 
     Ok(Child::from_parts(
@@ -269,7 +268,7 @@ pub(crate) fn spawn_lock() -> std::sync::MutexGuard<'static, ()> {
 }
 
 pub(crate) fn build_std_command(cmd: &Command) -> Result<std::process::Command, Error> {
-    // Program + args via the Plan-1 quoting model.
+    // Program + args via the `quote` model.
     let mut std_cmd = match cmd.input() {
         CommandInput::Empty => return Err(Error::Io(std::io::Error::other("no program specified"))),
         CommandInput::Argv(argv) => {
@@ -716,10 +715,7 @@ pub(crate) mod fault {
     }
 }
 
-// Windows raw `CreateProcessW` spawn backend (Plan 12). The MSVCRT fd-table
-// encoder + device classifier (`crt_fds`) lands first; the spawn path that
-// consumes it follows in later tasks. Explicit `#[path]` per the repo's
-// `foo.rs` + `foo/` module convention (mirroring `child.rs`'s `child/spawn.rs`).
+// Windows raw `CreateProcessW` spawn backend.
 #[cfg(windows)]
 #[path = "spawn/windows_raw.rs"]
 pub(crate) mod windows_raw;

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -1,10 +1,10 @@
-//! Windows raw `CreateProcessW` spawn backend (Plan 12).
+//! Windows raw `CreateProcessW` spawn backend.
 //!
 //! [`spawn_raw`] is the sync entry point: it loads an `executable()` file
 //! independently of argv[0] (the case std cannot express on Windows), wiring the
 //! child's std handles via `STARTUPINFOEXW` + a scoped `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
 //! The process-handle + FFI primitives live in [`proc`]; program/env/NUL
-//! resolution in [`resolve`]; the MSVCRT fd-table encoder (for fd >= 3, Task 5)
+//! resolution in [`resolve`]; the MSVCRT fd-table encoder (for fd >= 3)
 //! in [`crt_fds`].
 
 #[path = "windows_raw/crt_fds.rs"]
@@ -19,7 +19,7 @@ pub(crate) mod resolve;
 mod proc;
 
 pub(crate) use proc::RawChild;
-// Additional seams the async raw backend reuses (Task 7): the cancellable handle wait + its
+// Additional seams the async raw backend reuses: the cancellable handle wait + its
 // outcome, and the exit-status reader. The sync path uses these only inside `proc`, so the
 // re-export is tokio-only. (`create_process` is reached through the shared `spawn_step`, so it
 // needs no re-export.)

--- a/src/child/spawn/windows_raw/proc.rs
+++ b/src/child/spawn/windows_raw/proc.rs
@@ -2,9 +2,9 @@
 //!
 //! [`RawChild`] owns the process `HANDLE` a raw spawn returns and answers the
 //! same wait/kill/identity questions as the std backend. [`create_process`] and
-//! [`wait_handle_or_cancel`] are the shared FFI seams the async backend reuses
-//! (Task 7): the former is the sole `CreateProcessW` call site, the latter a
-//! cancellable process wait.
+//! [`wait_handle_or_cancel`] are the shared FFI seams the async backend reuses:
+//! the former is the sole `CreateProcessW` call site, the latter a cancellable
+//! process wait.
 
 use std::io;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
@@ -172,12 +172,12 @@ impl RawChild {
 pub(crate) enum WaitOutcome {
     /// The process handle signaled — the child exited.
     Exited,
-    /// The cancel handle signaled first (async grace cancellation, Task 7).
+    /// The cancel handle signaled first (async grace cancellation).
     Cancelled,
 }
 
 /// Wait for `proc` to exit, or for `cancel` (if given) to signal first. With no cancel handle this
-/// is a plain blocking wait; the cancel arm backs the async backend's grace cancellation (Task 7).
+/// is a plain blocking wait; the cancel arm backs the async backend's grace cancellation.
 pub(crate) fn wait_handle_or_cancel(proc: HANDLE, cancel: Option<HANDLE>) -> io::Result<WaitOutcome> {
     match cancel {
         Some(cancel) => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,5 @@
-//! The `Command` builder: executable/args/commandline input model (Task 1)
-//! extended with stdio, env, cwd, and kill_on_drop (Task 3).
+//! The `Command` builder: executable/args/commandline input model plus stdio,
+//! env, cwd, and kill_on_drop.
 //!
 //! Note: `Command` does not implement `Clone` because [`ResolvedStdio`] can
 //! hold a [`std::fs::File`], which is not `Clone` by design.
@@ -252,10 +252,9 @@ impl Command {
         self
     }
 
-    // Consumed in production by the POSIX elevation rewrite (`cfg(unix)`);
-    // `elevation_request`/`fds` read the request, `set_input_argv`/`set_env_ops`/
-    // `set_contain` build the DERIVED command. Still dead on non-unix (the Windows
-    // elevation arm lands in a later elevation-plan task), so the allow is gated there.
+    // Consumed by the elevation paths: `elevation_request`/`fds` read the request;
+    // `set_input_argv`/`set_env_ops`/`set_contain` build the POSIX DERIVED command
+    // (hence the non-unix dead_code allows on the setters).
     #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn elevation_request(&self) -> &crate::elevation::ElevationRequest {
         &self.elevation
@@ -277,7 +276,7 @@ impl Command {
         self.contain = req;
     }
 
-    // ---- crate-internal accessors for the spawn engine (Task 4) -------------
+    // ---- crate-internal accessors for the spawn engine -------------
     #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn fds(&self) -> &BTreeMap<Fd, ResolvedStdio> {
         &self.fds

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -41,8 +41,7 @@ pub enum Containment {
 
 impl Containment {
     /// Whether this handle can drive tree teardown (`kill_tree`/`terminate_tree` act
-    /// rather than returning `Unsupported`). Exhaustive (no `_`) so a new variant must
-    /// declare its disposition.
+    /// rather than returning `Unsupported`).
     pub fn can_teardown(&self) -> bool {
         match self {
             Containment::CgroupV2

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -25,14 +25,11 @@
 //! `String`.
 
 // parse_v2_relative_path and cgroup_procs_contains are pure (no OS deps) —
-// compiled on all platforms so their unit tests run on the Windows dev host.
+// compiled on all platforms so their unit tests run on any host.
 
 /// Parse the `0::` (cgroup v2 unified hierarchy) line from the contents of
 /// `/proc/self/cgroup`. Returns the relative path (e.g. `/user.slice/…`) on
 /// success, or `None` when no such line is present (v1-only or empty).
-///
-/// Pure function (no I/O); intentionally compiled on all platforms so the unit
-/// tests in `cgroup_tests.rs` run on the Windows dev host.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn parse_v2_relative_path(proc_self_cgroup: &str) -> Option<&str> {
     for line in proc_self_cgroup.lines() {
@@ -49,9 +46,6 @@ pub(crate) fn parse_v2_relative_path(proc_self_cgroup: &str) -> Option<&str> {
 /// Check whether `pid` appears in the contents of a `cgroup.procs` file.
 /// The file format is one pid per line (decimal, possibly with trailing
 /// whitespace/newline); blank lines are skipped.
-///
-/// Pure function (no I/O); intentionally compiled on all platforms so the unit
-/// tests in `cgroup_tests.rs` run on the Windows dev host.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn cgroup_procs_contains(contents: &str, pid: u32) -> bool {
     for line in contents.lines() {
@@ -140,8 +134,7 @@ impl CgroupLeaf {
     /// the signal a pid may exit and be recycled, potentially signalling an
     /// unrelated process. This is the same race as the process-group `SIGTERM`
     /// path; the cgroup mechanism's advantage (atomic, pid-free kill) applies
-    /// only to `hard_kill` via `cgroup.kill`. The window is narrow and
-    /// equivalent to the pgroup fallback — documented here for honesty.
+    /// only to `hard_kill` via `cgroup.kill`.
     pub(crate) fn terminate(&self) -> io::Result<()> {
         let content = fs::read_to_string(self.leaf_path.join("cgroup.procs"))?;
         for line in content.lines() {

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -1,12 +1,10 @@
 //! Per-OS containment dispatch (two-phase: prepare before spawn, attach after).
-//! Unix process-group branch filled by Task 3; Linux cgroup v2 by Task 4;
-//! Windows Job Object by Task 5.
 
 use crate::containment::{ContainMode, ContainRequest, Containment, Nesting};
 use crate::error::Error;
 
-/// Decided before spawn (env-marker root detection); later tasks also apply
-/// pre-spawn flags / process_group / pre_exec inside `prepare`.
+/// The pre-spawn containment decision produced by `prepare` (env-marker root
+/// detection plus per-OS pre-spawn setup).
 pub(crate) struct Prepared {
     #[allow(dead_code)] // read in #[cfg(unix)] branch of attach()
     pub mode: Option<ContainMode>,
@@ -151,7 +149,7 @@ fn resolve_root_id(pid: u32) -> Result<crate::identity::ProcessId, Error> {
 
 /// Which Unix setup action to apply to a root `Command` for a given mode.
 /// Pure function: used by `prepare` and unit-tested separately to verify
-/// mutual exclusivity (S3): Session → setsid only; Strongest/default → pgroup
+/// mutual exclusivity: Session → setsid only; Strongest/default → pgroup
 /// only; TreeWalk → neither (it must catch process-group escapees).
 #[cfg(unix)]
 #[derive(Debug, PartialEq, Eq)]
@@ -167,7 +165,7 @@ pub(crate) enum UnixSetup {
     None,
 }
 
-/// Decide which Unix mechanism to apply for `mode` (root spawns only, S3).
+/// Decide which Unix mechanism to apply for `mode` (root spawns only).
 /// Keeping this as a pure function makes the mutual-exclusivity invariant
 /// directly unit-testable without inspecting `std::process::Command` internals.
 #[cfg(unix)]
@@ -230,12 +228,12 @@ pub(crate) fn prepare(std_cmd: &mut std::process::Command, req: &ContainRequest)
     let is_root = !is_nested(marker_present);
     if is_root && req.nesting == Nesting::Mark {
         // Set AFTER any user env ops (env_clear) have been applied to std_cmd by
-        // the spawn engine, so the marker survives env_clear (N1). `env` appends.
+        // the spawn engine, so the marker survives env_clear. `env` appends.
         std_cmd.env(crate::containment::NESTED_ENV, "1");
     }
 
     // Linux: session mode or (cgroup v2 + process group).
-    // Mechanism selection via `unix_setup_for` (S3 mutual exclusivity):
+    // Mechanism selection via `unix_setup_for` (setsid/pgroup mutual exclusivity):
     // Session → setsid only; Strongest/TreeWalk → process_group(0) + try cgroup.
     #[cfg(target_os = "linux")]
     {
@@ -296,7 +294,7 @@ pub(crate) fn prepare(std_cmd: &mut std::process::Command, req: &ContainRequest)
         };
     }
 
-    // Non-Linux Unix: process group or session (mutually exclusive; S3).
+    // Non-Linux Unix: process group or session (mutually exclusive).
     // Mechanism selection via `unix_setup_for`: Session → setsid only;
     // Strongest (= ProcessGroup on macOS) → process_group(0).
     #[cfg(all(unix, not(target_os = "linux")))]
@@ -356,7 +354,7 @@ pub(crate) fn attach(
                 );
                 let pgid = raw_pid as i32;
 
-                // Session mode: setsid was applied pre-spawn; no cgroup (S3).
+                // Session mode: setsid was applied pre-spawn; no cgroup.
                 // pgid == sid == pid for the session leader; killpg works.
                 if matches!(prepared.mode, Some(ContainMode::Session)) {
                     return Ok((Containment::Session, Attached::ProcessGroup(pgid)));

--- a/src/containment/enumerate.rs
+++ b/src/containment/enumerate.rs
@@ -1,9 +1,9 @@
 //! A `(pid, ppid)` snapshot of every process on the host — the raw material the
 //! tree-walk mechanism filters by identity. Per-OS backends reuse the same
 //! infrastructure as `identity`: ToolHelp on Windows, `/proc` on Linux,
-//! `proc_listallpids` on macOS. We deliberately do NOT use `sysinfo` (its
+//! `proc_listallpids` on macOS. `sysinfo` is deliberately NOT used: its
 //! 1-second start-time granularity is useless as an ordering key, and it pulls a
-//! second major `windows` version).
+//! second major `windows` version.
 
 use crate::identity::RawPid;
 

--- a/src/containment/enumerate/windows.rs
+++ b/src/containment/enumerate/windows.rs
@@ -1,7 +1,7 @@
 //! Windows `(pid, ppid)` snapshot via the ToolHelp process snapshot — the same
-//! API the Job-Object backend uses for its thread walk. We read only
-//! `th32ProcessID` / `th32ParentProcessID`; the high-res start token comes from
-//! `ProcessId::of` later.
+//! API the Job-Object backend uses for its thread walk. Only
+//! `th32ProcessID` / `th32ParentProcessID` are read; the high-res start token
+//! comes from `ProcessId::of` later.
 
 use std::mem::size_of;
 

--- a/src/containment/treewalk.rs
+++ b/src/containment/treewalk.rs
@@ -14,10 +14,10 @@
 //!
 //! A `(pid, ppid)` snapshot is racy: a candidate's `pid` may have been recycled,
 //! or its `ppid` may name a *recycled* root pid. So a chained ppid alone does not
-//! prove descent. We additionally require the candidate's high-res start token
-//! (Linux jiffies / Windows 100 ns FILETIME / macOS µs) to order correctly
-//! against the root's: a genuine descendant was created at-or-after the root
-//! acquired its pid. The keep predicate is
+//! prove descent. The candidate's high-res start token (Linux jiffies / Windows
+//! 100 ns FILETIME / macOS µs) must additionally order correctly against the
+//! root's: a genuine descendant was created at-or-after the root acquired its
+//! pid. The keep predicate is
 //!
 //! ```text
 //! token > root.token || (allow_equal && token == root.token)
@@ -37,8 +37,8 @@
 //!   `>=` is therefore safe AND catches same-jiffy immediate children that strict
 //!   `>` would silently miss under Linux's coarse 10 ms jiffy clock (this also
 //!   makes the live integration test deterministic).
-//! - **Windows** does not reparent and recycles pids freely, so we keep strict
-//!   `>`. Its 100 ns FILETIME clock makes a same-tick *genuine* child
+//! - **Windows** does not reparent and recycles pids freely, so the rule stays
+//!   strict `>`. Its 100 ns FILETIME clock makes a same-tick *genuine* child
 //!   indistinguishable from impossible, so strict `>` loses nothing there.
 
 use crate::identity::{ProcessId, RawPid};
@@ -46,7 +46,7 @@ use crate::identity::{ProcessId, RawPid};
 #[cfg(unix)]
 use nix::sys::signal::Signal;
 
-/// Per-OS token-order rule (USER DECISION). See the module docs for the full
+/// Per-OS token-order rule. See the module docs for the full
 /// rationale. Linux/macOS reparent orphans → ppid is authoritative → keep
 /// same-tick children (`>=`). Windows recycles pids and never reparents → keep
 /// strict `>`.

--- a/src/containment/unix.rs
+++ b/src/containment/unix.rs
@@ -3,14 +3,14 @@
 //! Two mechanisms are available:
 //! - **ProcessGroup** (`process_group(0)` / `setpgid`): the child becomes a
 //!   process-group leader (pgid == pid). Teardown sends `killpg`. cgroup v2
-//!   (Task 4) preempts this on Linux when available. macOS uses this for
+//!   preempts this on Linux when available. macOS uses this for
 //!   `ContainMode::Strongest`.
 //! - **Session** (`setsid`): the child becomes a session leader *and*
 //!   process-group leader in a new session, detached from any controlling
 //!   terminal. Teardown is identical (`killpg` on the session's initial pgroup,
 //!   which equals the leader's pid). Useful for daemon-like children.
 //!
-//! **Mutual exclusivity (S3):** `setsid` makes the child a session *and*
+//! **Mutual exclusivity:** `setsid` makes the child a session *and*
 //! process-group leader simultaneously. Calling `setpgid`/`process_group(0)`
 //! on a session leader fails with `EPERM`. Therefore Session mode applies
 //! `setsid` *instead of* `process_group(0)` — never both.
@@ -19,7 +19,7 @@
 //! parent's session/group; containment is then best-effort. This applies to
 //! both mechanisms and is documented as a known limitation (not a sandbox).
 //!
-//! Parent-side signals use `nix` (not hand-rolled `libc`); see Global Constraints.
+//! Parent-side signals use `nix` (not hand-rolled `libc`).
 //!
 //! # PGID-reuse caveat
 //! `kill_tree` must run *before* the leader is reaped (`wait`): once reaped, the
@@ -35,7 +35,7 @@ use nix::sys::signal::{kill, killpg, Signal};
 use nix::unistd::Pid;
 
 /// Apply pre-spawn group setup to `std_cmd` (root spawns only).
-/// Must not be combined with `set_session` on the same command (S3).
+/// Must not be combined with `set_session` on the same command.
 pub(crate) fn set_process_group(std_cmd: &mut std::process::Command) {
     use std::os::unix::process::CommandExt;
     std_cmd.process_group(0); // leader: pgid == pid
@@ -48,7 +48,7 @@ pub(crate) fn set_process_group(std_cmd: &mut std::process::Command) {
 /// == sid == pid), detached from any controlling terminal. Because the child is
 /// already a process-group leader after `setsid`, calling `setpgid` or
 /// `process_group(0)` on it would return `EPERM` — do not call
-/// `set_process_group` on the same command (S3 mutual exclusivity).
+/// `set_process_group` on the same command.
 ///
 /// The `pre_exec` closure is async-signal-safe: it calls only raw `libc::setsid`
 /// (no allocation, no unwinding). Failure of `setsid` aborts the spawn.
@@ -56,7 +56,7 @@ pub(crate) fn set_session(std_cmd: &mut std::process::Command) {
     // Safety: `pre_exec` runs post-fork, pre-exec. The closure is
     // async-signal-safe: `libc::setsid` is a raw syscall with no allocation.
     // A non-zero return means `setsid` failed (EPERM: already a session leader),
-    // which we surface as an `io::Error` to abort the spawn.
+    // surfaced as an `io::Error` to abort the spawn.
     unsafe {
         use std::os::unix::process::CommandExt;
         std_cmd.pre_exec(|| {

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -2,7 +2,7 @@
 //! group, is immediately assigned to a `KILL_ON_JOB_CLOSE` job, then resumed.
 //! The kernel enforces the invariant: every descendant of the child inherits the
 //! job (Windows jobs nest, so inner jobs are not a problem), and closing the job
-//! handle terminates the whole tree. Adapted from hole `kill-group`.
+//! handle terminates the whole tree.
 //!
 //! Kill-group race invariant (why `CREATE_SUSPENDED`):
 //! the child must be inside the job before executing any instruction — otherwise
@@ -63,10 +63,8 @@ impl JobHandle {
         }
     }
 
-    /// Test-only: return the raw job handle so integration tests can call
-    /// `IsProcessInJob` against OUR job (not any inherited job). Always compiled
-    /// on Windows (not just cfg(test)) because integration tests are a separate
-    /// compilation unit that links the library.
+    /// The raw job handle, or `None` once consumed. Backs the test-only
+    /// membership probe (`job_contains_pid`).
     pub(crate) fn as_handle(&self) -> Option<HANDLE> {
         let p = self.raw.load(Ordering::Relaxed);
         if p.is_null() {
@@ -221,12 +219,11 @@ fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> 
 
 /// Resume every suspended thread of the process at `proc_handle` after job assignment.
 ///
-/// Why resume REGARDLESS of job-assign result:
-/// the kill-group race invariant requires the child to be inside the job before
-/// executing. We froze it at spawn (CREATE_SUSPENDED) to close the race window.
-/// Whether or not job assignment succeeded, we MUST resume the child — a frozen
-/// process is unacceptable. If `ResumeThread` fails we kill the child immediately
-/// and return an error.
+/// Why resume REGARDLESS of job-assign result: the kill-group race invariant
+/// requires the child to be inside the job before executing, so it was spawned
+/// frozen (CREATE_SUSPENDED). Whether or not job assignment succeeded, the child
+/// MUST be resumed — a frozen process is unacceptable. If `ResumeThread` fails
+/// the child is killed immediately and an error returned.
 ///
 /// PID-reuse safety: the caller holds the child's process handle (via the owning
 /// `Child`), keeping its PID alive for the duration of the Toolhelp snapshot walk.
@@ -299,8 +296,8 @@ fn resume_initial_threads(proc_handle: std::os::windows::io::RawHandle) -> io::R
 /// Returns `Ok(Some(JobHandle))` on full success (job assigned AND resumed).
 /// Returns `Ok(None)` when job assignment fails — the caller falls back to the
 /// universal `Containment::TreeWalk` mechanism (identity teardown).
-/// Returns `Err` when resume fails — a frozen child is unacceptable; we kill
-/// the child+job and propagate the error to fail the spawn.
+/// Returns `Err` when resume fails — a frozen child is unacceptable; the
+/// child+job are killed and the error propagates to fail the spawn.
 pub(crate) fn attach_job(proc_handle: std::os::windows::io::RawHandle) -> io::Result<Option<JobHandle>> {
     let job_result = assign_to_kill_on_close_job(proc_handle);
 
@@ -325,7 +322,7 @@ pub(crate) fn attach_job(proc_handle: std::os::windows::io::RawHandle) -> io::Re
 }
 
 /// Test-only membership probe: whether `pid` is inside the Job Object held by `attached`, via
-/// `IsProcessInJob` against OUR job handle (not "any job"). Membership is immutable once assigned,
+/// `IsProcessInJob` against that job handle (not "any job"). Membership is immutable once assigned,
 /// so it is deterministic for a handle-pinned child regardless of run state. Shared by the sync and
 /// async `Child::test_job_handle_contains_self` accessors (both compiled outside `cfg(test)` so
 /// integration crates can call them).

--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -44,7 +44,7 @@ pub fn is_elevated() -> bool {
 
 /// Which elevation program runs. `Auto` (default) detects among the CLI backends
 /// only — order `sudo` > `doas`. `run0` and `pkexec`/graphical elevation are
-/// explicit-only (`run0` spawns a PID-1-parented unit, not our descendant; a
+/// explicit-only (`run0` spawns a PID-1-parented unit, not a descendant of the caller; a
 /// library must not pop a polkit dialog unbidden).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Backend {
@@ -143,8 +143,8 @@ impl Default for ElevationRequest {
 /// The single source of the "already elevated, no wrapper needed" report. Every
 /// sync/async spawn arm that short-circuits on ambient privilege calls this, so the
 /// literal is never hand-copied.
-// The Windows `RunAsIs` arm (Task 14) consumes this; the POSIX spawn arms that
-// short-circuit on ambient privilege land in a later task, so it stays dead there.
+// Consumed by the Windows `RunAsIs` arms only (the POSIX rewrite reports
+// `AlreadyElevated` through `PosixRewrite`), hence the gated allow.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn already_elevated_report(stdio: ElevatedStdio) -> ElevationReport {
     ElevationReport {

--- a/src/elevation/posix.rs
+++ b/src/elevation/posix.rs
@@ -204,8 +204,7 @@ pub(super) fn detect() -> Host {
 // ===== Non-destructive rewrite + deferred password channel =====
 //
 // The deferred-password chain (`PendingPassword`/`password_line`/`write_*`) and the
-// `PosixRewrite` fields are consumed by the sync POSIX spawn arm
-// (`crate::child::spawn::spawn`); the async arm follows in a later task.
+// `PosixRewrite` fields are consumed by the sync and async POSIX spawn arms.
 
 /// The `Auth::Stdin` password channel: the pipe write-end plus the secret, written
 /// AFTER spawn (the child is then draining via `sudo -S`).

--- a/src/elevation/windows.rs
+++ b/src/elevation/windows.rs
@@ -263,8 +263,7 @@ fn program_and_params(cmd: &Command) -> Result<(OsString, OsString), Error> {
     Ok((program, OsString::from_wide(&joined)))
 }
 
-// The sync spawn arm (`crate::child::spawn::spawn`) routes an elevated `Command` here via
-// `spawn_elevated`; the async arm follows in a later task.
+// Both the sync (`spawn_elevated`) and async spawn arms route an elevated `Command` here.
 pub(crate) fn launch_runas(cmd: &mut Command) -> Result<RunasOutcome, Error> {
     launch_runas_with_host(cmd, &Host::detect())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Crate error taxonomy. Extended by later plans (spawn, containment, identity).
+//! Crate error taxonomy.
 
 /// Why splitting a command line failed. `pos` is a 0-based byte offset.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -51,7 +51,7 @@ pub enum ElevationErrorKind {
     Untracked,
 }
 
-/// The crate's top-level error type. Grows as later plans add fallible operations.
+/// The crate's top-level error type.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("argument parsing failed: {0}")]

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -9,7 +9,7 @@
 //! `/proc` `starttime` jiffies, macOS `sysctl KERN_PROC` (`kinfo_proc`) start
 //! µs), compared exactly. It is deliberately NOT a wall-clock time: deriving
 //! wall-clock from boot time drifts under NTP and would silently break
-//! `Eq`/`Hash`. The human-facing wall-clock lives in `created_at()` (Task 2),
+//! `Eq`/`Hash`. The human-facing wall-clock lives in `created_at()`,
 //! allowed to drift and never used for identity.
 
 pub(crate) mod stat_parse;

--- a/src/identity/stat_parse.rs
+++ b/src/identity/stat_parse.rs
@@ -1,9 +1,8 @@
-//! Pure parsers for `/proc/<pid>/stat` fields. In an always-compiled module so
-//! the tricky comm-field handling is unit-tested on every host, not only Linux.
+//! Pure parsers for `/proc/<pid>/stat` fields.
 //!
 //! The comm field (field 2) is paren-wrapped and may contain spaces and ')', so
-//! we anchor on the LAST ')': index 0 of the whitespace-split tail is field 3
-//! (state); `starttime` is field 22 (index 19).
+//! the parsers anchor on the LAST ')': index 0 of the whitespace-split tail is
+//! field 3 (state); `starttime` is field 22 (index 19).
 //
 // Compiled on every target (for host unit tests); only `linux.rs` calls these,
 // so they are dead on non-Linux builds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! `cosca`: unified cross-platform subprocess management.
 //!
-//! Under construction. The first landed layer is the pure core: the error
-//! taxonomy, argv quoting, and the command input model. Modules are added by
-//! the foundation plan task-by-task.
+//! Build a process with [`Command`] (stdio, env, tree containment, elevation),
+//! spawn it into an owned [`Child`], or attach to an already-running process by
+//! pid via [`Process`]. Sync by default; async counterparts live in the `tokio`
+//! module behind the `tokio` feature.
 
 pub mod containment;
 pub mod elevation;

--- a/src/log_capture.rs
+++ b/src/log_capture.rs
@@ -1,6 +1,5 @@
 //! Minimal capturing logger: installed once per process (`log::set_logger` is
 //! once-per-process); records every message so tests assert by unique marker.
-//! Consumed by the stranding twins on every platform and the macOS kinfo oracles.
 //!
 //! Records are append-only and never erased: each test takes a [`mark`] and scans
 //! only records emitted after it via [`contains_since`], so a stale record from an

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,6 @@
 //! A foreign process referenced by stable identity. Wraps a `ProcessId` (never a bare
-//! pid) and exposes lifecycle / identity / tree — NO stdio (we don't own its pipes).
+//! pid) and exposes lifecycle / identity / tree — NO stdio (its pipes belong to its
+//! real parent).
 //! Every operation re-verifies identity. `wait()` is a death-watch yielding no
 //! `ExitStatus` (the kernel hands exit status only to the real parent — contrast
 //! `Child::wait`).
@@ -56,8 +57,9 @@ impl Process {
         self.id.is_alive()
     }
 
-    /// Block until the process exits. Death-watch — yields no `ExitStatus` (we are not its
-    /// parent). `Err` only on a wait failure (incl. `Unsupported` on Linux < 5.3). Non-reaping.
+    /// Block until the process exits. Death-watch — yields no `ExitStatus` (only the real
+    /// parent gets one). `Err` only on a wait failure (incl. `Unsupported` on Linux < 5.3).
+    /// Non-reaping.
     pub fn wait(&self) -> Result<(), Error> {
         let exited = crate::wait::block_until_exit(self.id, None)?;
         debug_assert!(exited);
@@ -71,10 +73,10 @@ impl Process {
     }
 
     /// The parent process, by identity. Identity-guarded against pid-reuse: a genuine parent
-    /// predates this child, so a recycled `ppid` naming a process created AFTER us (token after
-    /// ours) is rejected by the same token rule as [`children`](Self::children) — sound, modulo
-    /// the per-OS same-tick residual the whole crate shares. `None` if we have no resolvable
-    /// parent or `self` itself was recycled.
+    /// predates this child, so a recycled `ppid` naming a process created AFTER it (later
+    /// token) is rejected by the same token rule as [`children`](Self::children) — sound,
+    /// modulo the per-OS same-tick residual the whole crate shares. `None` if there is no
+    /// resolvable parent or `self` itself was recycled.
     pub fn parent(&self) -> Option<Process> {
         // Anchor: a query against a recycled self pid is meaningless.
         if !self.id.exists() {
@@ -91,8 +93,8 @@ impl Process {
         }
         let parent = ProcessId::of(ppid)?;
         // Identity guard: a genuine parent predates this child, so the child's start token
-        // orders at-or-after the parent's. A recycled ppid names a process created AFTER us
-        // (token after ours) — reject it.
+        // orders at-or-after the parent's. A recycled ppid names a process created AFTER
+        // this one (later token) — reject it.
         crate::containment::treewalk::keeps_token(
             self.id.start_token_raw(),
             parent.start_token_raw(),

--- a/src/process/graceful.rs
+++ b/src/process/graceful.rs
@@ -1,7 +1,6 @@
-//! Foreign `Process` graceful shutdown — the soft-then-hard escalation trio over a process we
-//! do not own (no stdio, no reap). A submodule of `process` so it can reach the private `id`.
-//! Lone ops are identity-bound and surface real failures; tree ops are best-effort identity-
-//! walk sweeps (the `TreeWalk` contract).
+//! Foreign `Process` graceful shutdown — the soft-then-hard escalation trio over a process
+//! the crate does not own (no stdio, no reap). Lone ops are identity-bound and surface real
+//! failures; tree ops are best-effort identity-walk sweeps (the `TreeWalk` contract).
 
 use std::time::Duration;
 
@@ -51,7 +50,7 @@ impl Process {
 
     /// Best-effort graceful (`SIGTERM`) sweep of the foreign process's tree (identity-walk, root
     /// then descendants). Signal-only. Unix only: Windows has no per-process graceful signal and
-    /// a foreign process shares no addressable group with us, so this returns `Unsupported`
+    /// a foreign process shares no addressable group with the caller, so this returns `Unsupported`
     /// there (use [`kill_tree`](Process::kill_tree) for a hard sweep).
     pub fn terminate_tree(&self) -> Result<(), Error> {
         #[cfg(unix)]

--- a/src/quote/windows.rs
+++ b/src/quote/windows.rs
@@ -8,7 +8,7 @@
 //! `CommandLineToArgvW` reverses (MSVCRT / Win32 argv parsing). It does NOT
 //! handle `cmd.exe` metacharacter escaping: `.bat`/`.cmd` invocation (the
 //! actual BatBadBut / CVE-2024-24576 vector) requires a separate escaping
-//! layer and is deferred to spec §8.
+//! layer, which this module does not provide.
 
 const SPACE: u16 = b' ' as u16;
 const TAB: u16 = b'\t' as u16;
@@ -101,7 +101,7 @@ pub fn first_token_and_rest_wide(cmd: &[u16]) -> Option<(Vec<u16>, Vec<u16>)> {
 /// whitespace is skipped and empty/whitespace-only input returns `None`. The OS
 /// does not skip leading whitespace: on an empty string it substitutes the
 /// module path as argv[0]; on a whitespace-only string it returns `""` as
-/// argv[0]. In both cases our function returns `None`. The token shape
+/// argv[0]. In both cases this function returns `None`. The token shape
 /// otherwise matches: a leading `"` runs to the next `"` (or to the end if
 /// unterminated); an unquoted token runs to the next space/tab; backslashes
 /// are literal here (no escaping).

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -102,8 +102,7 @@ impl Stdio {
     pub fn merge(other: Fd) -> Stdio {
         Stdio(StdioKind::Merge(other))
     }
-    /// A pseudo-terminal. The variant exists now; wiring lands behind the `pty`
-    /// feature later, so this currently resolves to `Unsupported`.
+    /// A pseudo-terminal. Not yet wired: resolves to `Unsupported`.
     #[cfg(feature = "pty")]
     pub fn pty() -> Stdio {
         Stdio(StdioKind::Pty)

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -334,9 +334,8 @@ impl Child {
         }
     }
 
-    /// Test-only: return whether this child is inside our Job Object (via `IsProcessInJob` against
-    /// the handle we hold, not "any job"). Exposed outside `cfg(test)` so integration tests (a
-    /// separate compilation unit) can call it.
+    /// Test-only: whether this child is inside the crate's Job Object (`IsProcessInJob`
+    /// against the held handle, not "any job"). `pub` so integration tests can call it.
     #[cfg(windows)]
     pub fn test_job_handle_contains_self(&self) -> bool {
         crate::containment::windows::job_contains_pid(&self.attached, self.id.pid())

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -1,6 +1,5 @@
-//! Async `Child` graceful shutdown — the soft-then-hard escalation trio. A submodule of
-//! `child` (mirroring the sync `src/child/graceful.rs`) so it can reach `Child`'s private
-//! `require_contained` and fields.
+//! Async `Child` graceful shutdown — the soft-then-hard escalation trio, mirroring the
+//! sync `Child` counterparts.
 
 use std::process::ExitStatus;
 use std::time::Duration;

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -1,6 +1,5 @@
 //! Async `Command` builder — wraps the sync `crate::command::Command`, adding async run methods.
-//! The config methods hand-mirror the sync builder (no compiler-enforced parity): mirror any new
-//! sync builder method here too.
+//! The config methods hand-mirror the sync builder; parity is not compiler-enforced.
 
 use crate::command::Command as SyncCommand;
 use crate::error::Error;

--- a/src/tokio/process.rs
+++ b/src/tokio/process.rs
@@ -1,6 +1,6 @@
 //! Async mirror of the foreign [`Process`](crate::Process). Introspection delegates
 //! synchronously; only the death-watch and the graceful pair are async (`tokio::wait`).
-//! NO stdio (we do not own its pipes); every operation re-verifies identity; nothing here
+//! NO stdio (its pipes belong to its real parent); every operation re-verifies identity; nothing here
 //! reaps (the real parent collects the zombie).
 
 use std::time::Duration;
@@ -62,8 +62,8 @@ impl Process {
         self.inner.children(recursive).into_iter().map(Process::from).collect()
     }
 
-    /// Resolve when the process exits. Death-watch — yields no `ExitStatus` (we are not its
-    /// parent). Non-reaping and signal-free; `Err` only on a watch failure (incl.
+    /// Resolve when the process exits. Death-watch — yields no `ExitStatus` (only the real
+    /// parent gets one). Non-reaping and signal-free; `Err` only on a watch failure (incl.
     /// `Unsupported` on Linux < 5.3). Dropping the future cancels the watch on every
     /// platform (the Windows watcher is released via its cancel event).
     ///

--- a/src/tokio/process/graceful.rs
+++ b/src/tokio/process/graceful.rs
@@ -1,4 +1,4 @@
-//! Async foreign graceful shutdown — mirrors `src/process/graceful.rs` on the
+//! Async foreign graceful shutdown — mirrors the sync `Process` graceful methods on the
 //! reactor-native grace-wait. No reap anywhere (the real parent collects the zombie).
 
 use std::time::Duration;

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -109,10 +109,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
 
     let mut fds = std::mem::take(cmd.fds_mut());
 
-    // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend
-    // (Plan 12): an `executable()` loaded independently of argv[0], OR arbitrary descriptors
+    // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend:
+    // an `executable()` loaded independently of argv[0], OR arbitrary descriptors
     // (fd >= 3, wired through the MSVCRT `lpReserved2` table). The raw backend handles BOTH
-    // contained and uncontained via its own async containment (Task 8); everything else stays on
+    // contained and uncontained via its own async containment; everything else stays on
     // the std/tokio path, whose `prepare` applies containment for argv/commandline spawns.
     #[cfg(windows)]
     if cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3) {

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -1,4 +1,4 @@
-//! Async (tokio) raw `CreateProcessW` spawn backend (Plan 12 Tasks 7-8).
+//! Async (tokio) raw `CreateProcessW` spawn backend.
 //!
 //! The async mirror of [`crate::child::spawn::windows_raw`]: it loads an `executable()`
 //! independently of argv[0] (the case std/tokio cannot express on Windows), wires arbitrary

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,7 +1,6 @@
 //! Non-reaping, race-free death-watch and hard-kill for a `ProcessId`. `block_until_exit`
-//! blocks the calling thread in ONE kernel syscall until exit or timeout (no sleep-poll) —
-//! the sanctioned exception to the no-time-sync rule, since the timeout bounds a genuine
-//! external process-exit event. NEVER reaps: the target's real parent collects the zombie.
+//! blocks the calling thread in ONE kernel syscall until exit or timeout (no sleep-poll).
+//! NEVER reaps: the target's real parent collects the zombie.
 
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
Closes #37.

Strips internal planning vocabulary (`Task N`, `Plan 12`, `S3`, `N1`, `(USER DECISION)`, spec/constraint references), first-person maintainer framing, rotting status markers ("lands in a later task", "Under construction"), and test-infra rationale from doc comments across `src/`. Comments only — no code changes. Net -26 lines.

Also rewrites the `lib.rs` crate front page as a short orientation (`Command` / `Child` / `Process`), and fixes three comments that had rotted into falsehood (the async elevation arms exist now).

Kept: the qodana-cli attribution header in `src/quote/posix.rs` (Apache-2.0 §4, #22) and every genuine technical constraint (PID reuse, setsid/pgroup mutual exclusivity, the `sysinfo` rejection rationale).

Verify: `cargo fmt`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked` (default, `tokio`, `pty`) all pass.