### PR TITLE
feat: add macOS graphical elevation via osascript

### DIFF
--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -11,6 +11,11 @@ use zeroize::Zeroize;
 // public types below are exported. The one exception is `controlling_terminal_present`, a
 // `#[doc(hidden)]` probe the separate `testbin` binary (an external consumer) needs — re-exported
 // at this module's root so `posix` itself stays `pub(crate)`.
+// Pure and cross-tested, so it is compiled everywhere — but its only in-crate
+// caller is `posix.rs`, which is `cfg(unix)`. Off-unix every item is therefore
+// test-only, exactly like the `command.rs` accessors it calls.
+#[cfg_attr(not(unix), allow(dead_code))]
+pub(crate) mod macos;
 pub(crate) mod plan;
 #[cfg(unix)]
 #[path = "elevation/posix.rs"]
@@ -59,6 +64,21 @@ pub enum Backend {
 /// How the backend authenticates. `Interactive` (default) prompts on the
 /// controlling TTY; with no controlling terminal it is a loud
 /// [`crate::error::ElevationErrorKind::NoTty`].
+///
+/// `Gui` is the system graphical authentication dialog — the one form of elevation
+/// that works in a windowed application, which has no controlling terminal to
+/// prompt on:
+///
+/// | Platform | `Auth::Gui` | Backend |
+/// |---|---|---|
+/// | Windows | the UAC consent gate | `Backend::Auto` |
+/// | macOS | Authorization Services, via `osascript` | `Backend::Auto` |
+/// | Linux | polkit, via `pkexec` | `Backend::Pkexec` |
+///
+/// The three are not interchangeable in what they can carry. Read
+/// [`ElevatedVia::MacosOsascript`] before using `Auth::Gui` on macOS: the elevated
+/// program leaves this process's tree, so stdio, exit-status fidelity, `kill()` and
+/// `.contain()` all behave differently there.
 #[derive(Debug, Clone, Default)]
 pub enum Auth {
     #[default]
@@ -84,16 +104,77 @@ pub enum ElevatedStdio {
     /// POSIX [`Auth::Stdin`]: fd0 is the elevation password channel (EOF after
     /// the password), not the caller's stdin.
     StdinConsumed,
+    /// macOS [`Auth::Gui`]: the caller's stdio was NOT given to the elevated
+    /// program. The stdout/stderr you configure are **osascript's**, and what flows
+    /// through them is a relay, not the program's own streams:
+    ///
+    /// - the program's stdout is captured in full by `osascript` and written to
+    ///   osascript's stdout once the program exits — **buffered**, never streamed;
+    /// - that stdout round-trips through UTF-8 text and loses its final line
+    ///   ending, so byte-exact binary output does not survive;
+    /// - the program's **stderr is not relayed at all**. osascript's stderr carries
+    ///   AppleScript's own error text (which quotes the program's stderr when it
+    ///   exits non-zero), not the program's stream;
+    /// - the program's stdin comes from Authorization Services, not the caller.
+    ///   Configuring a pipe or file on fd0 is rejected, because nothing would ever
+    ///   read it;
+    /// - the relay is written only when the program exits, so killing or dropping
+    ///   the child early yields an empty or truncated capture with no signal that
+    ///   the program is still running. See [`ElevatedVia::MacosOsascript`];
+    /// - **on a non-zero exit there is no relay at all.** `do shell script` raises
+    ///   an AppleScript error instead of returning a result, so the program's
+    ///   stdout is discarded entirely and only osascript's error text reaches
+    ///   stderr. A caller that needs output on the failure path must have the
+    ///   program write it somewhere the caller reads, not rely on the relay.
+    OsascriptRelay,
 }
 
 /// How elevation was achieved. Distinct from [`Backend`]: `WindowsUac` is the
 /// dedicated Windows runas disposition (NOT `Backend::Auto`, a POSIX concept).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ElevatedVia {
     /// A POSIX backend wrapped the child (the resolved backend that ran).
     Wrapped(Backend),
     /// Windows `ShellExecuteEx("runas")` elevated the child through UAC.
     WindowsUac,
+    /// macOS `osascript … with administrator privileges` asked Authorization
+    /// Services to run the command as root.
+    ///
+    /// The elevated program is **not in this process's tree**. macOS runs it under
+    /// `com.apple.security.authtrampoline`, parented to `launchd`, so the tracked
+    /// [`crate::Child`] is the `osascript` front-end, not the program:
+    ///
+    /// - **Left alone, osascript outlives the program**: it blocks until the program
+    ///   exits, so [`crate::Child::wait`] returning means the elevated work is
+    ///   finished.
+    /// - **Killed or dropped early, it does not.** [`crate::Child::kill`] — and the
+    ///   drop-kill that [`crate::Command::kill_on_drop`] performs, which is **on by
+    ///   default** — reaches only osascript. The root program keeps running, nothing
+    ///   unprivileged can stop it, and once the front-end is gone its completion and
+    ///   its exit status are unobservable. If you need the program's outcome, do not
+    ///   kill the child and do not drop it before [`crate::Child::wait`] returns. (An
+    ///   explicit `.kill_on_drop(true)` cannot currently be told apart from the
+    ///   builder default, so this is documented rather than refused.)
+    /// - `wait` reports **osascript's** exit status. It is zero if and only if the
+    ///   elevated program exited zero; a non-zero code is osascript's, not the
+    ///   program's — and on that path the program's stdout is discarded rather than
+    ///   relayed (see [`ElevatedStdio::OsascriptRelay`]).
+    /// - A **cancelled** authentication dialog is one such non-zero exit, not a
+    ///   spawn-time [`crate::error::ElevationErrorKind::AuthDeclined`].
+    /// - Process containment cannot span the boundary, so `.contain()` is rejected
+    ///   up front.
+    /// - A `current_dir()` the caller can traverse but root cannot (NFS
+    ///   `root_squash`) fails the `cd` on the far side of the trampoline: the program
+    ///   never runs and the failure surfaces as a bare non-zero exit, because the
+    ///   explaining stderr is not relayed.
+    ///
+    /// The command text is visible to anyone able to inspect the running processes —
+    /// a real difference from `sudo` and from UAC. Do not put a secret in the argv of
+    /// an elevated macOS command.
+    ///
+    /// See [`ElevatedStdio::OsascriptRelay`] for what happens to stdio.
+    MacosOsascript,
     /// The process was already elevated, so no wrapper was needed.
     AlreadyElevated,
 }

--- a/src/elevation/macos.rs
+++ b/src/elevation/macos.rs
@@ -1,0 +1,374 @@
+//! macOS graphical elevation: the `osascript … with administrator privileges`
+//! effect path for [`Auth::Gui`](super::Auth::Gui).
+//!
+//! Everything here is PURE — no syscalls, no `cfg!` — so the whole module is
+//! compiled and unit-tested on every platform, exactly like [`super::plan`].
+//!
+//! # The two quoting layers
+//!
+//! `do shell script` hands its argument to `/bin/sh -c`, and the argument is itself
+//! an AppleScript string literal. So a command crosses two grammars:
+//!
+//! 1. argv -> `/bin/sh` word-quoting ([`crate::quote::posix::join`]);
+//! 2. that text -> AppleScript literal body ([`crate::quote::applescript::escape_literal`]).
+//!
+//! There is deliberately no third layer: the finished script is handed to
+//! `osascript` as ONE `-e` argv element through `std::process::Command`, which never
+//! involves a shell. Layer 2 is applied in exactly one place,
+//! [`wrap_do_shell_script`].
+
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+use super::{ElevatedStdio, ElevatedVia, ElevationReport};
+use crate::command::{Command, CommandInput};
+use crate::error::Error;
+use crate::stdio::{Fd, ResolvedStdio};
+
+fn unsupported(op: &str, detail: String) -> Error {
+    Error::Unsupported {
+        op: op.into(),
+        platform: "macos",
+        detail,
+    }
+}
+
+/// The raw bytes of an `OsStr`. Exact on unix. Off-unix an `OsStr` is WTF-16 and
+/// may hold unpaired surrogates with no byte form — a TYPED error, never a panic
+/// and never a lossy substitution, per the crate's rule. (Production only ever
+/// reaches this on unix, because `posix.rs` is the sole caller and is `cfg(unix)`,
+/// but that is a structural coincidence, not a guarantee, and this module is
+/// compiled and tested on Windows.)
+fn os_bytes(s: &OsStr) -> Result<&[u8], Error> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Ok(s.as_bytes())
+    }
+    #[cfg(not(unix))]
+    {
+        if let Some(valid) = s.to_str() {
+            return Ok(valid.as_bytes());
+        }
+        // A REAL offset, not a fabricated zero: `QuoteError.pos` is documented as a
+        // byte offset, and the crate's other constructors all measure one. Decode
+        // the WTF-16 and accumulate the UTF-8 length of everything that decoded
+        // cleanly, so `pos` points at the first code unit with no byte form.
+        use std::os::windows::ffi::OsStrExt;
+        let pos = char::decode_utf16(s.encode_wide())
+            .take_while(|c| c.is_ok())
+            .map(|c| c.expect("take_while kept only Ok").len_utf8())
+            .sum();
+        Err(Error::Quote(crate::error::QuoteError::new(
+            pos,
+            crate::error::QuoteErrorKind::NonUtf8,
+        )))
+    }
+}
+
+/// Does `s` name a POSIX-absolute path? A leading-`/` BYTE test, deliberately not
+/// `Path::is_absolute`: the target grammar is `/bin/sh`'s, not the build host's, and
+/// on Windows `Path::is_absolute("/usr/bin/id")` is `false` (no drive prefix) while
+/// `Path::is_absolute(r"C:\tool.exe")` is `true` — both backwards here.
+fn is_posix_absolute(s: &OsStr) -> Result<bool, Error> {
+    Ok(os_bytes(s)?.first() == Some(&b'/'))
+}
+
+/// The `/bin/sh` command text: an optional `cd`, then `exec` of the quoted argv.
+///
+/// `exec` replaces the shell so the payload is the trampoline's direct child rather
+/// than sitting under an idle `sh`. The cwd is stated rather than inherited: `do
+/// shell script` does not carry the caller's working directory across the
+/// authorization trampoline.
+///
+/// Requiring the cwd to be absolute makes osascript's directory and the script's
+/// `cd --` resolve the same PATH. It does not make them resolve the same OUTCOME:
+/// the `cd` runs as root on the far side of the trampoline, so a directory the
+/// caller can traverse but root cannot (NFS `root_squash`) fails there, `&&`
+/// short-circuits, and the payload never runs. That surfaces as a bare non-zero
+/// exit, since [`ElevatedStdio::OsascriptRelay`] never relays the payload's stderr.
+///
+/// Precondition: `program` and `cwd` are POSIX-absolute — enforced by
+/// [`reject_structural_gui_config`].
+pub(crate) fn build_shell_command(program: &OsStr, args: &[OsString], cwd: Option<&Path>) -> Result<Vec<u8>, Error> {
+    debug_assert!(
+        matches!(is_posix_absolute(program), Ok(true)),
+        "the structural gate must reject a non-absolute program before composition"
+    );
+    debug_assert!(
+        cwd.is_none_or(|d| matches!(is_posix_absolute(d.as_os_str()), Ok(true))),
+        "the structural gate must reject a non-absolute cwd before composition"
+    );
+    let mut words: Vec<&[u8]> = Vec::with_capacity(args.len() + 2);
+    words.push(b"exec".as_slice());
+    words.push(os_bytes(program)?);
+    let arg_bytes: Vec<&[u8]> = args.iter().map(|a| os_bytes(a)).collect::<Result<_, _>>()?;
+    words.extend(arg_bytes.iter().copied());
+
+    let mut out = Vec::new();
+    if let Some(dir) = cwd {
+        out.extend_from_slice(b"cd -- ");
+        out.extend_from_slice(&crate::quote::posix::quote(os_bytes(dir.as_os_str())?));
+        out.extend_from_slice(b" && ");
+    }
+    out.extend_from_slice(&crate::quote::posix::join(&words));
+    Ok(out)
+}
+
+/// Wrap a `/bin/sh` command as the complete AppleScript statement.
+///
+/// `without altering line endings` is mandatory: without it `do shell script`
+/// rewrites the payload's newlines to carriage returns before relaying them.
+///
+/// No `with timeout of …` clause is emitted. Per the AppleScript Language Guide,
+/// `with timeout` governs commands sent to *application objects*; `do shell script`
+/// under `osascript` is executed by the running script's own application, so neither
+/// the default event timeout nor an explicit clause applies to it. A clause here
+/// would be a silent no-op.
+///
+/// Non-ASCII passes through. `osascript(1)` documents no encoding for `-e`, but that
+/// is a documentation gap, not a behavior gap, and it is closed by measurement:
+/// `both_quoting_layers_survive_a_real_osascript_round_trip` drives CJK, combining
+/// marks, astral-plane codepoints and mixed scripts through the REAL osascript on
+/// macOS CI and compares byte-exact hex. Refusing the class instead would reject a
+/// CJK-named file argument on a UTF-8 filesystem.
+///
+/// `arg_max` is the detected `kern.argmax`. The check is a LOWER bound: the script is
+/// the dominant argv element of the `osascript` exec, but argv and the environment
+/// share the same budget, so a script under the cap can still overflow. `None` (the
+/// sysctl failed) disables the check rather than substituting a guess. Overflow is
+/// [`crate::error::ElevationErrorKind::CommandTooLong`], NOT `Unsupported`: the
+/// crate reserves `Unsupported` for "can never work on this platform", and this
+/// verdict is derived from a runtime sysctl reading.
+pub(crate) fn wrap_do_shell_script(shell_command: &[u8], arg_max: Option<usize>) -> Result<String, Error> {
+    let body = crate::quote::applescript::escape_literal(shell_command).map_err(Error::Quote)?;
+    let script = format!("do shell script \"{body}\" with administrator privileges without altering line endings");
+    if let Some(max) = arg_max {
+        if script.len() > max {
+            return Err(Error::Elevation {
+                kind: crate::error::ElevationErrorKind::CommandTooLong,
+                detail: format!(
+                    "the composed AppleScript is {} bytes; this system's kern.argmax is {max}. \
+                     Shorten the command, or write the arguments to a file the elevated program reads",
+                    script.len()
+                ),
+            });
+        }
+    }
+    Ok(script)
+}
+
+/// Program + args, honoring `executable()`. `exec`ing the program sets argv[0] to
+/// its own path, so an argv[0] distinct from a set `executable()` cannot survive.
+pub(crate) fn program_and_args(cmd: &Command) -> Result<(OsString, Vec<OsString>), Error> {
+    // `Empty` is matched FIRST. A fresh `Command` is `CommandInput::Empty`, not
+    // `Argv(vec![])`, so folding it into the commandline arm would answer "no
+    // program set" with a message about re-quoting a command line.
+    let argv = match cmd.input() {
+        CommandInput::Argv(argv) => argv,
+        CommandInput::Empty => {
+            return Err(unsupported(
+                "macOS graphical elevation of an empty command",
+                "set a program via .args([...]) before .elevate()".into(),
+            ))
+        }
+        CommandInput::CommandLine(_) => {
+            return Err(unsupported(
+                "macOS graphical elevation of a commandline() command",
+                "the command must be an argv (set .args([...])); a raw command line cannot be \
+                 re-quoted for /bin/sh without guessing its word boundaries"
+                    .into(),
+            ))
+        }
+    };
+    let Some(first) = argv.first() else {
+        return Err(unsupported(
+            "macOS graphical elevation of an empty command",
+            "set a program via .args([...]) before .elevate()".into(),
+        ));
+    };
+    match cmd.executable_path() {
+        Some(exe) => {
+            if first.as_os_str() != exe.as_os_str() {
+                return Err(unsupported(
+                    "macOS graphical elevation with an argv[0] distinct from executable()",
+                    "`do shell script` execs the program, which sets argv[0] to its own path; \
+                     a separate argv[0] cannot survive elevation"
+                        .into(),
+                ));
+            }
+            Ok((exe.as_os_str().to_os_string(), argv[1..].to_vec()))
+        }
+        None => Ok((first.clone(), argv[1..].to_vec())),
+    }
+}
+
+/// The honest capability matrix for macOS graphical elevation. Every rejection below
+/// is a thing Authorization Services genuinely cannot do — reported loudly rather
+/// than half-honored.
+///
+/// Returns `Error::Unsupported { platform: "macos", .. }` for a capability mismatch,
+/// and `Error::Quote(NonUtf8)` for a program or directory with no byte form
+/// (reachable only off-unix, where an `OsStr` is WTF-16). Both are typed; neither is
+/// a panic.
+pub(crate) fn reject_structural_gui_config(cmd: &Command) -> Result<(), Error> {
+    let (program, _) = program_and_args(cmd)?;
+    // root's /bin/sh resolves a bare name against ITS OWN PATH, so a relative
+    // program would let the environment choose which binary runs as root. The crate
+    // closes the same hole for its POSIX backends by carrying absolute paths.
+    if !is_posix_absolute(&program)? {
+        return Err(unsupported(
+            "macOS graphical elevation of a non-absolute program",
+            format!(
+                "{program:?} would be resolved by the elevated shell's own PATH, not the caller's, \
+                 so the binary that runs as root is not the one you selected; pass an absolute path"
+            ),
+        ));
+    }
+    // Same hole, for the directory. The caller's cwd is applied twice — to osascript,
+    // and as `cd --` inside the script — and the trampoline does not carry a cwd
+    // across, so a RELATIVE path resolves against two different bases and the two
+    // silently disagree. Absolute makes them name the same directory.
+    if let Some(dir) = cmd.cwd() {
+        if !is_posix_absolute(dir.as_os_str())? {
+            return Err(unsupported(
+                "macOS graphical elevation with a relative current_dir()",
+                format!(
+                    "{dir:?} would resolve against this process's directory for osascript but \
+                     against whatever the authorization trampoline hands the elevated shell for \
+                     the command itself; pass an absolute path"
+                ),
+            ));
+        }
+    }
+    for (&slot, resolved) in cmd.fds() {
+        if slot.raw() >= 3 {
+            return Err(unsupported(
+                "fd >= 3 on a macOS graphically-elevated child",
+                "the authorization trampoline passes no descriptors, so fd >= 3 cannot reach the \
+                 elevated program"
+                    .into(),
+            ));
+        }
+        // fd1/fd2 are osascript's own streams and carry the relay, so any resolution
+        // is honest there (see ElevatedStdio::OsascriptRelay). fd0 is not: osascript
+        // never reads it and the elevated program never sees it, so anything with
+        // content behind it silently goes nowhere. Written as an ALLOW-list so a
+        // future `ResolvedStdio` variant (or `Stdio::merge`, which resolves to
+        // `Merge` and would otherwise slip through) defaults to a loud rejection.
+        if slot == Fd::STDIN && !matches!(resolved, ResolvedStdio::Inherit | ResolvedStdio::Null) {
+            return Err(unsupported(
+                "a pipe or file on stdin for a macOS graphically-elevated child",
+                "the elevated program's stdin comes from Authorization Services; osascript never \
+                 reads fd0, so anything written there would be silently discarded. Use null() or \
+                 inherit()"
+                    .into(),
+            ));
+        }
+    }
+    if !cmd.env_ops().is_empty() {
+        return Err(unsupported(
+            "env forwarding to a macOS graphically-elevated child",
+            "the authorization trampoline builds the root environment; the only way to pass a \
+             variable would be an assignment in the command text, which is visible to anyone \
+             inspecting the running processes"
+                .into(),
+        ));
+    }
+    if cmd.contain_request().mode.is_some() {
+        return Err(unsupported(
+            ".contain() + macOS graphical elevation",
+            "the elevated program runs under the authorization trampoline, parented to launchd \
+             and outside this process's tree; containment cannot span it"
+                .into(),
+        ));
+    }
+    // kill_on_drop is deliberately NOT rejected. `Command::default()` sets it to
+    // `true` and offers no way to distinguish that default from an explicit request,
+    // so rejecting it would reject every default-constructed command and make this
+    // path unreachable. Its real reach (the osascript front-end only) is documented
+    // on `ElevatedVia::MacosOsascript` instead.
+    Ok(())
+}
+
+/// Build the DERIVED command (`osascript -e <script>`) plus the report to attach to
+/// the resulting child. The caller's `Command` keeps its `input`/`env_ops`; its fd
+/// 0-2 stdio is MOVED (`ResolvedStdio::File` is not `Clone`), matching the POSIX
+/// rewrite's contract.
+///
+/// Precondition: [`reject_structural_gui_config`] has already passed, so the program
+/// and cwd are absolute, and there are no env ops and no containment. `kill_on_drop`
+/// is NOT gated (see that function), so it is transferred like the POSIX rewrite
+/// transfers it.
+pub(crate) fn build_rewrite(
+    cmd: &mut Command,
+    osascript: &Path,
+    arg_max: Option<usize>,
+) -> Result<(Command, ElevationReport), Error> {
+    // Contracts the upstream gate owns, mirroring `build_shell_command`'s own
+    // precondition asserts. Zero-cost in release; a loud failure in debug if a
+    // second call site ever reaches here without passing the gate.
+    debug_assert!(
+        cmd.env_ops().is_empty(),
+        "reject_structural_gui_config must reject env ops before build_rewrite"
+    );
+    debug_assert!(
+        cmd.contain_request().mode.is_none(),
+        "reject_structural_gui_config must reject containment before build_rewrite"
+    );
+    debug_assert!(
+        cmd.fds().keys().all(|s| s.raw() < 3),
+        "reject_structural_gui_config must reject fd >= 3 before build_rewrite"
+    );
+    let (program, args) = program_and_args(cmd)?;
+    let shell_command = build_shell_command(&program, &args, cmd.cwd())?;
+    let script = wrap_do_shell_script(&shell_command, arg_max)?;
+
+    let mut derived = Command::new();
+    derived.set_input_argv(vec![
+        osascript.as_os_str().to_os_string(),
+        OsString::from("-e"),
+        OsString::from(script),
+    ]);
+    // The cwd is set on osascript AS WELL AS stated in the script: setting it here
+    // turns a bogus directory into a precise spawn-time `Io` error instead of an
+    // opaque non-zero exit, and the script's `cd --` makes the payload's cwd
+    // deterministic either way. The two name the same directory by construction.
+    if let Some(d) = cmd.cwd() {
+        derived.current_dir(d);
+    }
+    // kill_on_drop MUST be carried, exactly as `posix::transfer_process_attrs`
+    // carries it: the async spawn recurses with `spawn(&mut derived)` and re-reads
+    // the flag off the DERIVED command, so leaving it at `Command::default()`'s
+    // `true` would silently discard a caller's `.kill_on_drop(false)` on the tokio
+    // path while honoring it on the sync one.
+    derived.kill_on_drop(cmd.kill_on_drop_flag());
+    // …and when it is set, SAY SO — the default must not be silent (see
+    // `ElevatedVia::MacosOsascript` for why killing the front-end can't stop the
+    // payload). The program is named so a test can assert on its OWN record in the
+    // process-global capture buffer.
+    if cmd.kill_on_drop_flag() {
+        log::warn!(
+            "kill_on_drop is set on a macOS graphically-elevated child ({program:?}): killing or \
+             dropping it reaches only the osascript front-end, and the root program keeps running \
+             with its exit status unobservable. Call .kill_on_drop(false) and wait() if that matters."
+        );
+    }
+    // Containment IS rejected by the structural gate, so there is nothing else to carry.
+    for (slot, resolved) in std::mem::take(cmd.fds_mut()) {
+        derived.fds_mut().insert(slot, resolved);
+    }
+
+    let report = ElevationReport {
+        via: ElevatedVia::MacosOsascript,
+        // Nothing is forwarded (env ops are rejected outright), so the sanitizer has
+        // nothing to strip. Reporting an empty list is the truth, not a stub.
+        stripped_env: Vec::new(),
+        stdio: ElevatedStdio::OsascriptRelay,
+    };
+    Ok((derived, report))
+}
+
+#[cfg(test)]
+#[path = "macos_tests.rs"]
+mod macos_tests;

