### PR TITLE
build: publish 0.1.0 to crates.io

### DIFF
--- a/.github/scripts/assert-tag-absent.sh
+++ b/.github/scripts/assert-tag-absent.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Succeed only when `origin` provably has no tag `$1`.
+#
+# The three-way branch is the point. `git ls-remote --exit-code` returns 0 when
+# the ref exists and 2 when it does not; anything else is a transport, auth or
+# protocol failure. Collapsing those into "absent" would let an outage green-light
+# a release, and an existing tag silently captures `gh release create --target`.
+set -euo pipefail
+
+tag="${1:?tag required}"
+
+status=0
+git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1 || status=$?
+
+case "$status" in
+    0)
+        echo "::error::Tag ${tag} already exists on origin. gh release create would bind the release to it and ignore --target. Delete the tag first."
+        exit 1
+        ;;
+    2)
+        echo "no existing tag ${tag}"
+        ;;
+    *)
+        echo "::error::git ls-remote failed (exit ${status}); cannot confirm ${tag} is absent"
+        exit 1
+        ;;
+esac

--- a/.github/scripts/assert-tag-absent.sh
+++ b/.github/scripts/assert-tag-absent.sh
@@ -14,7 +14,7 @@ git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1 || st
 
 case "$status" in
     0)
-        echo "::error::Tag ${tag} already exists on origin. gh release create would bind the release to it and ignore --target. Delete the tag first."
+        echo "::error::Tag ${tag} already exists on origin. GitHub would bind the release to that tag's existing commit instead of the intended one. Delete the tag first."
         exit 1
         ;;
     2)

--- a/.github/scripts/normalize-version.sh
+++ b/.github/scripts/normalize-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Echo a bare MAJOR.MINOR.PATCH from a dispatch input, stripping one optional
+# leading `v`. Exits non-zero on anything else, including a leading zero in any
+# component: `v01.2.3` and `v1.2.3` are different git tags.
+set -euo pipefail
+
+input="${1-}"
+version="${input#v}"
+
+if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "::error::Invalid version: '${input}'" >&2
+    exit 1
+fi
+
+printf '%s\n' "$version"

