### PR TITLE
ci: publish via crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -32,6 +32,10 @@ jobs:
       # `write`, not `read`: the List releases API only returns drafts to a
       # caller with push access.
       contents: write
+      # Lets the runner mint the OIDC JWT that crates.io exchanges for a
+      # short-lived publish token. Both scopes must be listed: declaring any
+      # `permissions:` block sets every unlisted scope to `none`.
+      id-token: write
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
@@ -116,10 +120,19 @@ jobs:
               ;;
           esac
 
+      # Nothing to authenticate for once the version is already published.
+      #
+      # This action's post step can fail the job after publish already
+      # succeeded; see the completion-marker note on the final step for how
+      # to tell that apart from a real failure.
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+        if: steps.crates_check.outputs.already_published == 'false'
+
       - name: Publish to crates.io
         if: steps.crates_check.outputs.already_published == 'false'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --locked
 
       - name: Publish GitHub release
@@ -167,4 +180,15 @@ jobs:
             exit 1
           fi
 
-          echo "Release published: https://github.com/${REPO}/releases/tag/$TAG"
+          # Read this before reacting to a red run. Everything irreversible is
+          # done by this line, but the trusted-publishing action's post step
+          # runs AFTER it and fails the job if revoking its token errors. So a
+          # red run means one of two very different things:
+          #
+          #   * marker present in the job summary — the release is COMPLETE and
+          #     verified. The only thing that failed is token revocation, and
+          #     that token expires on its own 30 minutes after it was minted.
+          #     Take no action.
+          #   * marker absent — a real step failed. Follow the error it printed.
+          printf 'Release published: https://github.com/%s/releases/tag/%s\n' \
+            "$REPO" "$TAG" | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #41.

The token that published 0.1.0 can only create a new crate and expires 2026-08-06 — it cannot publish 0.1.1. Trusted Publishing replaces it: GitHub mints an OIDC JWT, crates.io exchanges it for a token valid 30 minutes, and the action revokes that token when the job ends. This was impossible before 0.1.0 because crates.io only allows configuring it for a crate that already exists.

`id-token: write` is added alongside `contents: write` rather than replacing it — declaring any `permissions:` block zeroes every unlisted scope, and the job still needs `contents: write` to see draft releases.

The auth step carries the same `if:` as the publish step, which the crates.io example does not, because that example always publishes. This job skips the upload when the version is already on crates.io — the resume path — and there is no reason to mint a publish token on a run that will not publish.

## The completion marker

The auth action registers a post step that calls `core.setFailed` when token revocation fails ([`src/post.ts`](https://github.com/rust-lang/crates-io-auth-action/blob/main/src/post.ts) → [`runAction`](https://github.com/rust-lang/crates-io-auth-action/blob/main/src/utils.ts)), and that post step runs after both irreversible actions. A transient 5xx from crates.io therefore turns the run red when everything real succeeded — which collides with this job's existing runbook, where red at that stage means "the release may be inconsistent, reconcile by hand," including an explicit warning not to delete anything.

The final step now writes a completion marker to `$GITHUB_STEP_SUMMARY`, so red has two unambiguous readings: marker present means the release is complete and only revocation failed (the token self-expires in 30 minutes, no action needed); marker absent means a real step failed.

## Sequencing

The crates.io side must be configured **before** this merges, or there is a window where neither credential works. Under the crate's Settings → Trusted Publishing: owner `bindreams`, repository `cosca`, workflow filename `publish-release.yaml`, environment `Deploy`. The environment must match the `environment: Deploy` this job declares, since it forms part of the OIDC claim crates.io validates.

Deleting the `CARGO_REGISTRY_TOKEN` secret is the last step, after this merges.

## Verification

There is no dry run — the auth exchange only happens during a real publish, and the `already_published` check means re-dispatching 0.1.0 skips publishing entirely. The first genuine exercise is 0.1.1; expect any failure there to be an OIDC-claim mismatch against the settings above.