--- a/src/elevation/macos_tests.rs
+++ b/src/elevation/macos_tests.rs
@@ -1,0 +1,659 @@
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+use super::{build_rewrite, build_shell_command, reject_structural_gui_config, wrap_do_shell_script};
+use crate::command::{Command, CommandInput};
+use crate::elevation::{ElevatedStdio, ElevatedVia};
+use crate::error::{ElevationErrorKind, Error, QuoteErrorKind};
+
+fn args(v: &[&str]) -> Vec<OsString> {
+    v.iter().map(OsString::from).collect()
+}
+
+fn shell(program: &str, a: &[&str], cwd: Option<&str>) -> String {
+    let bytes = build_shell_command(OsStr::new(program), &args(a), cwd.map(Path::new)).unwrap();
+    String::from_utf8(bytes).unwrap()
+}
+
+fn gui_cmd() -> Command {
+    let mut c = Command::new();
+    c.args(["/usr/bin/id", "-u"])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    c
+}
+
+fn assert_rejected(c: &Command, needle: &str) {
+    match reject_structural_gui_config(c) {
+        Err(Error::Unsupported { platform, detail, .. }) => {
+            assert_eq!(platform, "macos");
+            assert!(detail.contains(needle), "detail {detail:?} must mention {needle:?}");
+        }
+        other => panic!("expected a macos Unsupported mentioning {needle:?}, got {other:?}"),
+    }
+}
+
+// ===== composition =====
+
+#[test]
+fn the_shell_command_execs_the_quoted_argv() {
+    // `exec` so the payload replaces /bin/sh rather than sitting under it.
+    assert_eq!(shell("/usr/bin/id", &["-u"], None), "exec /usr/bin/id -u");
+}
+
+#[test]
+fn every_argv_element_is_shell_quoted() {
+    // Hand-derived from the POSIX quoter's documented rule (single-quote wrap, `'`
+    // written as '"'"'), not from running the code.
+    assert_eq!(
+        shell("/bin/echo", &["a b", "it's", "$HOME", "`id`"], None),
+        r#"exec /bin/echo 'a b' 'it'"'"'s' '$HOME' '`id`'"#
+    );
+}
+
+#[test]
+fn a_working_directory_becomes_an_explicit_cd() {
+    // `do shell script` does not carry a cwd across the authorization trampoline,
+    // so the cwd is stated in the command rather than assumed.
+    assert_eq!(
+        shell("/usr/bin/id", &[], Some("/tmp/a dir")),
+        "cd -- '/tmp/a dir' && exec /usr/bin/id"
+    );
+}
+
+#[test]
+fn the_script_is_a_single_do_shell_script_statement() {
+    let cmd = build_shell_command(OsStr::new("/usr/bin/id"), &args(&["-u"]), None).unwrap();
+    assert_eq!(
+        wrap_do_shell_script(&cmd, None).unwrap(),
+        "do shell script \"exec /usr/bin/id -u\" \
+         with administrator privileges without altering line endings"
+    );
+}
+
+#[test]
+fn both_quoting_layers_compose() {
+    // Layer 1 wraps the argument in single quotes; layer 2 escapes the embedded
+    // double quotes. Derived by hand from the two grammars.
+    let cmd = build_shell_command(OsStr::new("/bin/echo"), &args(&[r#"he said "hi""#]), None).unwrap();
+    assert_eq!(
+        wrap_do_shell_script(&cmd, None).unwrap(),
+        "do shell script \"exec /bin/echo 'he said \\\"hi\\\"'\" \
+         with administrator privileges without altering line endings"
+    );
+}
+
+#[test]
+fn non_utf8_argv_is_rejected_before_it_can_be_mangled() {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = OsString::from_vec(vec![b'a', 0xff]);
+        let cmd = build_shell_command(OsStr::new("/bin/echo"), &[bad], None).unwrap();
+        let e = wrap_do_shell_script(&cmd, None).unwrap_err();
+        // `ref q`: a by-value binding would partially move `e`, which the message
+        // then borrows (E0382).
+        assert!(
+            matches!(e, Error::Quote(ref q) if q.kind == QuoteErrorKind::NonUtf8),
+            "{e}"
+        );
+    }
+}
+
+#[test]
+fn non_ascii_passes_through_unaltered() {
+    // A CJK-named file argument to an ASCII-named tool is an ordinary macOS
+    // command, not an exotic one. The bytes must reach the script verbatim; that
+    // they survive the REAL osascript is asserted by
+    // `both_quoting_layers_survive_a_real_osascript_round_trip`.
+    let cmd = build_shell_command(
+        OsStr::new("/bin/echo"),
+        &args(&["\u{4e2d}\u{6587}.txt", "caf\u{e9}", "\u{1f389}"]),
+        None,
+    )
+    .unwrap();
+    let script = wrap_do_shell_script(&cmd, None).unwrap();
+    assert!(script.contains("\u{4e2d}\u{6587}.txt"), "{script}");
+    assert!(script.contains("\u{1f389}"), "{script}");
+}
+
+#[cfg(windows)]
+#[test]
+fn an_os_string_with_no_byte_form_is_a_typed_error_not_a_panic() {
+    // The `not(unix)` arm of `os_bytes` exists to turn a WTF-16 OsString that has
+    // no byte form into a typed error. Windows is the only place it is live, so it
+    // is the only place it can be tested — and untested, a future edit could make
+    // it panic (which the crate's rules forbid) with nothing to catch it.
+    use std::os::windows::ffi::OsStringExt;
+    let lone_surrogate = OsString::from_wide(&[0xD800]);
+    let e = build_shell_command(OsStr::new("/bin/echo"), &[lone_surrogate], None).unwrap_err();
+    assert!(
+        matches!(e, Error::Quote(ref q) if q.kind == QuoteErrorKind::NonUtf8),
+        "{e}"
+    );
+
+    // `pos` is documented as a byte offset, so it must be MEASURED, not fabricated:
+    // "ok" is two UTF-8 bytes, so the lone surrogate after it is at offset 2.
+    let with_prefix = OsString::from_wide(&[0x006F, 0x006B, 0xD800]);
+    let e = build_shell_command(OsStr::new("/bin/echo"), &[with_prefix], None).unwrap_err();
+    match e {
+        Error::Quote(q) => {
+            assert_eq!(q.kind, QuoteErrorKind::NonUtf8);
+            assert_eq!(q.pos, 2, "the offset must point at the first unrepresentable unit");
+        }
+        other => panic!("expected a Quote error, got {other:?}"),
+    }
+
+    // A multi-byte valid prefix counts in BYTES, not code units: U+00E9 is two.
+    let multibyte = OsString::from_wide(&[0x00E9, 0xD800]);
+    let e = build_shell_command(OsStr::new("/bin/echo"), &[multibyte], None).unwrap_err();
+    match e {
+        Error::Quote(q) => assert_eq!(q.pos, 2),
+        other => panic!("expected a Quote error, got {other:?}"),
+    }
+}
+
+/// The exact script length for an argument of `n` safe characters. Derived by
+/// composing, so the boundary test probes the comparison itself.
+fn script_len_for_arg(n: usize) -> usize {
+    let cmd = build_shell_command(OsStr::new("/bin/echo"), &[OsString::from("x".repeat(n))], None).unwrap();
+    wrap_do_shell_script(&cmd, None).unwrap().len()
+}
+
+#[test]
+fn the_length_guard_accepts_exactly_arg_max_and_rejects_one_more() {
+    let n = 1000;
+    let exact = script_len_for_arg(n);
+    let cmd = build_shell_command(OsStr::new("/bin/echo"), &[OsString::from("x".repeat(n))], None).unwrap();
+    assert!(
+        wrap_do_shell_script(&cmd, Some(exact)).is_ok(),
+        "a script of exactly arg_max bytes must be accepted"
+    );
+    match wrap_do_shell_script(&cmd, Some(exact - 1)) {
+        // Elevation, NOT Unsupported: the same command succeeds on a host with a
+        // larger kern.argmax, so this can never be a permanent platform verdict.
+        Err(Error::Elevation { kind, detail }) => {
+            assert_eq!(kind, ElevationErrorKind::CommandTooLong);
+            assert!(detail.contains(&exact.to_string()), "{detail}");
+            assert!(detail.contains(&(exact - 1).to_string()), "{detail}");
+        }
+        other => panic!("expected CommandTooLong, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unknown_arg_max_disables_the_guard_rather_than_guessing() {
+    let cmd = build_shell_command(OsStr::new("/bin/echo"), &[OsString::from("x".repeat(9_000))], None).unwrap();
+    assert!(wrap_do_shell_script(&cmd, None).is_ok());
+}
+
+// ===== structural gate =====
+
+#[test]
+fn a_plain_argv_command_is_accepted() {
+    // `gui_cmd()` is default-constructed, so kill_on_drop is already `true`. This
+    // pins that the default does NOT make the whole path unreachable.
+    assert!(gui_cmd().kill_on_drop_flag(), "the builder default is assumed here");
+    assert!(reject_structural_gui_config(&gui_cmd()).is_ok());
+}
+
+#[test]
+fn a_relative_program_is_rejected_so_roots_path_never_chooses_the_binary() {
+    let mut c = Command::new();
+    c.args(["mytool", "--apply"])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    assert_rejected(&c, "absolute");
+}
+
+#[test]
+fn absoluteness_is_judged_by_posix_rules_not_the_build_hosts() {
+    // `/usr/bin/id` must be accepted and `C:\tool.exe` rejected on EVERY host —
+    // `Path::is_absolute` gets both backwards on Windows.
+    let mut ok = Command::new();
+    ok.args(["/usr/bin/id"]).elevation_auth(crate::elevation::Auth::Gui);
+    assert!(reject_structural_gui_config(&ok).is_ok());
+
+    let mut windows_style = Command::new();
+    windows_style
+        .args([r"C:\tool.exe"])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    assert_rejected(&windows_style, "absolute");
+}
+
+#[test]
+fn a_relative_working_directory_is_rejected() {
+    // It would resolve against two different bases: this process's directory for
+    // osascript, and the trampoline's for the `cd --` inside the script.
+    let mut c = gui_cmd();
+    c.current_dir("subdir");
+    assert_rejected(&c, "absolute");
+}
+
+#[test]
+fn containment_is_rejected_because_the_payload_leaves_our_tree() {
+    let mut c = gui_cmd();
+    c.contain();
+    assert_rejected(&c, "trampoline");
+}
+
+#[test]
+fn env_forwarding_is_rejected() {
+    let mut c = gui_cmd();
+    c.env("A", "1");
+    assert_rejected(&c, "environment");
+}
+
+#[test]
+fn a_high_fd_is_rejected() {
+    let mut c = gui_cmd();
+    c.fd(3, crate::Stdio::null()).unwrap();
+    assert_rejected(&c, "fd >= 3");
+}
+
+#[test]
+fn only_null_and_inherit_are_accepted_on_stdin() {
+    // Every resolution with content behind it, including the `Merge` that
+    // `Stdio::merge` produces — an allow-list, so nothing new slips through.
+    let mut piped = gui_cmd();
+    piped.stdin(crate::Stdio::pipe()).unwrap();
+    assert_rejected(&piped, "stdin");
+
+    let f = tempfile::tempfile().expect("tempfile");
+    let mut filed = gui_cmd();
+    filed.stdin(crate::Stdio::from_file(f)).unwrap();
+    assert_rejected(&filed, "stdin");
+
+    let mut merged = gui_cmd();
+    merged.stdout(crate::Stdio::pipe()).unwrap();
+    merged.stdin(crate::Stdio::merge(crate::Fd::STDOUT)).unwrap();
+    assert_rejected(&merged, "stdin");
+
+    for allowed in [crate::Stdio::null(), crate::Stdio::inherit()] {
+        let mut ok = gui_cmd();
+        ok.stdin(allowed).unwrap();
+        assert!(reject_structural_gui_config(&ok).is_ok());
+    }
+}
+
+#[test]
+fn stdout_and_stderr_may_be_captured_because_they_carry_the_relay() {
+    // These are osascript's OWN streams. Capturing them is how the caller sees the
+    // relayed stdout at all, so `.output()` and `.read()` must work.
+    let mut c = gui_cmd();
+    c.stdout(crate::Stdio::pipe()).unwrap();
+    c.stderr(crate::Stdio::pipe()).unwrap();
+    c.stdin(crate::Stdio::null()).unwrap();
+    assert!(
+        reject_structural_gui_config(&c).is_ok(),
+        "output()/read() must be usable"
+    );
+}
+
+#[test]
+fn a_commandline_command_is_rejected() {
+    let mut c = Command::new();
+    c.commandline("id -u").elevation_auth(crate::elevation::Auth::Gui);
+    assert_rejected(&c, "argv");
+}
+
+#[test]
+fn an_empty_command_is_rejected() {
+    // BOTH internal spellings of "no program", which are separately reachable: a
+    // fresh Command is `CommandInput::Empty`, while `.args([])` takes the `_ =>`
+    // arm of `Command::args` and yields `CommandInput::Argv(vec![])`.
+    let mut fresh = Command::new();
+    fresh.elevation_auth(crate::elevation::Auth::Gui);
+    assert_rejected(&fresh, "program");
+
+    let mut empty_argv = Command::new();
+    empty_argv
+        .args::<[&str; 0], &str>([])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    assert!(
+        matches!(empty_argv.input(), CommandInput::Argv(v) if v.is_empty()),
+        "this test only means something if .args([]) really yields Argv(vec![])"
+    );
+    assert_rejected(&empty_argv, "program");
+}
+
+#[test]
+fn an_argv0_distinct_from_executable_is_rejected() {
+    let mut c = Command::new();
+    c.executable("/usr/bin/id")
+        .args(["not-id", "-u"])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    assert_rejected(&c, "argv[0]");
+}
+
+#[cfg(windows)]
+#[test]
+fn the_gate_reports_a_byte_formless_program_as_a_quote_error() {
+    // Not as "not absolute": the leading-slash test cannot even run on an OsStr
+    // with no byte form, so the gate must surface the real reason.
+    use std::os::windows::ffi::OsStringExt;
+    let mut c = Command::new();
+    c.args([OsString::from_wide(&[0xD800])])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    let e = reject_structural_gui_config(&c).unwrap_err();
+    assert!(
+        matches!(e, Error::Quote(ref q) if q.kind == QuoteErrorKind::NonUtf8),
+        "{e}"
+    );
+}
+
+#[test]
+fn a_matching_executable_yields_that_program_and_the_remaining_args() {
+    // The `Some(exe)` success arm substitutes `exe` for argv[0] and slices the
+    // tail; pin the returned pair, not merely the absence of a rejection.
+    let mut c = Command::new();
+    c.executable("/usr/bin/id")
+        .args(["/usr/bin/id", "-u", "-r"])
+        .elevation_auth(crate::elevation::Auth::Gui);
+    let (program, rest) = super::program_and_args(&c).expect("matching executable");
+    assert_eq!(program, OsString::from("/usr/bin/id"));
+    assert_eq!(rest, args(&["-u", "-r"]));
+}
+
+// ===== derived command =====
+
+#[test]
+fn the_derived_command_is_osascript_dash_e_with_one_script_argument() {
+    let mut c = gui_cmd();
+    let (derived, report) = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+    let CommandInput::Argv(argv) = derived.input() else {
+        panic!("derived command must be an argv");
+    };
+    assert_eq!(argv.len(), 3, "exactly osascript, -e, and ONE script argument");
+    assert_eq!(argv[0], OsString::from("/usr/bin/osascript"));
+    assert_eq!(argv[1], OsString::from("-e"));
+    assert_eq!(
+        argv[2],
+        OsString::from(
+            "do shell script \"exec /usr/bin/id -u\" \
+             with administrator privileges without altering line endings"
+        )
+    );
+    assert_eq!(report.via, ElevatedVia::MacosOsascript);
+    assert_eq!(report.stdio, ElevatedStdio::OsascriptRelay);
+    assert!(report.stripped_env.is_empty(), "no env crosses, so none is stripped");
+}
+
+#[test]
+fn the_derived_command_carries_no_elevation_request() {
+    // Otherwise spawning the derived command would re-enter the elevation branch.
+    let mut c = gui_cmd();
+    let (derived, _) = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+    assert!(!derived.elevation_request().enabled);
+}
+
+#[test]
+fn kill_on_drop_reaches_the_derived_command() {
+    // The async spawn recurses and re-reads this flag off the derived command, so a
+    // caller opting out must not be silently overridden by the builder default.
+    for requested in [true, false] {
+        let mut c = gui_cmd();
+        c.kill_on_drop(requested);
+        let (derived, _) = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+        assert_eq!(derived.kill_on_drop_flag(), requested);
+    }
+}
+
+#[test]
+fn kill_on_drop_warns_that_it_cannot_reach_the_payload() {
+    // The builder default sets the flag, so this is the DEFAULT path: dropping the
+    // child SIGKILLs osascript while the root payload keeps running, unobservable.
+    // That must never be silent, so the spawn says so.
+    //
+    // The capture buffer is process-global and every sibling test that calls
+    // build_rewrite with the default flag writes the same sentence, so BOTH halves
+    // key on a program path unique to this test — otherwise the negative assertion
+    // would race a concurrent sibling's record.
+    const LOUD: &str = "/usr/bin/cosca-koddrop-probe-loud";
+    const QUIET: &str = "/usr/bin/cosca-koddrop-probe-quiet";
+    crate::log_capture::install();
+
+    let mark = crate::log_capture::mark();
+    let mut c = Command::new();
+    c.args([LOUD]).elevation_auth(crate::elevation::Auth::Gui);
+    c.kill_on_drop(true);
+    let _ = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+    assert!(
+        crate::log_capture::contains_since(mark, LOUD),
+        "a kill_on_drop child must be warned about, not silently orphaned"
+    );
+
+    // Opting out is the quiet path — no warning to ignore.
+    let mark = crate::log_capture::mark();
+    let mut quiet = Command::new();
+    quiet.args([QUIET]).elevation_auth(crate::elevation::Auth::Gui);
+    quiet.kill_on_drop(false);
+    let _ = build_rewrite(&mut quiet, Path::new("/usr/bin/osascript"), None).unwrap();
+    assert!(!crate::log_capture::contains_since(mark, QUIET));
+}
+
+#[test]
+fn the_cwd_reaches_both_osascript_and_the_payload() {
+    let mut c = gui_cmd();
+    c.current_dir("/tmp");
+    let (derived, _) = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+    // Set on osascript so a bogus directory fails at spawn with a precise Io error…
+    assert_eq!(derived.cwd(), Some(Path::new("/tmp")));
+    let CommandInput::Argv(argv) = derived.input() else {
+        unreachable!()
+    };
+    // …and stated in the script, so the payload's cwd does not depend on whether
+    // the trampoline happens to carry it.
+    assert!(
+        argv[2].to_str().unwrap().contains("cd -- /tmp && exec"),
+        "{:?}",
+        argv[2]
+    );
+}
+
+#[test]
+fn the_length_guard_is_enforced_through_the_rewrite() {
+    let mut c = gui_cmd();
+    let e = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), Some(10)).unwrap_err();
+    assert!(
+        matches!(
+            e,
+            Error::Elevation {
+                kind: ElevationErrorKind::CommandTooLong,
+                ..
+            }
+        ),
+        "{e}"
+    );
+}
+
+#[test]
+fn the_rewrite_preserves_the_callers_argv_and_moves_its_fds() {
+    // Non-destructive on `input`/`env_ops`, matching the POSIX rewrite's contract —
+    // but the fd table is deliberately MOVED, because `ResolvedStdio::File` is not
+    // `Clone`. Both halves are asserted so neither can regress unnoticed.
+    let mut c = gui_cmd();
+    c.stdout(crate::Stdio::pipe()).unwrap();
+    let before = format!("{:?}", c.input());
+    let (derived, _) = build_rewrite(&mut c, Path::new("/usr/bin/osascript"), None).unwrap();
+    assert_eq!(format!("{:?}", c.input()), before, "argv must survive the rewrite");
+    assert!(c.env_ops().is_empty());
+    assert!(c.fds().is_empty(), "the caller's fds are moved, not copied");
+    assert!(
+        derived.fds().contains_key(&crate::Fd::STDOUT),
+        "the moved fds must land on the derived command"
+    );
+}
+
+// ===== real osascript (macOS CI, ungated, no dialog) =====
+
+/// The crate's own elevated script with ONLY the privilege clause removed, so
+/// running it raises no dialog while both quoting layers stay exactly the
+/// production ones. Asserts the removal matched — a renamed clause must not
+/// silently turn this into a test of an unmodified string.
+#[cfg(target_os = "macos")]
+fn crate_script_without_the_privilege_clause(program: &OsStr, args: &[OsString]) -> String {
+    const CLAUSE: &str = " with administrator privileges";
+    let shell_command = build_shell_command(program, args, None).unwrap();
+    let script = wrap_do_shell_script(&shell_command, None).unwrap();
+    assert!(script.contains(CLAUSE), "the privilege clause moved: {script}");
+    script.replace(CLAUSE, "")
+}
+
+// UNGATED, macOS only: drives the CRATE's quoting through the real AppleScript
+// parser and the real /bin/sh, with no elevation and no dialog. A bug in either
+// layer shows up as a mangled argv here.
+#[cfg(target_os = "macos")]
+#[test]
+fn both_quoting_layers_survive_a_real_osascript_round_trip() {
+    let nasty = [
+        "a b",
+        "it's",
+        r#"he said "hi""#,
+        "$HOME `id` $(id)",
+        r"back\slash",
+        "semi;colon & pipe|",
+        "tab\there",
+        // The newline and CR cases are why `without altering line endings` is
+        // mandatory: without it `do shell script` rewrites them.
+        "line\nbreak",
+        "carriage\rreturn",
+        "crlf\r\npair",
+        "",
+        "--",
+        "trailing ",
+        // ---- Controls with no AppleScript escape. The crate passes these through
+        // rather than refusing them on the inference that "no numeric escape" means
+        // "no representation". THIS is the measurement that decides whether that is
+        // right: if any of them fails to round-trip, `escape_literal` must reject
+        // exactly the failing ones, with this test as the evidence.
+        "\u{1b}[31mred\u{1b}[0m",
+        "bell\u{7}here",
+        "vtab\u{b}here",
+        "ff\u{c}here",
+        "del\u{7f}here",
+        // ---- Non-ASCII. `osascript(1)` documents no encoding for `-e`, so this
+        // block IS the specification: it decides whether the crate may pass
+        // non-ASCII through. A CJK-named file argument to an ASCII-named tool is an
+        // ordinary command on a UTF-8 filesystem, so refusing the class would reject
+        // real users; these cases prove it instead of assuming it.
+        "\u{4e2d}\u{6587}\u{6587}\u{4ef6}.txt",
+        "\u{440}\u{443}\u{441}\u{441}\u{43a}\u{438}\u{439}",
+        "\u{627}\u{644}\u{639}\u{631}\u{628}\u{64a}\u{629}",
+        // Precomposed vs decomposed: byte-DIFFERENT, canonically equivalent. If
+        // anything on the path normalizes (Apple filesystems historically did),
+        // these two collapse into one value and the comparison catches it.
+        "caf\u{e9}",
+        "cafe\u{301}",
+        "\u{1f389}\u{1f680}",
+        "mixed \u{65e5}\u{672c}\u{8a9e} and \u{3b5}\u{3bb}\u{3bb} and ascii",
+    ];
+    // The payload is `/bin/sh` and system tools only — no crate binary. A unit test
+    // cannot rely on `cosca_testbin`: cargo builds `[[bin]]` targets only when a
+    // non-lib target is selected, and CI has a darwin `--lib` leg. `$@` receives the
+    // fixture as real argv, and each element is hex-dumped so the TEXT relay cannot
+    // corrupt the comparison.
+    const DUMP: &str = r#"for a in "$@"; do printf %s "$a" | od -An -tx1 -v | tr -d ' \n'; echo; done"#;
+    let mut argv: Vec<OsString> = vec![
+        OsString::from("-c"),
+        OsString::from(DUMP),
+        OsString::from("sh"), // $0
+    ];
+    argv.extend(nasty.iter().map(OsString::from));
+    let script = crate_script_without_the_privilege_clause(OsStr::new("/bin/sh"), &argv);
+
+    let mut c = Command::new();
+    c.args([
+        OsString::from("/usr/bin/osascript"),
+        OsString::from("-e"),
+        script.into(),
+    ]);
+    let relayed = c.read().expect("osascript output");
+
+    // The expectation is the Rust-side UTF-8 bytes, hex-encoded. `od` dumps what
+    // /bin/sh ACTUALLY received, so any re-encoding, normalization or truncation
+    // anywhere between `wrap_do_shell_script` and the shell shows up as a diff.
+    let expected: Vec<String> = nasty
+        .iter()
+        .map(|s| s.as_bytes().iter().map(|b| format!("{b:02x}")).collect())
+        .collect();
+    let got: Vec<&str> = relayed.trim_end_matches('\n').split('\n').collect();
+    assert_eq!(got, expected, "argv was mangled crossing the two quoting layers");
+
+    // Guard the guard: the NFC and NFD spellings must stay DISTINCT in the output.
+    // If they were ever equal, the fixture would have stopped testing normalization
+    // without failing. Looked up by value so reordering cannot silently mis-target.
+    let hex = |s: &str| -> String { s.as_bytes().iter().map(|b| format!("{b:02x}")).collect() };
+    let nfc = hex("caf\u{e9}");
+    let nfd = hex("cafe\u{301}");
+    assert_ne!(nfc, nfd, "the NFC/NFD pair must remain byte-distinct");
+    assert!(got.contains(&nfc.as_str()) && got.contains(&nfd.as_str()));
+}
+
+// UNGATED, macOS only: feeds the crate's UNMODIFIED elevated script to osacompile,
+// which parses without executing. This is the one property of the real script the
+// round trip cannot reach — that `with administrator privileges` is syntactically
+// valid next to `without altering line endings` — and it needs no dialog. The output
+// goes to a real temp file: `osacompile` creates its `-o` target as a file, so a
+// device path would risk failing for reasons unrelated to the script.
+#[cfg(target_os = "macos")]
+#[test]
+fn the_administrator_script_compiles() {
+    let shell_command = build_shell_command(OsStr::new("/usr/bin/id"), &args(&["-u"]), None).unwrap();
+    let script = wrap_do_shell_script(&shell_command, None).unwrap();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out_path = dir.path().join("script.scpt");
+
+    let mut c = Command::new();
+    c.args([
+        OsString::from("/usr/bin/osacompile"),
+        OsString::from("-o"),
+        out_path.clone().into_os_string(),
+        OsString::from("-e"),
+        script.clone().into(),
+    ]);
+    let out = c.output().expect("osacompile output");
+    assert!(
+        out.status.success(),
+        "the elevated script does not compile: {script}\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out_path.exists(), "osacompile reported success but wrote nothing");
+}
+
+// UNGATED, macOS only: MEASURES the claim `wrap_do_shell_script` documents — that
+// `with timeout` does not govern `do shell script` under osascript, so the default
+// event timeout cannot cut a long-running elevated payload short. Asserting the
+// mechanism rather than the default's numeric value keeps this to a few seconds: if
+// an explicit 2-second bound does not fire on a 5-second payload, the 120-second
+// default cannot fire either — same dispatch path, larger bound.
+//
+// If this ever fails with -1712 ("AppleEvent timed out"), the doc claim is wrong and
+// `wrap_do_shell_script` must emit a timeout clause (or surface the bound as a typed
+// error), with this test as the evidence.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_timeout_clause_does_not_bound_do_shell_script() {
+    let shell_command = build_shell_command(OsStr::new("/bin/sleep"), &args(&["5"]), None).unwrap();
+    let body = crate::quote::applescript::escape_literal(&shell_command).unwrap();
+    let bounded = format!(
+        "with timeout of 2 seconds
+do shell script \"{body}\" without altering line endings
+end timeout"
+    );
+
+    let mut c = Command::new();
+    c.args([
+        OsString::from("/usr/bin/osascript"),
+        OsString::from("-e"),
+        bounded.into(),
+    ]);
+    let out = c.output().expect("osascript output");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "a 2s `with timeout` must not bound a 5s do-shell-script payload: {stderr}"
+    );
+    assert!(
+        !stderr.contains("-1712"),
+        "the payload was cut short by the Apple event timeout: {stderr}"
+    );
+}

--- a/src/elevation/plan.rs
+++ b/src/elevation/plan.rs
@@ -12,10 +12,26 @@ use crate::error::{ElevationErrorKind, Error};
 // Windows-shaped `Host` is planned on Linux and vice versa), so in a non-test single-platform
 // build the other platform's variant is never constructed. That is by design, not dead logic.
 #[allow(dead_code)]
+// The enum is named `Os` and `MacOs` names an OS, so the variant unavoidably ends
+// with the enum's name. Renaming either to satisfy the lint would make both worse.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Os {
+    /// Every POSIX host EXCEPT macOS — Linux, the BSDs, illumos. Deliberately not
+    /// named `Linux`: nothing keyed off it is Linux-specific, and a Linux-shaped
+    /// name would invite gating genuinely Linux-only behavior on it.
     Unix,
+    MacOs,
     Windows,
+}
+
+/// Is this request the macOS graphical path? Deliberately privilege-free: it is a
+/// property of the REQUEST, so the same answer holds for a root and a non-root
+/// caller. Every site that needs "is this osascript?" calls THIS — the structural
+/// matrix, [`Host::plan`]'s resolution arm, and the effect layer's gate selection.
+/// Deriving it inline in three places is how they drift apart.
+pub(crate) fn is_macos_gui_auto(os: Os, backend: Backend, auth: &Auth) -> bool {
+    os == Os::MacOs && matches!(auth, Auth::Gui) && backend == Backend::Auto
 }
 
 /// The resolved absolute path of each CLI backend on PATH (`None` = absent),