--- a/.github/scripts/release-script-tests.sh
+++ b/.github/scripts/release-script-tests.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+normalize="${script_dir}/normalize-version.sh"
+assert_tag="${script_dir}/assert-tag-absent.sh"
+failures=0
+
+# Asserts BOTH stdout and exit status. Checking stdout alone would pass a
+# script that printed the right version and then exited non-zero — which the
+# workflows consume under `set -euo pipefail`, so it would halt a release.
+assert_accepts() {
+    local description="$1" expected="$2" input="$3"
+    local actual status=0
+    actual="$(bash "$normalize" "$input" 2>/dev/null)" || status=$?
+    if [[ "$status" -eq 0 && "$actual" == "$expected" ]]; then
+        echo "ok   - ${description}"
+    else
+        echo "FAIL - ${description} (expected '${expected}' status 0, got '${actual}' status ${status})"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_rejects() {
+    local description="$1" input="$2"
+    if bash "$normalize" "$input" >/dev/null 2>&1; then
+        echo "FAIL - ${description} (expected rejection, got success)"
+        failures=$((failures + 1))
+    else
+        echo "ok   - ${description}"
+    fi
+}
+
+# normalize-version.sh -----------------------------------------------------
+
+assert_accepts "passes a bare semver core"    "0.1.0"    "0.1.0"
+assert_accepts "strips a leading v"           "0.1.0"    "v0.1.0"
+assert_accepts "accepts multi-digit parts"    "10.20.30" "10.20.30"
+assert_rejects "rejects a prerelease suffix"  "1.2.3-rc1"
+assert_rejects "rejects build metadata"       "1.2.3+build"
+assert_rejects "rejects two components"       "0.1"
+assert_rejects "rejects four components"      "0.1.0.0"
+assert_rejects "rejects an empty string"      ""
+assert_rejects "rejects trailing whitespace"  "0.1.0 "
+assert_rejects "rejects a command injection"  '0.1.0; rm -rf /'
+assert_rejects "rejects a doubled v"          "vv0.1.0"
+# v01.2.3 and v1.2.3 are different git tags, so a non-canonical component
+# would silently produce a tag nobody expects.
+assert_rejects "rejects a leading zero"       "01.2.3"
+assert_rejects "rejects an inner leading zero" "1.02.3"
+
+# assert-tag-absent.sh -----------------------------------------------------
+# Drives the script against a stub `git` that exits with a chosen status, so
+# all three branches are exercised without touching a real remote.
+
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+
+make_git_stub() {
+    local exit_code="$1"
+    cat > "${stub_dir}/git" <<EOF
+#!/usr/bin/env bash
+exit ${exit_code}
+EOF
+    chmod +x "${stub_dir}/git"
+}
+
+assert_tag_result() {
+    local description="$1" git_exit="$2" want_success="$3"
+    make_git_stub "$git_exit"
+    if PATH="${stub_dir}:${PATH}" bash "$assert_tag" v0.1.0 >/dev/null 2>&1; then
+        [[ "$want_success" == "yes" ]] && echo "ok   - ${description}" && return 0
+    else
+        [[ "$want_success" == "no" ]] && echo "ok   - ${description}" && return 0
+    fi
+    echo "FAIL - ${description} (git exit ${git_exit}, wanted success=${want_success})"
+    failures=$((failures + 1))
+}
+
+assert_tag_result "tag present (git exit 0) is refused"        0   no
+assert_tag_result "tag absent (git exit 2) is accepted"        2   yes
+assert_tag_result "transient failure (git exit 1) is refused"  1   no
+assert_tag_result "auth failure (git exit 128) is refused"     128 no
+
+# --------------------------------------------------------------------------
+
+if [[ "$failures" -gt 0 ]]; then
+    echo "${failures} test(s) failed"
+    exit 1
+fi
+echo "all tests passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,10 @@ jobs:
       # locally as git hooks. prek-action runs `prek run --all-files`.
       - uses: j178/prek-action@v2
 
+      - name: Test release helper scripts
+        shell: bash
+        run: bash .github/scripts/release-script-tests.sh
+
   test:
     name: Test (${{ matrix.os }}/${{ matrix.arch }})
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,36 @@ jobs:
       - name: Run tests (tokio feature)
         run: cargo test --locked --features tokio --target ${{ matrix.target }}
 
+      - name: Assert the package excludes test-only paths
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          # Write outside the workspace. A listing file created in the package
+          # root becomes an uncommitted, non-excluded file that cargo sees as a
+          # dirty worktree — the guard would abort before ever running.
+          LIST="${RUNNER_TEMP}/pkg-list.txt"
+          cargo package --list --locked --target "$TARGET" > "$LIST"
+
+          set +e
+          grep -qE '^(testbin/|tests/|\.github/|\.claude/|prek\.toml$)' "$LIST"
+          grep_status=$?
+          set -e
+
+          case "$grep_status" in
+            0)
+              echo "::error::Excluded paths leaked into the package:"
+              grep -E '^(testbin/|tests/|\.github/|\.claude/|prek\.toml$)' "$LIST"
+              exit 1
+              ;;
+            1) echo "no excluded paths in the package" ;;
+            *)
+              echo "::error::grep errored (exit $grep_status); exclusion unverified"
+              exit 1
+              ;;
+          esac
+
       # Release lane (debug_assertions off): exercises the calm-release arm of the
       # should_panic oracles in the macOS-gated kinfo_tests.rs.
       - name: Unit tests (release — debug_assertions off)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,13 @@ jobs:
       - name: Run tests (tokio feature)
         run: cargo test --locked --features tokio --target ${{ matrix.target }}
 