@@ -28,6 +44,10 @@ pub struct BackendSet {
     pub sudo: Option<PathBuf>,
     pub doas: Option<PathBuf>,
     pub pkexec: Option<PathBuf>,
+    /// macOS only: the absolute path of `/usr/bin/osascript`, the graphical
+    /// elevation front-end. Not a [`Backend`]: it does not wrap the child, it asks
+    /// Authorization Services to run the command as root.
+    pub osascript: Option<PathBuf>,
 }
 
 impl BackendSet {
@@ -50,6 +70,13 @@ pub struct Host {
     pub has_tty: bool,
     pub available: BackendSet,
     pub os: Os,
+    /// `sysctl kern.argmax` — the exec argument budget, read at detect time
+    /// because it has changed across macOS releases and must never be guessed.
+    /// `None` when the query failed or the platform has no equivalent; the macOS
+    /// length guard is then skipped rather than run against an invented number.
+    /// Only the macOS graphical path reads it; it lives here because the planner
+    /// is plain data.
+    pub arg_max: Option<usize>,
 }
 
 /// The planner's decision. Not `PartialEq` — `Reject` wraps a non-comparable
@@ -67,6 +94,14 @@ pub enum Transition {
     },
     ElevateWindows {
         auth: Auth,
+    },
+    ElevateMacosGui {
+        /// The absolute path of `/usr/bin/osascript`, carried for the same reason
+        /// the POSIX backends carry theirs: the validated path is exactly the one
+        /// argv[0] emits, so nothing on PATH can be substituted for it.
+        osascript: PathBuf,
+        /// The detected `kern.argmax`, carried so the effect layer stays pure.
+        arg_max: Option<usize>,
     },
     Reject {
         error: Error,
@@ -90,6 +125,7 @@ impl Host {
                 has_tty: false,
                 available: BackendSet::default(),
                 os: Os::Unix,
+                arg_max: None,
             }
         }
     }