+      - name: Check rustdoc
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --all-features --locked --target "$TARGET"
+
       - name: Assert the package excludes test-only paths
         shell: bash
         env:

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,241 @@
+name: Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.1.0)"
+        required: true
+        type: string
+
+concurrency:
+  # Keyed on the raw input. `normalize-version.sh` strips a leading `v`, so
+  # `0.1.0` and `v0.1.0` form separate groups resolving to one tag. Both sibling
+  # repos do this; accepted rather than deviating on one detail of a ported idiom.
+  group: draft-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # `write`, not `read`: GitHub returns draft releases only to callers with
+      # push access, so a read-scoped token reports every existing draft as absent.
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the ancestry check can resolve origin/main.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Normalize and validate version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          V="$(bash .github/scripts/normalize-version.sh "$INPUT_VERSION")"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Verify manifest version matches
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          MANIFEST="$(cargo metadata --no-deps --locked --format-version 1 | jq -r '.packages[0].version')"
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::Cargo.toml declares $MANIFEST but this dispatch asked for $VERSION"
+            exit 1
+          fi
+
+      - name: Fail if the release already exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+
+          # `gh release view` exits non-zero for a missing release AND for every
+          # transient failure. Discarding the reason would make an outage or a
+          # rate limit read as "no such release" — and since GitHub does not
+          # enforce tag_name uniqueness across drafts, the run would then create
+          # a SECOND draft for the same tag rather than being rejected.
+          set +e
+          OUTPUT="$(gh release view "$TAG" --json tagName 2>&1)"
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -eq 0 ]; then
+            echo "::error::Release $TAG already exists (draft or published). Delete it or pick a new version."
+            exit 1
+          fi
+          if ! grep -qi 'release not found' <<<"$OUTPUT"; then
+            echo "::error::Cannot confirm whether $TAG exists: $OUTPUT"
+            exit 1
+          fi
+          echo "no existing release $TAG"
+
+      # Not present in skuld or hole. A tag with no release attached is the
+      # dangerous case: `gh release create --target` is SILENTLY IGNORED when the
+      # tag exists, binding the release to the old tag's commit. `gh release
+      # delete` leaves tags behind, so an operator retrying after a bad release
+      # lands here.
+      - name: Fail if the tag already exists
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: bash .github/scripts/assert-tag-absent.sh "v${VERSION}"
+
+      # Not present in skuld or hole. workflow_dispatch accepts --ref, so without
+      # this a draft can be pinned to unmerged code and every downstream check
+      # still passes.
+      - name: Verify the release commit is on main
+        env:
+          SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+
+          set +e
+          git merge-base --is-ancestor "$SHA" origin/main
+          STATUS=$?
+          set -e
+
+          case "$STATUS" in
+            0) echo "$SHA is an ancestor of origin/main" ;;
+            1)
+              echo "::error::$SHA is not an ancestor of origin/main. Release only from merged commits."
+              exit 1
+              ;;
+            *)
+              echo "::error::git merge-base failed (exit $STATUS); cannot confirm $SHA is on main"
+              exit 1
+              ;;
+          esac
+
+  ci:
+    name: CI
+    needs: validate
+    # Re-run lint plus the 6-platform matrix against the release commit. Main's
+    # last green run does not imply THIS commit is green.
+    uses: ./.github/workflows/ci.yaml
+
+  verify:
+    name: Verify publishable (${{ matrix.os }})
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+          - os: windows
+            runner: windows-latest
+          - os: darwin
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Dry-run publish
+        # On all three hosts: the verification build only compiles for the host,
+        # while `ci` builds the repository rather than the tarball, so nothing
+        # else would catch an `exclude` that breaks a non-Linux build.
+        shell: bash
+        run: cargo publish --dry-run --locked
+
+  release:
+    name: Create draft release
+    needs: [validate, ci, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # The validate job's tag check ran before the CI matrix — tens of minutes
+      # ago. Re-check immediately before creating the draft, which narrows the
+      # window to seconds.
+      #
+      # Reading `targetCommitish` back afterwards would NOT substitute for this:
+      # a draft creates no tag, so GitHub stores the field verbatim as submitted
+      # and echoes it back unchanged whether or not a tag exists.
+      - name: Re-check that the tag is still absent
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        shell: bash
+        run: bash .github/scripts/assert-tag-absent.sh "v${VERSION}"
+
+      # `concurrency.group` is keyed on the raw input, so `0.1.0` and
+      # `v0.1.0` land in different groups and run concurrently. Both pass
+      # `validate` (no release yet) and both pass the tag re-check above (a
+      # draft creates no tag) unless we also re-check the release itself
+      # here, immediately before creating it.
+      - name: Fail if the release already exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+
+          # `gh release view` exits non-zero for a missing release AND for every
+          # transient failure. Discarding the reason would make an outage or a
+          # rate limit read as "no such release" — and since GitHub does not
+          # enforce tag_name uniqueness across drafts, the run would then create
+          # a SECOND draft for the same tag rather than being rejected.
+          set +e
+          OUTPUT="$(gh release view "$TAG" --json tagName 2>&1)"
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -eq 0 ]; then
+            echo "::error::Release $TAG already exists (draft or published). Delete it or pick a new version."
+            exit 1
+          fi
+          if ! grep -qi 'release not found' <<<"$OUTPUT"; then
+            echo "::error::Cannot confirm whether $TAG exists: $OUTPUT"
+            exit 1
+          fi
+          echo "no existing release $TAG"
+
+      - name: Create draft release pinned to commit SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          URL="$(gh release create "$TAG" \
+            --draft \
+            --generate-notes \
+            --title "$TAG" \
+            --target "$SHA")"
+          echo "Draft release created for commit $SHA:"
+          echo "  $URL"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -154,7 +154,13 @@ jobs:
           # it is "unused if the Git tag already exists" — so it would just
           # echo back the original $SHA and the guard would never fire.
           # Resolve the tag itself instead.
-          PUBLISHED="$(gh api "repos/${GH_REPO}/commits/${TAG}" --jq '.sha')"
+          if ! PUBLISHED="$(gh api "repos/${GH_REPO}/commits/${TAG}" --jq '.sha')"; then
+            echo "::error::Could not resolve tag $TAG after publishing."
+            echo "::error::The crate was uploaded to crates.io and the release was published; both are irreversible."
+            echo "::error::Verify by hand that $TAG points at $SHA. Do NOT delete the release or tag on the strength of this error alone."
+            exit 1
+          fi
+
           if [ "$PUBLISHED" != "$SHA" ]; then
             echo "::error::Release $TAG points at $PUBLISHED, not the published commit $SHA."
             echo "::error::Fix by hand: delete the release and its tag, then re-run Draft Release."

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,164 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.1.0)"
+        required: true
+        type: string
+
+concurrency:
+  # Keyed on the raw input. `normalize-version.sh` strips a leading `v`, so
+  # `0.1.0` and `v0.1.0` form separate groups resolving to one tag. Both sibling
+  # repos do this; accepted rather than deviating on one detail of a ported idiom.
+  group: publish-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Verify and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Real preflight — version validation, the CI matrix, the dry-run publish —
+    # happens in draft-release.yaml before a draft can exist. The draft's
+    # existence is the evidence it passed, and the operator dispatching this has
+    # already reviewed it, so preflight is not duplicated here.
+    environment: Deploy
+    permissions:
+      # `write`, not `read`: the List releases API only returns drafts to a
+      # caller with push access.
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize and validate version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          V="$(bash .github/scripts/normalize-version.sh "$INPUT_VERSION")"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "tag=v${V}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify draft release exists and resolve commit SHA
+        id: release
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! RELEASE_JSON=$(gh release view "$TAG" --json isDraft,targetCommitish); then
+            echo "::error::gh release view failed for $TAG. Does the draft release exist?"
+            exit 1
+          fi
+
+          IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "::error::Release $TAG is already published"
+            exit 1
+          fi
+
+          TARGET=$(echo "$RELEASE_JSON" | jq -r '.targetCommitish')
+          if ! [[ "$TARGET" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Draft release target '$TARGET' is not a 40-char commit SHA. Recreate the draft via the Draft Release workflow."
+            exit 1
+          fi
+          echo "commit_sha=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.commit_sha }}
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Re-verify manifest version matches the release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          MANIFEST="$(cargo metadata --no-deps --locked --format-version 1 | jq -r '.packages[0].version')"
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::Checked-out commit declares $MANIFEST but this dispatch asked for $VERSION"
+            exit 1
+          fi
+
+      - name: Check crates.io for an existing version
+        id: crates_check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          # crates.io rejects requests without a User-Agent with HTTP 403.
+          CRATES_UA: "cosca-release-pipeline (https://github.com/bindreams/cosca)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          CODE=$(curl -sL -A "$CRATES_UA" -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/cosca/${VERSION}")
+          case "$CODE" in
+            200)
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "Version ${VERSION} already on crates.io; skipping publish."
+              ;;
+            404) echo "already_published=false" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Unexpected HTTP $CODE from crates.io API"
+              exit 1
+              ;;
+          esac
+
+      - name: Publish to crates.io
+        if: steps.crates_check.outputs.already_published == 'false'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked
+
+      - name: Publish GitHub release
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SHA: ${{ steps.release.outputs.commit_sha }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # One last check immediately before the action that creates the tag:
+          # the draft itself creates no tag, and a re-dispatch that resumes
+          # after a failed un-draft still has no tag (isDraft was still true
+          # above), so this is safe on every reachable path. It turns the race
+          # below into an early, explicit refusal instead of a silent
+          # mis-binding caught only by the read-back.
+          bash .github/scripts/assert-tag-absent.sh "$TAG"
+
+          gh release edit "$TAG" --draft=false
+
+          # Un-drafting is what creates the tag, so this is the first moment the
+          # binding is observable. If a tag named $TAG appeared between the draft's
+          # creation and now, GitHub attaches the release to THAT commit — leaving
+          # crates.io holding $SHA while the release points elsewhere. Read back and
+          # fail loudly; a visible inconsistency is recoverable by hand, an
+          # undetected one is not.
+          #
+          # `targetCommitish` is NOT usable for this: it is the stored input
+          # field from release creation, not the tag's resolved commit. GitHub
+          # never recomputes it when a draft is published — per the REST docs
+          # it is "unused if the Git tag already exists" — so it would just
+          # echo back the original $SHA and the guard would never fire.
+          # Resolve the tag itself instead.
+          PUBLISHED="$(gh api "repos/${GH_REPO}/commits/${TAG}" --jq '.sha')"
+          if [ "$PUBLISHED" != "$SHA" ]; then
+            echo "::error::Release $TAG points at $PUBLISHED, not the published commit $SHA."
+            echo "::error::Fix by hand: delete the release and its tag, then re-run Draft Release."
+            exit 1
+          fi
+
+          echo "Release published: https://github.com/${REPO}/releases/tag/$TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Claude Code
 .claude/*.local.*
 CLAUDE.local.md
+.claude/worktrees/
 
 # Agent scratch: plans, specs, task briefs and reports.
 .tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "cosca"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "command-fds",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,19 @@
 [package]
 name = "cosca"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
-rust-version = "1.87"
+authors = ["Anna Zhukova"]
 description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation."
 license = "Apache-2.0"
-publish = false           # name settled (`cosca`); not yet published
+repository = "https://github.com/bindreams/cosca"
+readme = "README.md"
+keywords = ["subprocess", "process", "spawn", "elevation", "cross-platform"]
+categories = ["os", "development-tools", "asynchronous"]
+exclude = ["/testbin", "/tests", "/.github", "/.claude", "/prek.toml"]
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 
 [features]
 pty = []

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unified cross-platform subprocess management: spawning, stdio, process trees, st
 
 `std::process` hands you a child and little else. It cannot tell you whether the process you spawned is still the process you think it is, cannot tear down a process tree, cannot address a process it did not spawn, and cannot run one elevated. This crate covers those, with one API across Linux, macOS, and Windows, and a `tokio` mirror behind a feature flag.
 
-> **Status:** under construction. The crate is unpublished and the API is not stable. User-facing documentation is tracked in [#30](https://github.com/bindreams/subprocess/issues/30).
+The API is not stable; expect breaking changes in any 0.x release.
 
 ## License
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -97,24 +97,24 @@ impl Command {
     /// on both POSIX and Windows. On Windows the raw `CreateProcessW` backend sets
     /// the loaded image (`lpApplicationName`) independently of the command line
     /// (`lpCommandLine`), so `executable` selects the file that runs while the
-    /// child's argv[0] is the command line's first token.
+    /// child's `argv[0]` is the command line's first token.
     pub fn commandline<S: Into<OsString>>(&mut self, line: S) -> &mut Command {
         self.input = CommandInput::CommandLine(line.into());
         self
     }
 
-    /// Override the executable file that the OS loads, independently of argv[0]
-    /// (e.g. load `/bin/busybox` while argv[0] is `sh`).
+    /// Override the executable file that the OS loads, independently of `argv[0]`
+    /// (e.g. load `/bin/busybox` while `argv[0]` is `sh`).
     ///
     /// # Platform note
     ///
-    /// On POSIX, the user's argv[0] is preserved via `CommandExt::arg0`, so
+    /// On POSIX, the user's `argv[0]` is preserved via `CommandExt::arg0`, so
     /// `executable("/bin/busybox").args(["sh", "-c", "..."])` correctly loads
-    /// busybox while the child sees `"sh"` as its argv[0].
+    /// busybox while the child sees `"sh"` as its `argv[0]`.
     ///
     /// On Windows, a set `executable` spawns through the raw `CreateProcessW`
     /// backend, which sets `lpApplicationName` independently of `lpCommandLine` —
-    /// so argv[0] is preserved (it no longer degrades to the executable path), and
+    /// so `argv[0]` is preserved (it no longer degrades to the executable path), and
     /// combining `executable` with [`commandline`](Self::commandline) is supported.
     /// A bare or relative `executable` is resolved with a deliberate rule (not full
     /// `CreateProcessW` search parity): the current directory first, then each

--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -1,6 +1,6 @@
 //! Cross-platform privilege elevation. Elevation wraps the CHILD (a
 //! `sudo`/`run0`/`doas`/`pkexec` prefix on POSIX; `ShellExecuteEx("runas")` on
-//! Windows), never the calling process. See the pure planner in [`plan`].
+//! Windows), never the calling process.
 
 use std::ffi::OsString;
 use std::path::PathBuf;

--- a/src/quote/windows.rs
+++ b/src/quote/windows.rs
@@ -21,7 +21,7 @@ fn needs_quotes(arg: &[u16]) -> bool {
 
 /// Join argv into a single command-line string per the MSVCRT rules that
 /// `CommandLineToArgvW` reverses. Intended for argv[1..]; the program name
-/// (argv[0]) is passed separately as `lpApplicationName`.
+/// (`argv[0]`) is passed separately as `lpApplicationName`.
 pub fn join_wide(args: &[&[u16]]) -> Vec<u16> {
     let mut cmd: Vec<u16> = Vec::new();
     for (idx, arg) in args.iter().enumerate() {
@@ -94,14 +94,14 @@ pub fn first_token_and_rest_wide(cmd: &[u16]) -> Option<(Vec<u16>, Vec<u16>)> {
     Some((first, cmd[i..].to_vec()))
 }
 
-/// Extract the program token (argv[0]) from a command line, for deriving
+/// Extract the program token (`argv[0]`) from a command line, for deriving
 /// `lpApplicationName` from a user-supplied `commandline`.
 ///
-/// Deliberate deviation from `CommandLineToArgvW`'s argv[0] handling: leading
+/// Deliberate deviation from `CommandLineToArgvW`'s `argv[0]` handling: leading
 /// whitespace is skipped and empty/whitespace-only input returns `None`. The OS
 /// does not skip leading whitespace: on an empty string it substitutes the
-/// module path as argv[0]; on a whitespace-only string it returns `""` as
-/// argv[0]. In both cases this function returns `None`. The token shape
+/// module path as `argv[0]`; on a whitespace-only string it returns `""` as
+/// `argv[0]`. In both cases this function returns `None`. The token shape
 /// otherwise matches: a leading `"` runs to the next `"` (or to the end if
 /// unterminated); an unquoted token runs to the next space/tab; backslashes
 /// are literal here (no escaping).

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -82,7 +82,7 @@ impl Stdio {
         Stdio(StdioKind::Null)
     }
     /// A pipe whose direction is inferred from the slot (stdin=child-reads,
-    /// stdout/stderr=child-writes). Use [`pipe_in`]/[`pipe_out`] for fds >= 3.
+    /// stdout/stderr=child-writes). Use [`Stdio::pipe_in`]/[`Stdio::pipe_out`] for fds >= 3.
     pub fn pipe() -> Stdio {
         Stdio(StdioKind::Pipe(None))
     }


### PR DESCRIPTION
Makes the crate publishable and ports the two-stage release idiom from skuld and hole. Closes #36, closes #24.

`exclude` keeps `cosca_testbin` and the integration tests out of the tarball. Cargo drops an excluded target with a warning rather than erroring, so this needs no feature gate and leaves `cargo test` untouched. `/tests` has to go with `/testbin` — those tests resolve the helper through `CARGO_BIN_EXE_cosca_testbin`. A CI step asserts the exclusion holds, since a manifest array has no compiler behind it.

`rust-version` is dropped rather than shipped: CI installs stable only, so 1.87 was never verified. #35 tracks determining the real floor.

Fourteen rustdoc warnings on public surfaces are fixed — `argv[0]` was parsing as an intra-doc link, and two `stdio` links plus one into a private module never resolved. All would have rendered broken on the 0.1.0 docs page. CI now runs `cargo doc` with `-D warnings` per target in the test matrix, which covers the three docs.rs builds.

The release workflows follow skuld and hole, including hole's idempotent crates.io check that lets a re-dispatch finish a partially-completed publish. Three additions close gaps present in both: a tag-existence check (`gh release create --target` is silently ignored when the tag exists, and `gh release delete` leaves tags behind), an ancestry check (`workflow_dispatch` accepts `--ref`, so a draft could otherwise be pinned to unmerged code), and `contents: write` on the validate job (drafts are invisible to read-scoped tokens, a latent gap in skuld's equivalent job).

The `CARGO_REGISTRY_TOKEN` this uses can create a new crate and nothing else, and expires 2026-08-06. Migrating to Trusted Publishing is the next PR: until it lands, 0.1.1 cannot be published.