@@ -102,7 +138,7 @@ impl Host {
         // short-circuit, so an impossible combo never passes under root.
         let structural = match self.os {
             Os::Windows => structural_windows(backend, &auth),
-            Os::Unix => structural_posix(backend, &auth, &self.available),
+            os => structural_posix(os, backend, &auth, &self.available),
         };
         if let Some(error) = structural {
             return Transition::Reject { error };
@@ -112,7 +148,21 @@ impl Host {
         }
         match self.os {
             Os::Windows => Transition::ElevateWindows { auth },
-            Os::Unix => self.resolve_posix(backend, auth),
+            Os::MacOs if is_macos_gui_auto(self.os, backend, &auth) => {
+                match self.available.osascript.as_deref() {
+                    Some(p) => Transition::ElevateMacosGui {
+                        osascript: p.to_path_buf(),
+                        arg_max: self.arg_max,
+                    },
+                    // Honest here, unlike the pkexec verdict: /usr/bin/osascript
+                    // can genuinely be missing or non-executable.
+                    None => reject_backend_unavailable(
+                        "/usr/bin/osascript is missing or not executable; \
+                         macOS graphical elevation needs it",
+                    ),
+                }
+            }
+            Os::MacOs | Os::Unix => self.resolve_posix(backend, auth),
         }
     }
 
@@ -172,19 +222,49 @@ fn reject_backend_unavailable(detail: &str) -> Transition {
 /// `Backend::Auto` + `Auth::Stdin` on a doas-only host would return `Unsupported`
 /// unprivileged but `RunAsIs` once already root, a verdict that flips on ambient
 /// privilege instead of staying a property of the request.
-fn structural_posix(backend: Backend, auth: &Auth, available: &BackendSet) -> Option<Error> {
+fn structural_posix(os: Os, backend: Backend, auth: &Auth, available: &BackendSet) -> Option<Error> {
+    let platform = if os == Os::MacOs { "macos" } else { "unix" };
     let unsupported = |op: String, detail: &str| {
         Some(Error::Unsupported {
             op,
-            platform: "unix",
+            platform,
             detail: detail.into(),
         })
     };
-    if matches!(auth, Auth::Gui) && backend != Backend::Pkexec {
-        return unsupported(
-            format!("{backend:?} + Auth::Gui"),
-            "graphical (Gui) auth is only available through Backend::Pkexec",
-        );
+    // polkit and systemd are Linux stacks. Saying "not on PATH" on macOS reads as a
+    // fixable environment problem on a platform where neither will ever exist.
+    // sudo and doas are NOT in this list: both are portable and do run on macOS.
+    if os == Os::MacOs {
+        let impossible = match backend {
+            Backend::Pkexec => Some(
+                "pkexec is a polkit (Linux) program and does not exist on macOS; \
+                 use Backend::Auto with Auth::Gui for the macOS authentication dialog",
+            ),
+            Backend::Run0 => Some(
+                "run0 ships with systemd and does not exist on macOS; \
+                 use Backend::Auto (sudo), or Auth::Gui for the macOS authentication dialog",
+            ),
+            _ => None,
+        };
+        if let Some(detail) = impossible {
+            return unsupported(format!("Backend::{backend:?}"), detail);
+        }
+    }
+    if matches!(auth, Auth::Gui) {
+        if os == Os::MacOs {
+            if !is_macos_gui_auto(os, backend, auth) {
+                return unsupported(
+                    format!("{backend:?} + Auth::Gui"),
+                    "macOS graphical elevation goes through Authorization Services, not a \
+                     CLI wrapper; pair Auth::Gui with Backend::Auto",
+                );
+            }
+        } else if backend != Backend::Pkexec {
+            return unsupported(
+                format!("{backend:?} + Auth::Gui"),
+                "graphical (Gui) auth is only available through Backend::Pkexec",
+            );
+        }
     }
     if backend == Backend::Pkexec && !matches!(auth, Auth::Gui) {
         return unsupported(

--- a/src/elevation/plan_tests.rs
+++ b/src/elevation/plan_tests.rs
@@ -25,6 +25,7 @@ fn win_host(elevated: bool) -> Host {
         has_tty: false,
         available: BackendSet::default(),
         os: Os::Windows,
+        arg_max: None,
     }
 }
 
@@ -34,6 +35,7 @@ fn all_backends() -> BackendSet {
         sudo: Some(PathBuf::from("/usr/bin/sudo")),
         doas: Some(PathBuf::from("/usr/bin/doas")),
         pkexec: Some(PathBuf::from("/usr/bin/pkexec")),
+        osascript: None,
     }
 }
 
@@ -43,6 +45,7 @@ fn unix_host(available: BackendSet, elevated: bool, has_tty: bool) -> Host {
         has_tty,
         available,
         os: Os::Unix,
+        arg_max: None,
     }
 }
 
@@ -82,6 +85,7 @@ fn auto_prefers_sudo_then_doas() {
             sudo: None,
             doas: Some(PathBuf::from("/usr/bin/doas")),
             pkexec: None,
+            osascript: None,
         },
         false,
         true,
@@ -104,6 +108,7 @@ fn auto_never_selects_run0_or_pkexec() {
             sudo: None,
             doas: None,
             pkexec: Some(PathBuf::from("/usr/bin/pkexec")),
+            osascript: None,
         },
         false,
         true,
@@ -136,6 +141,7 @@ fn windows_unprivileged_elevates_via_uac() {
         has_tty: false,
         available: BackendSet::default(),
         os: Os::Windows,
+        arg_max: None,
     };
     assert!(matches!(
         h.plan(Privilege::Elevated, Backend::Auto, Auth::Interactive),
@@ -247,6 +253,7 @@ fn auto_resolving_to_doas_rejects_stdin() {
                 sudo: None,
                 doas: Some(PathBuf::from("/usr/bin/doas")),
                 pkexec: None,
+                osascript: None,
             },
             elevated,
             true,
@@ -271,5 +278,173 @@ fn pkexec_with_gui_is_accepted() {
             backend: Backend::Pkexec,
             ..
         }
+    ));
+}
+
+/// A macOS host: sudo exists, pkexec/run0/doas do not, osascript does.
+fn macos_host(elevated: bool, has_tty: bool) -> Host {
+    Host {
+        elevated,
+        has_tty,
+        available: BackendSet {
+            run0: None,
+            sudo: Some(PathBuf::from("/usr/bin/sudo")),
+            doas: None,
+            pkexec: None,
+            osascript: Some(PathBuf::from("/usr/bin/osascript")),
+        },
+        os: Os::MacOs,
+        arg_max: Some(1_048_576),
+    }
+}
+
+fn unsupported_platform(t: Transition) -> &'static str {
+    match reject_error(t) {
+        Error::Unsupported { platform, .. } => platform,
+        other => panic!("expected Unsupported, got {other}"),
+    }
+}
+
+#[test]
+fn macos_pkexec_is_unsupported_not_backend_unavailable() {
+    // pkexec can never exist on macOS, so a "backend not on PATH" verdict would
+    // wrongly invite installing it. Even with a fabricated pkexec path present,
+    // the verdict must be a platform Unsupported.
+    let mut h = macos_host(false, true);
+    h.available.pkexec = Some(PathBuf::from("/usr/bin/pkexec"));
+    assert_eq!(
+        unsupported_platform(h.plan(Privilege::Elevated, Backend::Pkexec, Auth::Gui)),
+        "macos"
+    );
+}
+
+#[test]
+fn macos_run0_is_unsupported_not_backend_unavailable() {
+    // Same reasoning as pkexec: run0 ships with systemd, so "not on PATH" would
+    // invite installing something that does not exist for this platform.
+    let mut h = macos_host(false, true);
+    h.available.run0 = Some(PathBuf::from("/usr/bin/run0"));
+    for auth in [Auth::Interactive, Auth::NonInteractive] {
+        match reject_error(h.plan(Privilege::Elevated, Backend::Run0, auth)) {
+            Error::Unsupported { platform, detail, .. } => {
+                assert_eq!(platform, "macos");
+                assert!(detail.contains("systemd"), "{detail}");
+            }
+            other => panic!("expected Unsupported, got {other}"),
+        }
+    }
+}
+
+#[test]
+fn macos_keeps_the_backends_that_really_do_run_there() {
+    // sudo and doas are portable and DO exist on macOS, so they must not be swept
+    // into the impossible-backend guard alongside pkexec/run0.
+    let mut h = macos_host(false, true);
+    h.available.doas = Some(PathBuf::from("/usr/local/bin/doas"));
+    for backend in [Backend::Sudo, Backend::Doas] {
+        assert!(
+            matches!(
+                h.plan(Privilege::Elevated, backend, Auth::Interactive),
+                Transition::ElevatePosix { .. }
+            ),
+            "{backend:?} must still be usable on macOS"
+        );
+    }
+}
+
+#[test]
+fn macos_sudo_still_works_like_other_unix() {
+    let h = macos_host(false, true);
+    assert!(matches!(
+        h.plan(Privilege::Elevated, Backend::Auto, Auth::Interactive),
+        Transition::ElevatePosix {
+            backend: Backend::Sudo,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn non_macos_unix_gui_still_requires_pkexec() {
+    let h = unix_host(all_backends(), false, true);
+    assert!(matches!(
+        h.plan(Privilege::Elevated, Backend::Pkexec, Auth::Gui),
+        Transition::ElevatePosix {
+            backend: Backend::Pkexec,
+            ..
+        }
+    ));
+    assert!(is_unsupported(h.plan(Privilege::Elevated, Backend::Sudo, Auth::Gui)));
+}
+
+#[test]
+fn macos_gui_resolves_to_the_osascript_transition() {
+    let h = macos_host(false, /* has_tty */ false);
+    match h.plan(Privilege::Elevated, Backend::Auto, Auth::Gui) {
+        Transition::ElevateMacosGui { osascript, arg_max } => {
+            assert_eq!(osascript, PathBuf::from("/usr/bin/osascript"));
+            assert_eq!(arg_max, Some(1_048_576));
+        }
+        other => panic!("expected ElevateMacosGui, got {other:?}"),
+    }
+}
+
+#[test]
+fn macos_gui_needs_no_controlling_terminal() {
+    // A windowed app has no controlling terminal, so Auth::Gui must not trip the
+    // NoTty gate the way Auth::Interactive does.
+    let h = macos_host(false, false);
+    assert!(matches!(
+        h.plan(Privilege::Elevated, Backend::Auto, Auth::Gui),
+        Transition::ElevateMacosGui { .. }
+    ));
+    assert!(matches!(
+        reject_error(h.plan(Privilege::Elevated, Backend::Auto, Auth::Interactive)),
+        Error::Elevation {
+            kind: ElevationErrorKind::NoTty,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn macos_gui_with_a_non_auto_backend_is_still_unsupported() {
+    // Auth::Gui names Authorization Services on macOS; no CLI wrapper is involved,
+    // so a forced sudo/doas/run0 is a config error, not something osascript runs.
+    for backend in [Backend::Sudo, Backend::Doas, Backend::Run0] {
+        let h = macos_host(false, true);
+        // `plan_tests.rs` is NOT platform-gated, so asserting the message HERE is
+        // what keeps this arm's wording checked on the Windows CI leg too.
+        match reject_error(h.plan(Privilege::Elevated, backend, Auth::Gui)) {
+            Error::Unsupported { platform, detail, .. } => {
+                assert_eq!(platform, "macos", "{backend:?}");
+                assert!(detail.contains("Backend::Auto"), "{backend:?}: {detail}");
+            }
+            other => panic!("expected Unsupported for {backend:?}, got {other}"),
+        }
+    }
+}
+
+#[test]
+fn macos_gui_without_osascript_is_a_backend_problem_not_a_platform_one() {
+    // Here BackendUnavailable is honest: /usr/bin/osascript really can be absent
+    // or non-executable on a stripped system.
+    let mut h = macos_host(false, true);
+    h.available.osascript = None;
+    assert!(matches!(
+        reject_error(h.plan(Privilege::Elevated, Backend::Auto, Auth::Gui)),
+        Error::Elevation {
+            kind: ElevationErrorKind::BackendUnavailable,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn macos_gui_already_elevated_runs_as_is() {
+    let h = macos_host(true, false);
+    assert!(matches!(
+        h.plan(Privilege::Elevated, Backend::Auto, Auth::Gui),
+        Transition::RunAsIs
     ));
 }

--- a/src/elevation/posix.rs
+++ b/src/elevation/posix.rs
@@ -187,6 +187,31 @@ pub(super) fn resolve_in_path_var(path_var: &OsStr, program: &str) -> Option<Pat
     })
 }
 
+/// Reads `sysctl kern.argmax` for [`Host::arg_max`]; `None` if the query fails.
+#[cfg(target_os = "macos")]
+fn kern_argmax() -> Option<usize> {
+    let mut mib = [libc::CTL_KERN, libc::KERN_ARGMAX];
+    let mut value: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+    // SAFETY: a two-element MIB with a matching `c_int` out-buffer and its exact
+    // size; a read-only sysctl (null new-value, zero new-length).
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            &mut value as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 || value <= 0 {
+        log::debug!("could not read kern.argmax; the elevation length guard is disabled");
+        return None;
+    }
+    Some(value as usize)
+}
+
 pub(super) fn detect() -> Host {
     Host {
         elevated: is_elevated(),
@@ -196,8 +221,31 @@ pub(super) fn detect() -> Host {
             sudo: resolve_on_path("sudo"),
             doas: resolve_on_path("doas"),
             pkexec: resolve_on_path("pkexec"),
+            // A fixed system path, never PATH-resolved: a PATH lookup would let a
+            // shadowing `osascript` earlier on PATH receive an elevation request.
+            osascript: {
+                #[cfg(target_os = "macos")]
+                {
+                    let p = Path::new("/usr/bin/osascript");
+                    is_executable(p).then(|| p.to_path_buf())
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    None
+                }
+            },
         },
-        os: Os::Unix,
+        os: if cfg!(target_os = "macos") { Os::MacOs } else { Os::Unix },
+        arg_max: {
+            #[cfg(target_os = "macos")]
+            {
+                kern_argmax()
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                None
+            }
+        },
     }
 }
 
@@ -387,21 +435,28 @@ fn explicit_set_env(ops: &[EnvOp]) -> Vec<(OsString, OsString)> {
 /// Program + args, honoring `executable()`. An argv[0] distinct from a set
 /// `executable()` cannot survive the backend wrapper → `Unsupported`.
 fn program_and_args(cmd: &Command) -> Result<(OsString, Vec<OsString>), Error> {
-    let CommandInput::Argv(argv) = cmd.input() else {
-        return Err(Error::Unsupported {
-            op: "elevation of a commandline() command".into(),
-            platform: "unix",
-            detail:
-                "elevation requires an argv command (set .args([...])); a raw command line cannot be safely wrapped"
-                    .into(),
-        });
+    // `Empty` is matched FIRST. A fresh `Command` is `CommandInput::Empty`, not
+    // `Argv(vec![])`, so folding it into the commandline arm would answer "no
+    // program set" with a message about re-quoting a command line that was never set.
+    let empty = || Error::Unsupported {
+        op: "elevation of an empty command".into(),
+        platform: "unix",
+        detail: "set a program via .args([...]) before .elevate()".into(),
     };
+    let argv =
+        match cmd.input() {
+            CommandInput::Argv(argv) => argv,
+            CommandInput::Empty => return Err(empty()),
+            CommandInput::CommandLine(_) => return Err(Error::Unsupported {
+                op: "elevation of a commandline() command".into(),
+                platform: "unix",
+                detail:
+                    "elevation requires an argv command (set .args([...])); a raw command line cannot be safely wrapped"
+                        .into(),
+            }),
+        };
     if argv.is_empty() {
-        return Err(Error::Unsupported {
-            op: "elevation of an empty command".into(),
-            platform: "unix",
-            detail: "set a program via .args([...]) before .elevate()".into(),
-        });
+        return Err(empty());
     }
     match cmd.executable_path() {
         Some(exe) => {
@@ -493,11 +548,33 @@ pub(crate) fn rewrite_with_host(cmd: &mut Command, host: &Host) -> Result<PosixR
     let requested_auth = cmd.elevation_request().auth.clone();
 
     // Structural config gates FIRST — privilege-independent (before the short-circuit).
-    reject_structural_posix_config(cmd, requested_backend, &requested_auth)?;
+    //
+    // Which gate applies is a property of the REQUEST, not the run — see
+    // `is_macos_gui_auto`'s doc and the ambient-privilege invariant
+    // `structural_posix` documents. Keying on the resolved `Transition` instead
+    // would break it: `plan()` yields `RunAsIs` under root, so the same request
+    // would be accepted as root and rejected as a normal user.
+    let macos_gui = super::plan::is_macos_gui_auto(host.os, requested_backend, &requested_auth);
+    if macos_gui {
+        super::macos::reject_structural_gui_config(cmd)?;
+    } else {
+        reject_structural_posix_config(cmd, requested_backend, &requested_auth)?;
+    }
 
     match host.plan(Privilege::Elevated, requested_backend, requested_auth) {
         Transition::Reject { error } => Err(error),
         Transition::ElevateWindows { .. } => unreachable!("planner never yields ElevateWindows on a unix host"),
+        Transition::ElevateMacosGui { osascript, arg_max } => {
+            let (derived, report) = super::macos::build_rewrite(cmd, &osascript, arg_max)?;
+            Ok(PosixRewrite {
+                derived: Some(derived),
+                report: Some(report),
+                password_write: None,
+                // The derived program IS osascript, so an exec failure remaps to
+                // BackendUnavailable exactly as it does for the POSIX backends.
+                backend_path: Some(osascript),
+            })
+        }
         Transition::RunAsIs => {
             // Already elevated: no wrapper, but the sanitizer STILL runs so a dangerous
             // forwarded var never reaches the root child. Build a non-destructive derived

--- a/src/elevation/posix_tests.rs
+++ b/src/elevation/posix_tests.rs
@@ -767,9 +767,12 @@ mod rewrite_tests {
         // choice is what makes the difference, so assert the macOS message.
         let mut c = Command::new();
         c.args(["/usr/bin/id"]).contain().elevation_auth(Auth::Gui);
+        // `PosixRewrite` has no `Debug`, so the error is named rather than the whole
+        // Result — the same reason the sibling arms below spell `Ok(_)` out.
         match rewrite_with_host(&mut c, &macos_gui_host(false)) {
             Err(Error::Unsupported { platform, .. }) => assert_eq!(platform, "macos"),
-            other => panic!("expected a macos Unsupported, got {other:?}"),
+            Err(other) => panic!("expected a macos Unsupported, got {other}"),
+            Ok(_) => panic!("expected a macos Unsupported, got a successful rewrite"),
         }
     }
 
@@ -784,7 +787,8 @@ mod rewrite_tests {
             c.args(["/usr/bin/id"]).contain().elevation_auth(Auth::Gui);
             match rewrite_with_host(&mut c, &macos_gui_host(elevated)) {
                 Err(Error::Unsupported { platform, .. }) => assert_eq!(platform, "macos"),
-                other => panic!("expected a macos Unsupported (elevated={elevated}), got {other:?}"),
+                Err(other) => panic!("expected a macos Unsupported (elevated={elevated}), got {other}"),
+                Ok(_) => panic!("the verdict must not flip on ambient privilege (elevated={elevated})"),
             }
         }
     }
@@ -812,7 +816,8 @@ mod rewrite_tests {
                 assert!(detail.contains("Backend::Auto"), "{detail}");
                 assert!(!detail.contains("trampoline"), "{detail}");
             }
-            other => panic!("expected Unsupported, got {other:?}"),
+            Err(other) => panic!("expected Unsupported, got {other}"),
+            Ok(_) => panic!("Backend::Sudo + Auth::Gui must not resolve on macOS"),
         }
     }
 
@@ -831,7 +836,8 @@ mod rewrite_tests {
                 assert_eq!(kind, crate::error::ElevationErrorKind::BackendUnavailable);
                 assert!(detail.contains("osascript"), "{detail}");
             }
-            other => panic!("expected BackendUnavailable, got {other:?}"),
+            Err(other) => panic!("expected BackendUnavailable, got {other}"),
+            Ok(_) => panic!("a missing osascript must not resolve to a rewrite"),
         }
     }
 

--- a/src/elevation/posix_tests.rs
+++ b/src/elevation/posix_tests.rs
@@ -306,8 +306,10 @@ mod rewrite_tests {
                 sudo: Some(PathBuf::from("/usr/bin/sudo")),
                 doas: Some(PathBuf::from("/usr/bin/doas")),
                 pkexec: None,
+                osascript: None,
             },
             os: Os::Unix,
+            arg_max: None,
         }
     }
 
@@ -394,6 +396,7 @@ mod rewrite_tests {
                 sudo: None,
                 doas: Some(PathBuf::from("/usr/bin/doas")),
                 pkexec: None,
+                osascript: None,
             },
             ..sudo_host()
         };
@@ -413,6 +416,7 @@ mod rewrite_tests {
                 sudo: None,
                 doas: None,
                 pkexec: Some(PathBuf::from("/usr/bin/pkexec")),
+                osascript: None,
             },
             ..sudo_host()
         };
@@ -435,6 +439,7 @@ mod rewrite_tests {
                 sudo: None,
                 doas: None,
                 pkexec: None,
+                osascript: None,
             },
             ..sudo_host()
         };
@@ -524,6 +529,7 @@ mod rewrite_tests {
                 sudo: None,
                 doas: None,
                 pkexec: None,
+                osascript: None,
             },
             ..sudo_host()
         };
@@ -629,6 +635,7 @@ mod rewrite_tests {
                     sudo: None,
                     doas: Some(PathBuf::from("/usr/bin/doas")),
                     pkexec: None,
+                    osascript: None,
                 },
                 ..host.clone()
             };
@@ -715,5 +722,124 @@ mod rewrite_tests {
         assert_eq!(got.len(), secret_bytes.len() + 1);
         assert_eq!(&got[..secret_bytes.len()], &secret_bytes[..]);
         assert_eq!(got[secret_bytes.len()], b'\n');
+    }
+
+    // ===== macOS graphical elevation, planned on ANY unix host =====
+
+    fn macos_gui_host(elevated: bool) -> Host {
+        Host {
+            elevated,
+            has_tty: false,
+            available: BackendSet {
+                run0: None,
+                sudo: Some(PathBuf::from("/usr/bin/sudo")),
+                doas: None,
+                pkexec: None,
+                osascript: Some(PathBuf::from("/usr/bin/osascript")),
+            },
+            os: Os::MacOs,
+            arg_max: Some(1_048_576),
+        }
+    }
+
+    #[test]
+    fn macos_gui_rewrites_to_osascript() {
+        let mut c = Command::new();
+        c.args(["/usr/bin/id", "-u"]).elevation_auth(Auth::Gui);
+        let rw = rewrite_with_host(&mut c, &macos_gui_host(false)).expect("macos gui rewrite");
+        let derived = rw.derived.expect("a derived command");
+        let CommandInput::Argv(argv) = derived.input() else {
+            panic!("argv expected")
+        };
+        assert_eq!(argv[0], OsString::from("/usr/bin/osascript"));
+        assert_eq!(argv[1], OsString::from("-e"));
+        assert!(argv[2].to_str().unwrap().contains("with administrator privileges"));
+        assert_eq!(rw.backend_path, Some(PathBuf::from("/usr/bin/osascript")));
+        assert!(rw.password_write.is_none());
+        let report = rw.report.expect("a report");
+        assert_eq!(report.via, ElevatedVia::MacosOsascript);
+        assert_eq!(report.stdio, ElevatedStdio::OsascriptRelay);
+    }
+
+    #[test]
+    fn macos_gui_uses_the_macos_gate_not_the_posix_one() {
+        // .contain() is legal under sudo and illegal under osascript; the gate
+        // choice is what makes the difference, so assert the macOS message.
+        let mut c = Command::new();
+        c.args(["/usr/bin/id"]).contain().elevation_auth(Auth::Gui);
+        match rewrite_with_host(&mut c, &macos_gui_host(false)) {
+            Err(Error::Unsupported { platform, .. }) => assert_eq!(platform, "macos"),
+            other => panic!("expected a macos Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_macos_gui_gate_is_privilege_independent() {
+        // The crate's stated invariant: a structural verdict is a property of the
+        // REQUEST, never of ambient privilege. If this flipped, a developer testing
+        // as root would see .contain() accepted and ship it, and every unprivileged
+        // user would hit a hard Unsupported at runtime.
+        for elevated in [false, true] {
+            let mut c = Command::new();
+            c.args(["/usr/bin/id"]).contain().elevation_auth(Auth::Gui);
+            match rewrite_with_host(&mut c, &macos_gui_host(elevated)) {
+                Err(Error::Unsupported { platform, .. }) => assert_eq!(platform, "macos"),
+                other => panic!("expected a macos Unsupported (elevated={elevated}), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn an_already_root_macos_gui_caller_runs_unwrapped() {
+        // With a clean config the short-circuit still applies: no osascript.
+        let mut c = Command::new();
+        c.args(["/usr/bin/id"]).elevation_auth(Auth::Gui);
+        let rw = rewrite_with_host(&mut c, &macos_gui_host(true)).expect("already-root rewrite");
+        assert_eq!(rw.report.expect("a report").via, ElevatedVia::AlreadyElevated);
+        assert!(rw.backend_path.is_none(), "no wrapper runs when already elevated");
+    }
+
+    #[test]
+    fn a_forced_backend_with_gui_gets_the_planners_verdict_not_the_trampolines() {
+        // Backend::Sudo + Auth::Gui never reaches osascript, so the message must be
+        // about the backend pairing, not about the authorization trampoline.
+        let mut c = Command::new();
+        c.args(["/usr/bin/id"])
+            .elevation_backend(Backend::Sudo)
+            .elevation_auth(Auth::Gui);
+        match rewrite_with_host(&mut c, &macos_gui_host(false)) {
+            Err(Error::Unsupported { detail, .. }) => {
+                assert!(detail.contains("Backend::Auto"), "{detail}");
+                assert!(!detail.contains("trampoline"), "{detail}");
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_missing_osascript_keeps_the_honest_backend_verdict_through_the_dispatch() {
+        // The gate is chosen from the REQUEST, so a missing osascript still takes
+        // the macOS gate; it passes on this clean config, and the planner's honest
+        // BackendUnavailable then reaches the caller verbatim rather than being
+        // pre-empted by a structural complaint.
+        let mut host = macos_gui_host(false);
+        host.available.osascript = None;
+        let mut c = Command::new();
+        c.args(["/usr/bin/id"]).elevation_auth(Auth::Gui);
+        match rewrite_with_host(&mut c, &host) {
+            Err(Error::Elevation { kind, detail }) => {
+                assert_eq!(kind, crate::error::ElevationErrorKind::BackendUnavailable);
+                assert!(detail.contains("osascript"), "{detail}");
+            }
+            other => panic!("expected BackendUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn macos_non_gui_auth_still_takes_the_posix_path() {
+        let mut c = Command::new();
+        c.args(["/usr/bin/id"]).elevation_auth(Auth::NonInteractive);
+        let rw = rewrite_with_host(&mut c, &macos_gui_host(false)).expect("sudo rewrite");
+        assert_eq!(rw.backend_path, Some(PathBuf::from("/usr/bin/sudo")));
     }
 }

--- a/src/elevation/windows.rs
+++ b/src/elevation/windows.rs
@@ -104,6 +104,7 @@ pub(super) fn detect() -> Host {
         has_tty: false, // Windows never prompts on a TTY — UAC is a GUI gate.
         available: BackendSet::default(),
         os: Os::Windows,
+        arg_max: None,
     }
 }
 
@@ -281,6 +282,9 @@ pub(crate) fn launch_runas_with_host(cmd: &mut Command, host: &Host) -> Result<R
         Transition::RunAsIs => return Ok(RunasOutcome::AlreadyElevated),
         Transition::Reject { error } => return Err(error),
         Transition::ElevatePosix { .. } => unreachable!("planner never yields ElevatePosix on a windows host"),
+        Transition::ElevateMacosGui { .. } => {
+            unreachable!("planner never yields ElevateMacosGui on a windows host")
+        }
         Transition::ElevateWindows { .. } => {}
     }
 

--- a/src/elevation/windows_tests.rs
+++ b/src/elevation/windows_tests.rs
@@ -92,6 +92,7 @@ fn win_host(elevated: bool) -> crate::elevation::plan::Host {
         has_tty: false,
         available: crate::elevation::plan::BackendSet::default(),
         os: crate::elevation::plan::Os::Windows,
+        arg_max: None,
     }
 }
 

--- a/src/elevation_tests.rs
+++ b/src/elevation_tests.rs
@@ -153,11 +153,25 @@ fn is_elevated_matches_effective_uid_ground_truth() {
     assert_eq!(super::is_elevated(), euid0, "is_elevated disagreed with geteuid()==0");
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn detect_reports_unix_os() {
     let h = super::plan::Host::detect();
     assert_eq!(h.os, super::plan::Os::Unix);
+}
+
+/// macOS must NOT report `Os::Unix`: the whole point of the split is that the
+/// planner can tell it apart, and detection is the only place that decision is made.
+#[cfg(target_os = "macos")]
+#[test]
+fn detect_reports_macos() {
+    let h = super::plan::Host::detect();
+    assert_eq!(h.os, super::plan::Os::MacOs);
+    assert!(
+        h.available.osascript.is_some(),
+        "a macOS host must resolve /usr/bin/osascript"
+    );
+    assert!(h.arg_max.is_some(), "kern.argmax must be readable on macOS");
 }
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ impl QuoteError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum QuoteErrorKind {
     #[error("unterminated single quote")]
     UnterminatedSingleQuote,
@@ -22,11 +23,19 @@ pub enum QuoteErrorKind {
     UnterminatedDoubleQuote,
     #[error("trailing backslash")]
     TrailingBackslash,
+    /// The text is not valid UTF-8, and the target grammar (AppleScript) is
+    /// defined over UTF-8 text rather than bytes.
+    #[error("not valid UTF-8")]
+    NonUtf8,
+    /// A character the target grammar cannot express at all.
+    #[error("character cannot be represented in this grammar")]
+    UnrepresentableChar,
 }
 
 /// Runtime elevation failures — "could work here but failed now" (contrast
 /// [`Error::Unsupported`], which is "can never work on this platform").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum ElevationErrorKind {
     /// The requested (or auto-detected) backend is not on PATH, or the resolved
     /// backend could not be executed.
@@ -49,6 +58,11 @@ pub enum ElevationErrorKind {
     /// manage it. Whether it was terminated is reported in the error `detail`.
     #[error("elevated child launched but could not be tracked")]
     Untracked,
+    /// The composed elevation command exceeded this host's exec argument budget
+    /// (`kern.argmax` on macOS). A property of THIS command on THIS host, not of
+    /// the platform: a shorter command, or a host with a larger budget, succeeds.
+    #[error("the elevation command is too long for this host")]
+    CommandTooLong,
 }
 
 /// The crate's top-level error type.

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -21,6 +21,24 @@ fn quote_error_kinds_have_distinct_messages() {
         "unterminated double quote"
     );
     assert_eq!(QuoteErrorKind::TrailingBackslash.to_string(), "trailing backslash");
+    assert_eq!(QuoteErrorKind::NonUtf8.to_string(), "not valid UTF-8");
+    assert_eq!(
+        QuoteErrorKind::UnrepresentableChar.to_string(),
+        "character cannot be represented in this grammar"
+    );
+    // The whole set, so a new variant colliding with an existing message fails here.
+    let all = [
+        QuoteErrorKind::UnterminatedSingleQuote,
+        QuoteErrorKind::UnterminatedDoubleQuote,
+        QuoteErrorKind::TrailingBackslash,
+        QuoteErrorKind::NonUtf8,
+        QuoteErrorKind::UnrepresentableChar,
+    ];
+    for (i, a) in all.iter().enumerate() {
+        for b in &all[i + 1..] {
+            assert_ne!(a.to_string(), b.to_string(), "{a:?} vs {b:?}");
+        }
+    }
 }
 
 #[test]
@@ -62,6 +80,14 @@ fn elevation_error_displays_kind_and_detail() {
 }
 
 #[test]
+fn command_too_long_names_the_host_not_the_platform() {
+    // The wording matters: this verdict is per-host and per-command, so it must not
+    // read like a permanent platform limitation.
+    let m = crate::error::ElevationErrorKind::CommandTooLong.to_string();
+    assert_eq!(m, "the elevation command is too long for this host");
+}
+
+#[test]
 fn elevation_error_kinds_have_distinct_messages() {
     use crate::error::ElevationErrorKind::*;
     let all = [
@@ -71,6 +97,7 @@ fn elevation_error_kinds_have_distinct_messages() {
         NoTty,
         Unkillable,
         Untracked,
+        CommandTooLong,
     ];
     for (i, a) in all.iter().enumerate() {
         for b in &all[i + 1..] {

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -1,5 +1,6 @@
-//! Argv quoting/splitting. POSIX operates on bytes; Windows on UTF-16 code units.
-//! Both are pure and unit-testable on any host.
+//! Argv quoting/splitting. POSIX operates on bytes; Windows on UTF-16 code units;
+//! AppleScript on UTF-8 text. All three are pure and unit-testable on any host.
 
+pub mod applescript;
 pub mod posix;
 pub mod windows;

--- a/src/quote/applescript.rs
+++ b/src/quote/applescript.rs
@@ -1,0 +1,43 @@
+//! AppleScript double-quoted string-literal escaping.
+//!
+//! The grammar (Apple TN2065, *do shell script in AppleScript*) is small: inside a
+//! `"…"` literal, `\"` is a quote and `\\` is a backslash, and `\n`/`\r`/`\t` are
+//! the three character escapes.
+//!
+//! AppleScript source is decoded as UTF-8, so this operates on text, not bytes;
+//! non-UTF-8 input is a typed error.
+
+use crate::error::{QuoteError, QuoteErrorKind};
+
+/// Escape `bytes` as the BODY of an AppleScript double-quoted string literal. The
+/// surrounding quotes are the caller's to add.
+///
+/// Only NUL is refused. It is the one byte with no representation anywhere on this
+/// path — it cannot appear in argv at all, since exec takes NUL-terminated strings.
+/// Every other control passes through raw: `\n` and `\r` are escaped above for a
+/// MEASURED reason (a raw newline ends an AppleScript statement), but nothing shows
+/// ESC/BEL/VT/FF/DEL failing inside a literal, and "no numeric escape exists" does
+/// not imply "no representation exists". Refusing them would refuse an
+/// ANSI-coloured argument that succeeds under sudo, pkexec and UAC, on an
+/// inference; `both_quoting_layers_survive_a_real_osascript_round_trip` drives them
+/// through real `osascript` instead.
+pub fn escape_literal(bytes: &[u8]) -> Result<String, QuoteError> {
+    let s = std::str::from_utf8(bytes).map_err(|e| QuoteError::new(e.valid_up_to(), QuoteErrorKind::NonUtf8))?;
+    let mut out = String::with_capacity(s.len() + 2);
+    for (pos, c) in s.char_indices() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str(r#"\""#),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            '\0' => return Err(QuoteError::new(pos, QuoteErrorKind::UnrepresentableChar)),
+            c => out.push(c),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+#[path = "applescript_tests.rs"]
+mod applescript_tests;

--- a/src/quote/applescript_tests.rs
+++ b/src/quote/applescript_tests.rs
@@ -1,0 +1,100 @@
+use super::escape_literal;
+use crate::error::QuoteErrorKind;
+
+/// An INDEPENDENT un-escaper, written from the AppleScript literal grammar
+/// (TN2065: `\"` is a quote, `\\` is a backslash; `\n`, `\r`, `\t` are the three
+/// character escapes), NOT from `escape_literal`. Panics on anything the grammar
+/// does not define, so a sloppy escaper cannot round-trip by accident.
+fn unescape_literal(s: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut it = s.bytes();
+    while let Some(b) = it.next() {
+        if b != b'\\' {
+            assert!(b != b'"', "a raw quote must never appear in a literal body");
+            assert!(b != b'\n' && b != b'\r', "LF/CR must always be escaped");
+            out.push(b);
+            continue;
+        }
+        match it.next().expect("a literal body never ends in a lone backslash") {
+            b'\\' => out.push(b'\\'),
+            b'"' => out.push(b'"'),
+            b'n' => out.push(b'\n'),
+            b'r' => out.push(b'\r'),
+            b't' => out.push(b'\t'),
+            other => panic!("undefined AppleScript escape \\{}", other as char),
+        }
+    }
+    out
+}
+
+#[test]
+fn tn2065_worked_examples() {
+    // Straight from TN2065: `a "quote" mark` and `a back\slash`.
+    assert_eq!(escape_literal(br#"a "quote" mark"#).unwrap(), r#"a \"quote\" mark"#);
+    assert_eq!(escape_literal(br"a back\slash").unwrap(), r"a back\\slash");
+}
+
+#[test]
+fn safe_text_is_returned_verbatim() {
+    assert_eq!(escape_literal(b"/usr/bin/id -u").unwrap(), "/usr/bin/id -u");
+    assert_eq!(escape_literal(b"").unwrap(), "");
+}
+
+#[test]
+fn control_characters_use_the_defined_escapes() {
+    assert_eq!(escape_literal(b"a\nb").unwrap(), r"a\nb");
+    assert_eq!(escape_literal(b"a\rb").unwrap(), r"a\rb");
+    assert_eq!(escape_literal(b"a\tb").unwrap(), r"a\tb");
+}
+
+#[test]
+fn round_trips_through_an_independent_unescaper() {
+    let cases: &[&[u8]] = &[
+        b"",
+        b"plain",
+        br#"he said "hi""#,
+        br"C:\not\a\path",
+        b"'single' \"double\" `backtick` $dollar",
+        b"newline\nand\ttab\rand\rcr",
+        b"\\\"\\\"\\\"",
+        "unicode: \u{e9}\u{4e2d}\u{1f600}".as_bytes(),
+        br#"'; rm -rf /; echo '"#,
+        br"trailing backslash\",
+    ];
+    for c in cases {
+        let escaped = escape_literal(c).unwrap_or_else(|e| panic!("{c:?}: {e}"));
+        assert_eq!(&unescape_literal(&escaped)[..], *c, "round-trip failed for {c:?}");
+    }
+}
+
+#[test]
+fn non_utf8_input_is_rejected_at_its_offset() {
+    let e = escape_literal(b"ok\xffbad").unwrap_err();
+    assert_eq!(e.kind, QuoteErrorKind::NonUtf8);
+    assert_eq!(e.pos, 2);
+}
+
+#[test]
+fn nul_is_rejected_not_dropped() {
+    // Dropping or substituting would silently change the command.
+    let e = escape_literal(b"a\0b").unwrap_err();
+    assert_eq!(e.kind, QuoteErrorKind::UnrepresentableChar);
+    assert_eq!(e.pos, 1);
+}
+
+#[test]
+fn other_controls_pass_through_raw_rather_than_being_refused_on_inference() {
+    // Verified against real osascript by
+    // `both_quoting_layers_survive_a_real_osascript_round_trip`; if that fails on
+    // macOS CI, the refusal comes back here with the evidence attached.
+    for bytes in [
+        b"a\x07b".as_slice(),
+        b"\x1b[0m".as_slice(),
+        b"a\x0bb".as_slice(),
+        b"a\x0cb".as_slice(),
+        b"a\x7fb".as_slice(),
+    ] {
+        let escaped = escape_literal(bytes).unwrap_or_else(|e| panic!("{bytes:?}: {e}"));
+        assert_eq!(&unescape_literal(&escaped)[..], bytes, "{bytes:?}");
+    }
+}

--- a/tests/elevation.rs
+++ b/tests/elevation.rs
@@ -1,3 +1,11 @@
+//! `COSCA_TEST_ELEVATION_GUI` gates the macOS graphical tier separately: unlike the
+//! POSIX tier, it raises an interactive authentication dialog that no CI runner can
+//! answer, so it is human-driven only. What CI DOES verify unattended lives in the
+//! unit suite (`elevation::macos`), where the crate's own composer is in scope: the
+//! two quoting layers driven through the real AppleScript parser and the real
+//! /bin/sh with the privilege clause removed, plus an `osacompile` parse of the
+//! unmodified elevated script.
+//!
 //! Live elevation tier — gated behind COSCA_TEST_ELEVATION (cgroup precedent):
 //! a TRUE no-op when the var is absent, and FAILS LOUDLY when set but elevation is
 //! unavailable. The pure tiers cover all logic unconditionally; only the privilege-gain
@@ -434,4 +442,37 @@ async fn async_windows_elevated_child_is_unkillable_and_drop_does_not_hang() {
         other => panic!("expected Unkillable or Ok, got {other:?}"),
     }
     drop(child); // must return promptly (non-blocking async teardown)
+}
+
+// GATED behind COSCA_TEST_ELEVATION_GUI: a TRUE no-op without it, and loud when set.
+// This is the ONLY test that raises the authentication dialog, so it can never run
+// unattended — a human must be at the keyboard to approve it. It is here so the path
+// is verifiable at all, not so CI can verify it.
+#[cfg(target_os = "macos")]
+#[test]
+fn gui_elevated_child_runs_as_root() {
+    // Already root means the planner short-circuits to RunAsIs and reports
+    // AlreadyElevated: osascript never runs, so the assertions below would fail on
+    // a defect that does not exist. Same guard the POSIX gated tests use.
+    if std::env::var_os("COSCA_TEST_ELEVATION_GUI").is_none() || cosca::elevation::is_elevated() {
+        return;
+    }
+    let mut c = cosca::Command::new();
+    c.args(["/usr/bin/id", "-u"])
+        .elevation_auth(cosca::elevation::Auth::Gui);
+    c.stdin(cosca::Stdio::null()).unwrap();
+    c.stdout(cosca::Stdio::pipe()).unwrap();
+    let mut child = c.spawn().expect("gui-elevated spawn");
+    let report = child.elevation().expect("an elevation report");
+    assert_eq!(report.via, cosca::ElevatedVia::MacosOsascript);
+    assert_eq!(report.stdio, cosca::ElevatedStdio::OsascriptRelay);
+    // NOT dropped or killed before this returns: killing the front-end early would
+    // leave the root payload running and its outcome unobservable.
+    let out = child.communicate(None).expect("communicate");
+    assert!(out.status.success(), "the elevated `id -u` failed: {out:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "0",
+        "the relayed stdout must show the elevated child ran as root"
+    );
 }


### PR DESCRIPTION
Closes #52.

`Auth::Gui` was reachable on Linux only. On macOS it returned `BackendUnavailable` ("forced backend Pkexec is not on PATH") — a verdict that reads as a fixable environment problem on a platform where pkexec will never exist — while `Auth::Interactive` returned `NoTty`, leaving a windowed macOS app with no elevation path at all.

## What changed

**The honest verdict (ships on its own).** The planner gains `Os::MacOs` alongside `Os::Unix` (kept generic — it covers the BSDs and illumos too, so naming it `Linux` would invite gating Linux-only behavior on it). `Backend::Pkexec` and `Backend::Run0` on macOS are now a platform-named `Unsupported` naming polkit and systemd, not a "not on PATH" that invites installing them. `sudo` and `doas` are deliberately not swept in — both really do run on macOS.

**The effect path.** `Auth::Gui` + `Backend::Auto` on macOS composes `osascript -e 'do shell script "…" with administrator privileges without altering line endings'`. A new always-compiled `src/elevation/macos.rs` holds the pure parts; `posix::rewrite_with_host` routes the new `Transition::ElevateMacosGui` into the existing `PosixRewrite`, so **neither `child/spawn.rs` nor `tokio/spawn.rs` changes**.

## Design points worth reviewing

- **Two quoting layers, never three.** argv → `/bin/sh` word-quoting → AppleScript literal body, then handed to `osascript` as one `-e` argv element through `std::process::Command`, so no shell ever parses it. Layer 2 is applied in exactly one place.
- **The gate is privilege-independent.** It keys on `plan::is_macos_gui_auto` (the request shape), never on `host.elevated` or the resolved transition — matching the invariant `structural_posix` documents. Keying on the transition would accept `.contain()` as root and reject it as a normal user.
- **Honest reporting.** New `ElevatedVia::MacosOsascript` and `ElevatedStdio::OsascriptRelay` spell out that the payload runs under `com.apple.security.authtrampoline` parented to `launchd`: `wait()` reports osascript's status, a cancelled dialog is a non-zero exit rather than a typed `AuthDeclined`, a non-zero exit discards the payload's stdout entirely, and `kill()` reaches only the front-end.
- **`kill_on_drop` is warned about, not refused.** `Command::default()` sets it `true` and offers no way to tell that from an explicit request, so refusing it would make the whole path unreachable. `build_rewrite` emits a `log::warn!` instead, so the default can never silently orphan a root process. The explicit/default distinction is #57.
- **Measured, not inferred.** `osascript(1)` documents no encoding for `-e`, but a documentation gap is not a behavior gap — non-ASCII passes through and a macOS CI test drives CJK, Cyrillic, Arabic, an NFC/NFD pair, astral-plane codepoints and mixed scripts through real `osascript`, comparing byte-exact hex. The same standard narrowed `escape_literal` to refusing NUL alone. `kern.argmax` is read via `sysctl` rather than hardcoded, and the "`with timeout` does not govern `do shell script`" claim now has its own test.

## Breaking

`ElevatedVia`, `QuoteErrorKind` and `ElevationErrorKind` gain `#[non_exhaustive]` plus new variants (`MacosOsascript`, `OsascriptRelay`, `NonUtf8`, `UnrepresentableChar`, `CommandTooLong`). Part of the batch-wide 0.2.0. `Cargo.toml` is deliberately untouched — release tooling owns the version.

## What CI verifies, and what it cannot

Unattended on macOS CI: both quoting layers driven through the **real** AppleScript parser and the **real** `/bin/sh` (the crate's own script with only the privilege clause stripped, assertion-checked), an `osacompile` parse of the unmodified elevated script, and the timeout measurement. The elevation itself needs a human at the keyboard — that test is gated behind `COSCA_TEST_ELEVATION_GUI` and is a true no-op without it. Nothing mocks the privilege escalation.

Developed on Windows, so the unix-only and macOS-only tests run first here.
