### PR TITLE
fix!: report an unassessed identity state instead of absence

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -94,9 +94,11 @@ impl Child {
         self.id
     }
 
-    /// Whether the child is still running — re-checked via its stable identity,
-    /// so a recycled pid never reads as alive.
-    pub fn is_alive(&self) -> bool {
+    /// Whether the child is still running — re-checked via its stable identity, so a
+    /// recycled pid never reads as alive. [`crate::identity::Liveness::Unknown`] when the OS
+    /// refuses the query: an unelevated parent cannot open a UAC-elevated child by pid, and
+    /// the honest answer there is not "dead".
+    pub fn is_alive(&self) -> crate::identity::Liveness {
         self.id.is_alive()
     }
 

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -36,8 +36,7 @@ fn graceful_tree_watch_error_still_sweeps_and_reaps() {
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
     #[cfg(unix)]
-    assert!(
-        !id.exists(),
+    assert_eq!(id.exists(), crate::identity::Existence::Gone,
         "root must be swept AND reaped despite the watch error (a zombie would still exist)"
     );
     #[cfg(windows)]
@@ -72,8 +71,7 @@ fn graceful_lone_watch_error_still_escalates_and_reaps() {
         "seam not consumed — the watch did not run on this thread"
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
-    assert!(
-        !id.exists(),
+    assert_eq!(id.exists(), crate::identity::Existence::Gone,
         "child must be killed AND reaped despite the watch error (a zombie would still exist)"
     );
     let status = child.wait().expect("cached status — already reaped by the graceful op");

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -36,7 +36,9 @@ fn graceful_tree_watch_error_still_sweeps_and_reaps() {
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
     #[cfg(unix)]
-    assert_eq!(id.exists(), crate::identity::Existence::Gone,
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
         "root must be swept AND reaped despite the watch error (a zombie would still exist)"
     );
     #[cfg(windows)]
@@ -71,7 +73,9 @@ fn graceful_lone_watch_error_still_escalates_and_reaps() {
         "seam not consumed — the watch did not run on this thread"
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
-    assert_eq!(id.exists(), crate::identity::Existence::Gone,
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
         "child must be killed AND reaped despite the watch error (a zombie would still exist)"
     );
     let status = child.wait().expect("cached status — already reaped by the graceful op");

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -230,17 +230,24 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
     // Unix its /proc entry persists; on Windows the std Child pins the process
     // handle so the pid cannot be reused — so this read is race-free.
     let id = match resolve_identity(child.id()) {
-        Some(id) => id,
-        // Same teardown (incl. the safe-to-discard `kill()`) as the attach arm above — never leak
-        // the spawned child on a failed read.
-        None => {
+        crate::identity::Resolved::Found(id) => id,
+        // Same teardown for both arms (never leak the spawned child), different diagnosis:
+        // an OS refusal is not a vanish. The teardown itself is unchanged from the
+        // attach-failure arm above, whose invariant holds here too - for a child we own and
+        // have not reaped, `kill` can only fail because it already exited, and `wait()` then
+        // reaps at once, never an unbounded block.
+        other => {
             let _ = child.kill();
-            if let Err(_e) = child.wait() {
-                debug_assert!(false, "sync spawn teardown failed to reap child: {_e}");
+            if let Err(e) = child.wait() {
+                // warn first: `debug_assert` is compiled out in release, and a swallowed
+                // reap failure would otherwise leave no trace at all there.
+                log::warn!("spawn teardown failed to reap pid {}: {e}", child.id());
+                debug_assert!(false, "sync spawn teardown failed to reap child: {e}");
             }
-            return Err(Error::Io(std::io::Error::other(
-                "spawned child vanished before its identity could be read",
-            )));
+            // The distinction must survive as a VARIANT, not as prose: a supervisor matching
+            // on `Unassessable` to retry elevated would otherwise see an I/O failure and
+            // treat a live, merely-unreadable child as a startup failure.
+            return Err(spawn_identity_error(other));
         }
     };
     // Adopt AFTER the identity read (and after the containment resume) so
@@ -624,15 +631,31 @@ fn inherit_end(slot: Fd) -> Result<ChildEnd, Error> {
     }
 }
 
+/// The error for a spawn whose child could not be identified. `Gone` is an absence;
+/// `Unknown` is an OS refusal about a child that may be running fine - never report the
+/// second as the first. Mirrors `containment::dispatch::resolve_root_id`.
+pub(crate) fn spawn_identity_error(outcome: crate::identity::Resolved<ProcessId>) -> Error {
+    match outcome {
+        crate::identity::Resolved::Unknown => Error::Unassessable {
+            detail: "the OS refused to report the spawned child's identity".into(),
+            source: None,
+        },
+        _ => Error::Io(std::io::Error::other(
+            "spawned child vanished before its identity could be read",
+        )),
+    }
+}
+
 /// Read the spawned child's stable identity. A test-only fault seam (`fault`) can force the
 /// vanished branch, exercising either spawn path's error-teardown arm deterministically.
-pub(crate) fn resolve_identity(pid: u32) -> Option<ProcessId> {
+pub(crate) fn resolve_identity(pid: u32) -> crate::identity::Resolved<ProcessId> {
     #[cfg(test)]
     if fault::force_identity_vanished() {
         // Capture the child's real identity for the test to prove it was reaped, then simulate a
         // vanish so `spawn` takes the teardown arm.
         fault::capture(ProcessId::of(pid));
-        return None;
+        // The seam simulates a VANISH, not a refusal.
+        return crate::identity::Resolved::Gone;
     }
     ProcessId::of(pid)
 }
@@ -674,7 +697,7 @@ pub(crate) mod fault {
     thread_local! {
         static FORCE_VANISH: Cell<bool> = const { Cell::new(false) };
         static FORCE_ATTACH_FAIL: Cell<bool> = const { Cell::new(false) };
-        static CAPTURED: Cell<Option<ProcessId>> = const { Cell::new(None) };
+        static CAPTURED: Cell<Option<crate::identity::Resolved<ProcessId>>> = const { Cell::new(None) };
     }
 
     pub(crate) fn set_force_identity_vanished(on: bool) {
@@ -689,10 +712,10 @@ pub(crate) mod fault {
     pub(crate) fn force_attach_failure() -> bool {
         FORCE_ATTACH_FAIL.with(|f| f.get())
     }
-    pub(crate) fn capture(id: Option<ProcessId>) {
-        CAPTURED.with(|c| c.set(id));
+    pub(crate) fn capture(id: crate::identity::Resolved<ProcessId>) {
+        CAPTURED.with(|c| c.set(Some(id)));
     }
-    pub(crate) fn take_captured() -> Option<ProcessId> {
+    pub(crate) fn take_captured() -> Option<crate::identity::Resolved<ProcessId>> {
         CAPTURED.with(|c| c.take())
     }
 
@@ -703,15 +726,29 @@ pub(crate) mod fault {
     /// recycled pid never false-fails. Windows has no zombies, and its process-object cleanup is not
     /// synchronous with `wait()`, so there we assert only that the child is dead (`!is_alive()`, also
     /// reuse-immune via the start token).
-    pub(crate) fn assert_child_reaped(captured: ProcessId) {
+    pub(crate) fn assert_child_reaped(captured: crate::identity::Resolved<ProcessId>) {
+        let crate::identity::Resolved::Found(captured) = captured else {
+            panic!("the seam must capture a resolved identity, got {captured:?}");
+        };
         #[cfg(unix)]
-        assert_ne!(
-            ProcessId::of(captured.pid()),
-            Some(captured),
-            "a failed spawn must fully reap its child (no lingering zombie at its identity)"
-        );
+        match ProcessId::of(captured.pid()) {
+            crate::identity::Resolved::Found(id) => assert_ne!(
+                id, captured,
+                "a failed spawn must fully reap its child (no lingering zombie at its identity)"
+            ),
+            crate::identity::Resolved::Gone => {}
+            // NOT a panic: once the child is reaped its pid is free host-wide, so a recycle
+            // between the failed `/proc` read and the `kill(pid, 0)` probe legitimately
+            // yields Unknown. What matters is only that the pid no longer resolves to OUR
+            // identity, and an unreadable stranger is not our child either.
+            crate::identity::Resolved::Unknown => {}
+        }
         #[cfg(windows)]
-        assert!(!captured.is_alive(), "a failed spawn must leave the child dead");
+        assert_eq!(
+            captured.is_alive(),
+            crate::identity::Liveness::Dead,
+            "a failed spawn must leave the child dead"
+        );
     }
 }
 

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -164,12 +164,10 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
         }
     };
     let id = match resolve_identity(pid) {
-        Some(id) => id,
-        None => {
+        crate::identity::Resolved::Found(id) => id,
+        other => {
             raw_spawn_teardown(proc, pid);
-            return Err(Error::Io(std::io::Error::other(
-                "spawned child vanished before its identity could be read",
-            )));
+            return Err(crate::child::spawn::spawn_identity_error(other));
         }
     };
 
@@ -236,9 +234,17 @@ pub(crate) fn spawn_step(
 /// raw backend shares the identical error-teardown.
 pub(crate) fn raw_spawn_teardown(proc: OwnedHandle, pid: u32) {
     let rc = RawChild::new(proc, pid);
-    let _ = rc.kill();
-    if let Err(_e) = rc.wait() {
-        debug_assert!(false, "raw spawn teardown failed to reap child: {_e}");
+    // Windows only, so the std path-s invariant does NOT carry: there is no zombie to reap
+    // and `rc.wait()` is a bare `WaitForSingleObject(handle, INFINITE)`. If the kill failed,
+    // nothing asked the child to exit and that wait would park forever - a logged, leaked
+    // child is strictly better.
+    if let Err(e) = rc.kill() {
+        log::warn!("raw spawn teardown: kill of pid {pid} failed: {e}; not waiting");
+        return;
+    }
+    if let Err(e) = rc.wait() {
+        log::warn!("raw spawn teardown failed to reap pid {pid}: {e}");
+        debug_assert!(false, "raw spawn teardown failed to reap child: {e}");
     }
 }
 

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -142,9 +142,16 @@ pub(crate) fn is_nested(marker_present: bool) -> bool {
 /// un-reaped, and on Windows still suspended, hence resolvable).
 #[cfg(any(unix, windows))]
 fn resolve_root_id(pid: u32) -> Result<crate::identity::ProcessId, Error> {
-    crate::identity::ProcessId::of(pid).ok_or_else(|| Error::Containment {
-        detail: "tree-walk root vanished before its identity could be read".into(),
-    })
+    match crate::identity::ProcessId::of(pid) {
+        crate::identity::Resolved::Found(id) => Ok(id),
+        crate::identity::Resolved::Gone => Err(Error::Containment {
+            detail: "tree-walk root vanished before its identity could be read".into(),
+        }),
+        crate::identity::Resolved::Unknown => Err(Error::Unassessable {
+            detail: format!("tree-walk root pid {pid} identity could not be read"),
+            source: None,
+        }),
+    }
 }
 
 /// Which Unix setup action to apply to a root `Command` for a given mode.

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -187,3 +187,25 @@ async fn async_kill_tree_backstop_is_load_bearing() {
         "the handle backstop must be what killed the root, got {status:?}"
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn resolve_root_id_distinguishes_a_denied_pid_from_a_vanished_one() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    assert!(child.is_running(), "precondition: the subject must be live");
+
+    let Err(crate::error::Error::Unassessable { detail, .. }) = super::resolve_root_id(child.pid()) else {
+        panic!("a pid we may not query must not resolve to a root identity");
+    };
+    assert!(
+        detail.contains("identity could not be read"),
+        "denial must not read as vanishing: {detail}"
+    );
+
+    // Contrast: a pid no process holds.
+    let Err(crate::error::Error::Containment { detail }) = super::resolve_root_id(0xFFFF_FFF0) else {
+        panic!("a nonexistent pid must not resolve");
+    };
+    assert!(detail.contains("vanished"), "absence must not read as denial: {detail}");
+}

--- a/src/containment/treewalk.rs
+++ b/src/containment/treewalk.rs
@@ -222,7 +222,10 @@ pub(crate) fn kill_by_identity(id: ProcessId, signal: Signal) -> KillOutcome {
     match ProcessId::of(id.pid()) {
         Resolved::Found(live) if live == id => {}
         Resolved::Found(_) | Resolved::Gone => {
-            log::debug!("treewalk: skipping pid {pid} - identity changed since the snapshot", pid = id.pid());
+            log::debug!(
+                "treewalk: skipping pid {pid} - identity changed since the snapshot",
+                pid = id.pid()
+            );
             return KillOutcome::AlreadyGone;
         }
         Resolved::Unknown => {
@@ -236,7 +239,10 @@ pub(crate) fn kill_by_identity(id: ProcessId, signal: Signal) -> KillOutcome {
     // `nix::unistd::Pid::from_raw` is infallible and accepts 0, and `kill(0, sig)` signals
     // the CALLER-S ENTIRE PROCESS GROUP. Use the same total guard the `sig 0` probe uses.
     let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
-        log::warn!("treewalk: pid {} is not a single-process signal target - not signaled", id.pid());
+        log::warn!(
+            "treewalk: pid {} is not a single-process signal target - not signaled",
+            id.pid()
+        );
         return KillOutcome::NotAttempted;
     };
     match kill(Pid::from_raw(target), signal) {
@@ -284,7 +290,10 @@ pub(crate) fn kill_by_identity(id: ProcessId) -> KillOutcome {
             }
         }
         HandleIdentity::Different => {
-            log::debug!("treewalk: skipping pid {} - identity changed since the snapshot", id.pid());
+            log::debug!(
+                "treewalk: skipping pid {} - identity changed since the snapshot",
+                id.pid()
+            );
             KillOutcome::AlreadyGone
         }
         HandleIdentity::Unreadable(e) => {

--- a/src/containment/treewalk.rs
+++ b/src/containment/treewalk.rs
@@ -41,7 +41,38 @@
 //!   strict `>`. Its 100 ns FILETIME clock makes a same-tick *genuine* child
 //!   indistinguishable from impossible, so strict `>` loses nothing there.
 
-use crate::identity::{ProcessId, RawPid};
+use crate::identity::{ProcessId, RawPid, Resolved};
+
+/// What one identity-verified kill attempt achieved. `AlreadyGone` and `NotAttempted` are
+/// both "no signal was delivered", but only the first means there was nothing to deliver one
+/// to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KillOutcome {
+    /// The signal reached the verified identity.
+    Terminated,
+    /// The pid holds no process, or holds a different one - nothing to kill.
+    AlreadyGone,
+    /// A live-or-unassessable process we did not signal. The only outcome that can leave a
+    /// process running.
+    NotAttempted,
+}
+
+/// The tree-walk resolver. A pid we may not query is dropped from the walk exactly like a
+/// pid that is gone - the walk cannot kill what it cannot verify - but the two are logged
+/// apart, because "denied" is an operational signal (run elevated) and "gone" is not.
+pub(crate) fn resolve_or_drop(pid: RawPid) -> Option<ProcessId> {
+    match ProcessId::of(pid) {
+        Resolved::Found(id) => Some(id),
+        Resolved::Gone => None,
+        Resolved::Unknown => {
+            // The pid is IN the message on purpose: `log_capture` is one process-global
+            // buffer shared by every parallel test, so a test asserting on this line must be
+            // able to pin it to its own fixture rather than to any concurrent teardown.
+            log::warn!("treewalk: pid {pid} could not be queried (access denied?) - dropped from the walk");
+            None
+        }
+    }
+}
 
 #[cfg(unix)]
 use nix::sys::signal::Signal;
@@ -140,7 +171,7 @@ pub(crate) fn descendants_with(
 /// Live descendants of `root`: the pure filter wired to the host's
 /// `ProcessId::of` resolver and per-OS `ALLOW_EQUAL_TOKEN` rule.
 pub(crate) fn descendants(root: ProcessId, parents: &[(RawPid, RawPid)]) -> Vec<ProcessId> {
-    descendants_with(root, parents, ALLOW_EQUAL_TOKEN, ProcessId::of)
+    descendants_with(root, parents, ALLOW_EQUAL_TOKEN, resolve_or_drop)
 }
 
 /// Pure one-level child filter (host-testable): keep each pid whose ppid == the parent's
@@ -177,33 +208,45 @@ pub(crate) fn children_of_with(
 /// Live one-level children of `parent`: the pure filter wired to `ProcessId::of` and the
 /// per-OS `ALLOW_EQUAL_TOKEN` rule.
 pub(crate) fn children_of(parent: ProcessId, parents: &[(RawPid, RawPid)]) -> Vec<ProcessId> {
-    children_of_with(parent, parents, ALLOW_EQUAL_TOKEN, ProcessId::of)
+    children_of_with(parent, parents, ALLOW_EQUAL_TOKEN, resolve_or_drop)
 }
 
 /// Kill `id` only if the pid STILL resolves to that exact identity — never a
 /// recycled pid. Already-gone (`None`, or `ESRCH`) is success. Best-effort.
 #[cfg(unix)]
-pub(crate) fn kill_by_identity(id: ProcessId, signal: Signal) {
+pub(crate) fn kill_by_identity(id: ProcessId, signal: Signal) -> KillOutcome {
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
-    // Re-verify identity at the instant of the kill: if the pid was recycled
-    // since the snapshot, `of` returns a different (or no) identity and we skip.
-    if ProcessId::of(id.pid()) != Some(id) {
-        log::debug!(
-            "treewalk: skipping pid {pid} — identity changed since the snapshot",
-            pid = id.pid()
-        );
-        return;
+    // Re-verify identity at the instant of the kill. Three outcomes, not two: a denied
+    // re-verify is NOT a confirmed change, and must not be logged as one.
+    match ProcessId::of(id.pid()) {
+        Resolved::Found(live) if live == id => {}
+        Resolved::Found(_) | Resolved::Gone => {
+            log::debug!("treewalk: skipping pid {pid} - identity changed since the snapshot", pid = id.pid());
+            return KillOutcome::AlreadyGone;
+        }
+        Resolved::Unknown => {
+            log::warn!(
+                "treewalk: pid {pid} could not be queried (access denied?) - not signaled, left running",
+                pid = id.pid()
+            );
+            return KillOutcome::NotAttempted;
+        }
     }
-    debug_assert!(
-        id.pid() <= i32::MAX as u32,
-        "pid {} exceeds i32::MAX; signal target cast would truncate",
-        id.pid()
-    );
-    match kill(Pid::from_raw(id.pid() as i32), signal) {
-        Ok(()) => {}
-        Err(nix::errno::Errno::ESRCH) => {} // already gone between re-verify and kill
-        Err(_) => {}                        // best-effort (EPERM etc.): nothing actionable to surface here
+    // `nix::unistd::Pid::from_raw` is infallible and accepts 0, and `kill(0, sig)` signals
+    // the CALLER-S ENTIRE PROCESS GROUP. Use the same total guard the `sig 0` probe uses.
+    let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
+        log::warn!("treewalk: pid {} is not a single-process signal target - not signaled", id.pid());
+        return KillOutcome::NotAttempted;
+    };
+    match kill(Pid::from_raw(target), signal) {
+        Ok(()) => KillOutcome::Terminated,
+        // Exited between the re-verify and the signal - nothing was left to kill.
+        Err(nix::errno::Errno::ESRCH) => KillOutcome::AlreadyGone,
+        Err(e) => {
+            log::warn!("treewalk: kill(pid {}, {signal:?}) failed: {e}", id.pid());
+            KillOutcome::NotAttempted
+        }
     }
 }
 
@@ -211,29 +254,49 @@ pub(crate) fn kill_by_identity(id: ProcessId, signal: Signal) {
 /// Opens the process for terminate rights and calls `TerminateProcess`. Already
 /// gone (unresolvable / unopenable) is success. Best-effort.
 #[cfg(windows)]
-pub(crate) fn kill_by_identity(id: ProcessId) {
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+pub(crate) fn kill_by_identity(id: ProcessId) -> KillOutcome {
+    use windows::Win32::System::Threading::{TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE};
 
-    // Re-verify identity against the live pid before opening it for terminate.
-    if ProcessId::of(id.pid()) != Some(id) {
-        log::debug!(
-            "treewalk: skipping pid {pid} — identity changed since the snapshot",
-            pid = id.pid()
-        );
-        return;
-    }
-    // SAFETY: OpenProcess tolerates an invalid/dead pid (returns Err); the handle
-    // is closed before return. We re-verified identity just above, so the pid is
-    // (was) ours; the worst case under a same-instant recycle is a no-op Err.
-    unsafe {
-        let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, id.pid()) else {
-            return; // gone or unopenable => already-dead is success
-        };
-        // best-effort (ERROR_ACCESS_DENIED etc.): nothing actionable to surface here
-        let _ = TerminateProcess(handle, 1);
-        let _ = CloseHandle(handle);
-    }
+    use crate::identity::{windows_close, windows_open_classified, HandleIdentity, Opened};
+
+    // Open for terminate AND query, so the SAME held handle both pins the kernel object
+    // (pid-reuse-safe) and lets us re-verify identity before terminating, race-free.
+    let handle = match windows_open_classified(id.pid(), PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION) {
+        Opened::Found(h) => h,
+        Opened::Gone => return KillOutcome::AlreadyGone,
+        Opened::Denied(e) => {
+            log::warn!(
+                "treewalk: pid {} could not be queried (access denied?) - not opened to terminate ({e}), left running",
+                id.pid()
+            );
+            return KillOutcome::NotAttempted;
+        }
+    };
+    let outcome = match crate::identity::windows_handle_identity(handle, id) {
+        HandleIdentity::Same => {
+            // SAFETY: `handle` is live and pins the verified process.
+            match unsafe { TerminateProcess(handle, 1) } {
+                Ok(()) => KillOutcome::Terminated,
+                Err(e) => {
+                    log::warn!("treewalk: TerminateProcess(pid {}) failed: {e}", id.pid());
+                    KillOutcome::NotAttempted
+                }
+            }
+        }
+        HandleIdentity::Different => {
+            log::debug!("treewalk: skipping pid {} - identity changed since the snapshot", id.pid());
+            KillOutcome::AlreadyGone
+        }
+        HandleIdentity::Unreadable(e) => {
+            log::warn!(
+                "treewalk: pid {} opened but its identity could not be read ({e}) - not terminated",
+                id.pid()
+            );
+            KillOutcome::NotAttempted
+        }
+    };
+    windows_close(handle);
+    outcome
 }
 
 /// Hard-kill the tree rooted at `root` by identity: snapshot once, compute
@@ -250,19 +313,19 @@ pub(crate) fn hard_kill(root: ProcessId) {
     #[cfg(unix)]
     {
         if !skip_root {
-            kill_by_identity(root, Signal::SIGKILL);
+            let _ = kill_by_identity(root, Signal::SIGKILL);
         }
         for id in descendants {
-            kill_by_identity(id, Signal::SIGKILL);
+            let _ = kill_by_identity(id, Signal::SIGKILL);
         }
     }
     #[cfg(windows)]
     {
         if !skip_root {
-            kill_by_identity(root);
+            let _ = kill_by_identity(root);
         }
         for id in descendants {
-            kill_by_identity(id);
+            let _ = kill_by_identity(id);
         }
     }
     #[cfg(not(any(unix, windows)))]
@@ -308,9 +371,9 @@ pub(crate) fn terminate(root: ProcessId) -> Result<(), crate::error::Error> {
     {
         let parents = crate::containment::enumerate::process_parents();
         let descendants = descendants(root, &parents);
-        kill_by_identity(root, Signal::SIGTERM);
+        let _ = kill_by_identity(root, Signal::SIGTERM);
         for id in descendants {
-            kill_by_identity(id, Signal::SIGTERM);
+            let _ = kill_by_identity(id, Signal::SIGTERM);
         }
         Ok(())
     }

--- a/src/containment/treewalk_tests.rs
+++ b/src/containment/treewalk_tests.rs
@@ -213,3 +213,66 @@ fn children_of_duplicate_edge_yields_pid_once() {
         "duplicate edge collapses to a single child"
     );
 }
+
+/// `resolve_or_drop` is a named discard site: an access-denied descendant must be dropped
+/// from the walk AND leave a warn behind, never be silently folded in with a gone pid.
+#[cfg(windows)]
+#[test]
+fn resolve_or_drop_drops_an_access_denied_pid_and_warns() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    crate::log_capture::install();
+    let denied = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    assert!(denied.is_running(), "precondition: the subject must be live");
+    let mark = crate::log_capture::mark();
+    assert!(
+        super::resolve_or_drop(denied.pid()).is_none(),
+        "the walk cannot keep what it cannot verify"
+    );
+    assert!(crate::log_capture::contains_since(
+        mark,
+        &format!("treewalk: pid {} could not be queried", denied.pid())
+    ));
+    assert!(denied.is_running(), "and dropping it must not have touched it");
+}
+
+/// `kill_by_identity`-s pre-open Denied arm - the outcome that can leave a process running.
+#[cfg(windows)]
+#[test]
+fn kill_by_identity_reports_not_attempted_when_the_open_is_denied() {
+    let child = crate::identity::windows_fixture::spawn_unkillable();
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(super::kill_by_identity(id), super::KillOutcome::NotAttempted);
+    assert!(child.is_running(), "a denied open must leave the process running");
+}
+
+/// `kill_by_identity` must terminate only the process whose START TOKEN matches. A stale
+/// identity names a recycled pid, and killing it would kill a stranger.
+#[cfg(windows)]
+#[test]
+fn kill_by_identity_spares_a_stale_identity_and_kills_a_matching_one() {
+    use windows::Win32::System::Threading::PROCESS_QUERY_LIMITED_INFORMATION;
+    // The ACE must grant QUERY_LIMITED as well as TERMINATE: kill_by_identity opens for
+    // both, and a combined-mask OpenProcess fails entirely if ANY requested bit is ungranted.
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    let real = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    let stale = crate::identity::ProcessId::from_parts_for_test(real.pid(), real.start_token_raw() ^ 1);
+
+    assert_eq!(
+        super::kill_by_identity(stale),
+        super::KillOutcome::AlreadyGone,
+        "a stale identity names a process that is gone - nothing to terminate"
+    );
+    assert!(child.is_running(), "a stale identity must never terminate the pid-s occupant");
+
+    assert_eq!(
+        super::kill_by_identity(real),
+        super::KillOutcome::Terminated,
+        "a matching identity must reach TerminateProcess - otherwise the wait below is unbounded"
+    );
+    // Bounded by the exit kill_by_identity just reported it requested.
+    child.await_exit();
+    assert!(!child.is_running(), "a matching identity must terminate the process");
+}

--- a/src/containment/treewalk_tests.rs
+++ b/src/containment/treewalk_tests.rs
@@ -265,7 +265,10 @@ fn kill_by_identity_spares_a_stale_identity_and_kills_a_matching_one() {
         super::KillOutcome::AlreadyGone,
         "a stale identity names a process that is gone - nothing to terminate"
     );
-    assert!(child.is_running(), "a stale identity must never terminate the pid-s occupant");
+    assert!(
+        child.is_running(),
+        "a stale identity must never terminate the pid-s occupant"
+    );
 
     assert_eq!(
         super::kill_by_identity(real),

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,10 @@ pub enum ElevationErrorKind {
 }
 
 /// The crate's top-level error type.
+///
+/// `#[non_exhaustive]`: the crate is still growing failure modes, so callers carry a
+/// wildcard arm rather than have each new variant break them.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("argument parsing failed: {0}")]
@@ -85,6 +89,19 @@ pub enum Error {
     /// Privilege elevation could not be completed at runtime.
     #[error("elevation failed ({kind}): {detail}")]
     Elevation { kind: ElevationErrorKind, detail: String },
+    /// The OS refused to establish whether the target process exists or is running, so the
+    /// operation was not performed. Distinct from a failure of the operation: nothing is
+    /// known to have gone wrong with the target — the caller was not allowed to look.
+    /// Typically an unprivileged caller querying a service, or a parent that cannot open
+    /// its own elevated child. Also covers the crate's own refusal to act on a target it
+    /// cannot address safely — a pid that names a process *group* rather than a single
+    /// process — where nothing was asked of the OS at all; those carry no `source`.
+    #[error("could not determine the target process's state: {detail}")]
+    Unassessable {
+        detail: String,
+        #[source]
+        source: Option<std::io::Error>,
+    },
 }
 
 #[cfg(test)]

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -139,7 +139,10 @@ fn unassessable_reads_as_a_refusal_not_a_failure() {
         source: Some(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
     };
     let s = e.to_string();
-    assert!(s.contains("could not determine"), "must not read as a failure of the target: {s}");
+    assert!(
+        s.contains("could not determine"),
+        "must not read as a failure of the target: {s}"
+    );
     assert!(s.contains("pid 4 could not be opened"), "detail must survive: {s}");
     // The OS cause stays reachable rather than flattened into prose.
     assert!(std::error::Error::source(&e).is_some(), "source is preserved");

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -131,3 +131,25 @@ fn unkillable_message_is_about_the_failed_signal_not_the_childs_fate() {
         "{s}"
     );
 }
+
+#[test]
+fn unassessable_reads_as_a_refusal_not_a_failure() {
+    let e = crate::error::Error::Unassessable {
+        detail: "pid 4 could not be opened".into(),
+        source: Some(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+    };
+    let s = e.to_string();
+    assert!(s.contains("could not determine"), "must not read as a failure of the target: {s}");
+    assert!(s.contains("pid 4 could not be opened"), "detail must survive: {s}");
+    // The OS cause stays reachable rather than flattened into prose.
+    assert!(std::error::Error::source(&e).is_some(), "source is preserved");
+}
+
+#[test]
+fn unassessable_carries_no_source_when_there_is_no_os_error() {
+    let e = crate::error::Error::Unassessable {
+        detail: "identity could not be confirmed".into(),
+        source: None,
+    };
+    assert!(std::error::Error::source(&e).is_none());
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -12,12 +12,21 @@
 //! `Eq`/`Hash`. The human-facing wall-clock lives in `created_at()`,
 //! allowed to drift and never used for identity.
 
+pub(crate) mod probe;
 pub(crate) mod stat_parse;
+
+#[path = "identity/state.rs"]
+mod state;
+pub use state::{Existence, Liveness, Resolved};
 
 #[cfg_attr(windows, path = "identity/windows.rs")]
 #[cfg_attr(target_os = "linux", path = "identity/linux.rs")]
 #[cfg_attr(target_os = "macos", path = "identity/macos.rs")]
 mod backend;
+
+#[cfg(all(windows, test))]
+#[path = "identity/windows_fixture.rs"]
+pub(crate) mod windows_fixture;
 
 #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 compile_error!("cosca::identity is implemented only for Windows, Linux, and macOS");
@@ -63,11 +72,11 @@ impl ProcessId {
         self.start.raw()
     }
 
-    /// Resolve the live identity of `pid`, or `None` if no such process is
-    /// currently resolvable.
-    pub fn of(pid: RawPid) -> Option<ProcessId> {
-        let start = backend::start_token(pid)?;
-        Some(ProcessId { pid, start })
+    /// Resolve the live identity of `pid`. [`Resolved::Gone`] means the OS reports no such
+    /// process; [`Resolved::Unknown`] means it refused the question (typically an
+    /// unprivileged caller querying a service) — the process may well be running.
+    pub fn of(pid: RawPid) -> Resolved<ProcessId> {
+        backend::start_token(pid).map(|start| ProcessId { pid, start })
     }
 
     /// Test-only constructor from raw parts, so sibling modules can build
@@ -80,26 +89,47 @@ impl ProcessId {
         }
     }
 
-    /// This process's own identity.
+    /// This process's own identity. Windows reads the current-process pseudo-handle, which
+    /// performs no access check at all; Unix reads the caller's own entry by pid, which no
+    /// `hidepid` mount or sandbox policy hides from the task itself. Either way it is
+    /// resolvable even for a process whose own DACL would deny a foreign by-pid open.
+    ///
+    /// # Panics
+    /// If the process cannot read its own start token: on Linux, if `/proc` is not mounted
+    /// or its own `stat` record has no parseable `starttime` (both hard requirements of that
+    /// backend); on Windows and macOS, if a self-directed `GetProcessTimes` / `proc_pidinfo`
+    /// fails, which has no documented cause. Infallible by design — every caller, including
+    /// `Process::current()`, relies on it.
     pub fn current() -> ProcessId {
-        let pid = std::process::id();
-        ProcessId::of(pid).expect("the current process always has a resolvable identity")
+        let start = backend::current_token()
+            .found()
+            .expect("a process must be able to read its own start token (Linux: /proc must be mounted)");
+        ProcessId {
+            pid: std::process::id(),
+            start,
+        }
     }
 
     /// Whether a process with this exact identity is still *resolvable* (the
-    /// zombie-inclusive sense, matching psutil's `is_running`). True for a not-yet-reaped
-    /// zombie on every platform: Linux (`/proc` persists), macOS (`sysctl KERN_PROC`
-    /// resolves zombies), and Windows (during the post-exit handle window). For
-    /// "is it still running?", use [`ProcessId::is_alive`].
-    pub fn exists(&self) -> bool {
-        backend::start_token(self.pid) == Some(self.start)
+    /// zombie-inclusive sense, matching psutil's `is_running`). [`Existence::Present`] for a
+    /// not-yet-reaped zombie on every platform: Linux (`/proc` persists), macOS (`sysctl
+    /// KERN_PROC` resolves zombies), and Windows (during the post-exit handle window).
+    /// [`Existence::Unknown`] when the OS refuses the query — never `Gone`. For "is it still
+    /// running?", use [`ProcessId::is_alive`].
+    pub fn exists(&self) -> Existence {
+        match backend::start_token(self.pid) {
+            Resolved::Found(t) if t == self.start => Existence::Present,
+            Resolved::Found(_) | Resolved::Gone => Existence::Gone,
+            Resolved::Unknown => Existence::Unknown,
+        }
     }
 
-    /// Whether the process is currently *running* (has not exited). Authoritative
-    /// and synchronously correct the instant the process exits — on Windows via
-    /// the handle's signaled state, on Unix via process state / `/proc`
-    /// presence. A reused PID (different start token) is never alive.
-    pub fn is_alive(&self) -> bool {
+    /// Whether the process is currently *running* (has not exited). Authoritative and
+    /// synchronously correct the instant the process exits — on Windows via the handle's
+    /// signaled state, on Unix via process state / `/proc` presence. A reused PID (different
+    /// start token) is never alive. [`Liveness::Unknown`] when the OS refuses the query, or
+    /// answers ambiguously — never `Dead` on a process we could not assess.
+    pub fn is_alive(&self) -> Liveness {
         backend::is_running(self.pid, self.start)
     }
 
@@ -110,13 +140,31 @@ impl ProcessId {
     }
 }
 
-/// Re-verify identity on an ALREADY-OPEN Windows handle: does its creation token
-/// match `id`'s? The held handle pins the kernel object, so this is pid-reuse-safe
-/// (unlike re-resolving by raw pid). Reuses the backend FILETIME read — no duplicate
-/// packing.
 #[cfg(windows)]
-pub(crate) fn windows_handle_is(handle: windows::Win32::Foundation::HANDLE, id: ProcessId) -> bool {
-    backend::creation_token(handle) == Some(id.start)
+pub(crate) use backend::{close as windows_close, open_classified as windows_open_classified, Opened};
+
+/// What an ALREADY-OPEN Windows handle says about an identity. The held handle pins the
+/// kernel object, so this is pid-reuse-safe (unlike re-resolving by raw pid).
+#[cfg(windows)]
+#[derive(Debug)]
+pub(crate) enum HandleIdentity {
+    /// The handle's creation token matches — it IS this process.
+    Same,
+    /// The token differs — the pid was recycled; the original is gone.
+    Different,
+    /// `GetProcessTimes` failed, so nothing was established. Never treat as "gone". Carries
+    /// the failure for the same reason `Opened::Denied` does: by the time a caller wants to
+    /// report it, `GetLastError` has been overwritten.
+    Unreadable(windows::core::Error),
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_handle_identity(handle: windows::Win32::Foundation::HANDLE, id: ProcessId) -> HandleIdentity {
+    match backend::creation_token_result(handle) {
+        Ok(t) if t == id.start => HandleIdentity::Same,
+        Ok(_) => HandleIdentity::Different,
+        Err(e) => HandleIdentity::Unreadable(e),
+    }
 }
 
 /// Build a `ProcessId` from an already-open Windows handle + its pid, reusing the

--- a/src/identity/linux.rs
+++ b/src/identity/linux.rs
@@ -1,23 +1,85 @@
 //! Linux process-identity backend: raw field-22 `starttime` (jiffies) from
-//! `/proc/<pid>/stat` as the start token; `is_running` via process state;
-//! `created_at` via `/proc/stat` `btime` and `_SC_CLK_TCK`.
+//! `/proc/<pid>/stat` as the start token; `is_running` via process state; `created_at` via
+//! `/proc/stat` `btime` and `_SC_CLK_TCK`.
 
 use std::time::{Duration, SystemTime};
 
+use super::probe::{classify_unreadable, SignalProbe};
 use super::stat_parse::parse_starttime_jiffies;
-use super::{RawPid, StartToken};
+use super::{Liveness, RawPid, Resolved, StartToken};
 
-pub(super) fn start_token(pid: RawPid) -> Option<StartToken> {
-    let stat = std::fs::read(format!("/proc/{pid}/stat")).ok()?;
-    // RAW jiffies are the identity token — NOT converted to wall-clock.
-    parse_starttime_jiffies(&stat).map(StartToken::from_raw)
+/// `kill(pid, 0)` — existence/permission check only, no signal delivered. The target
+/// validation lives in the pure `probe` module so it is executed on every host.
+fn signal_probe(pid: RawPid) -> SignalProbe {
+    let Some(p) = super::probe::signal_target(pid) else {
+        return SignalProbe::NotAPid;
+    };
+    // SAFETY: kill with signal 0 performs the permission/existence check only.
+    if unsafe { libc::kill(p, 0) } == 0 {
+        return SignalProbe::Signalable;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => SignalProbe::NoSuchProcess,
+        _ => SignalProbe::Denied,
+    }
 }
 
-pub(super) fn is_running(pid: RawPid, start: StartToken) -> bool {
-    let Ok(stat) = std::fs::read(format!("/proc/{pid}/stat")) else {
-        return false; // gone (reaped) => not running
-    };
-    super::stat_parse::running_from_stat(&stat, start)
+/// Classify a failed `/proc/<pid>/stat` read. `ErrorKind` alone is not enough: under a
+/// `hidepid` mount another user's `/proc/<pid>` is invisible, so a LIVE process yields
+/// `ENOENT`; and a task that exits mid-read yields `ESRCH`, which has no `ErrorKind`.
+fn read_stat(pid: RawPid) -> Resolved<Vec<u8>> {
+    match std::fs::read(format!("/proc/{pid}/stat")) {
+        Ok(bytes) => Resolved::Found(bytes),
+        Err(e) => match classify_unreadable(signal_probe(pid)) {
+            Resolved::Gone => Resolved::Gone,
+            _ => {
+                // `debug`, not `warn`: this is a per-pid probe the tree-walk calls once per
+                // process per sweep. The decision made from it warns.
+                log::debug!("/proc/{pid}/stat unreadable ({e}) but the pid is not provably gone");
+                Resolved::Unknown
+            }
+        },
+    }
+}
+
+pub(super) fn start_token(pid: RawPid) -> Resolved<StartToken> {
+    match read_stat(pid) {
+        // RAW jiffies are the identity token — NOT converted to wall-clock.
+        Resolved::Found(stat) => match parse_starttime_jiffies(&stat) {
+            Some(j) => Resolved::Found(StartToken::from_raw(j)),
+            // Reachable when a task exits mid-read and the kernel hands back a truncated
+            // buffer, so this must not be an assertion.
+            None => {
+                log::debug!("/proc/{pid}/stat has no parseable starttime");
+                Resolved::Unknown
+            }
+        },
+        Resolved::Gone => Resolved::Gone,
+        Resolved::Unknown => Resolved::Unknown,
+    }
+}
+
+pub(super) fn is_running(pid: RawPid, start: StartToken) -> Liveness {
+    match read_stat(pid) {
+        Resolved::Found(stat) => super::stat_parse::running_from_stat(&stat, start),
+        Resolved::Gone => Liveness::Dead, // gone (reaped) => not running
+        Resolved::Unknown => Liveness::Unknown,
+    }
+}
+
+/// Our own start token, read by pid — deliberately NOT via `/proc/self`.
+///
+/// `ProcessId` is the pair `(std::process::id(), token)`, so the token must come from the
+/// same namespace view as that pid. `/proc/self` and `/proc/<getpid()>` diverge exactly when
+/// the reading task's pid namespace is not the one `/proc` was mounted from (`unshare --pid
+/// --fork` without `--mount-proc`): there `getpid()` is 1 while `/proc` still shows the outer
+/// namespace. Reading `/proc/self` there would pair the caller's real token with the inner
+/// pid 1, and `exists()`/`is_alive()` — which re-read BY PID — would then report the running
+/// caller as `Gone`/`Dead`. Keeping both halves by-pid keeps the pair self-consistent.
+///
+/// `hidepid` never hides a task from itself, so this read cannot be denied to us.
+pub(super) fn current_token() -> Resolved<StartToken> {
+    start_token(std::process::id())
 }
 
 pub(super) fn created_at(start: StartToken) -> Option<SystemTime> {

--- a/src/identity/macos.rs
+++ b/src/identity/macos.rs
@@ -95,9 +95,9 @@ pub(super) fn is_running(pid: RawPid, start: StartToken) -> Liveness {
     // and a kinfo layout drift fails safe to the pre-fix answer (token mismatch => false).
     match kinfo::kinfo(pid) {
         Resolved::Found(info) => {
-            if token_of_kinfo(&info) != start {
-                Liveness::Dead // reused PID
-            } else if info.kp_proc.p_stat as u32 == libc::SZOMB {
+            // A reused PID names a different process; SZOMB is exited-but-unreaped. Both
+            // are "not running", and neither is an unassessable read.
+            if token_of_kinfo(&info) != start || info.kp_proc.p_stat as u32 == libc::SZOMB {
                 Liveness::Dead
             } else {
                 Liveness::Alive

--- a/src/identity/macos.rs
+++ b/src/identity/macos.rs
@@ -8,7 +8,7 @@
 
 use std::time::{Duration, SystemTime};
 
-use super::{RawPid, StartToken};
+use super::{Liveness, RawPid, Resolved, StartToken};
 
 #[path = "macos/kinfo.rs"]
 mod kinfo;
@@ -63,33 +63,49 @@ fn token_of_kinfo(info: &kinfo::kinfo_proc) -> StartToken {
     StartToken::from_raw(start.tv_sec as u64 * 1_000_000 + start.tv_usec as u64)
 }
 
-pub(super) fn start_token(pid: RawPid) -> Option<StartToken> {
+pub(super) fn start_token(pid: RawPid) -> Resolved<StartToken> {
     if let Some(info) = bsd_info(pid) {
-        return Some(token_of_bsd(&info));
+        return Resolved::Found(token_of_bsd(&info));
     }
-    // libproc-invisible: gone or a ZOMBIE — only sysctl resolves the latter.
-    kinfo::kinfo(pid).as_ref().map(token_of_kinfo)
+    // libproc-invisible: gone, a ZOMBIE, or EPERM-hidden - only sysctl resolves the latter
+    // two, and it distinguishes an empty reply (gone) from a failure (unknown).
+    kinfo::kinfo(pid).map(|info| token_of_kinfo(&info))
 }
 
-pub(super) fn is_running(pid: RawPid, start: StartToken) -> bool {
+/// `proc_pidinfo` on self is always permitted, so the by-pid path cannot be denied here.
+pub(super) fn current_token() -> Resolved<StartToken> {
+    start_token(std::process::id())
+}
+
+pub(super) fn is_running(pid: RawPid, start: StartToken) -> Liveness {
     if let Some(info) = bsd_info(pid) {
         if token_of_bsd(&info) != start {
-            return false; // reused PID
+            return Liveness::Dead; // reused PID
         }
         // SZOMB == zombie (exited, unreaped). Anything else is a live process.
-        return info.pbi_status != libc::SZOMB;
+        return if info.pbi_status == libc::SZOMB {
+            Liveness::Dead
+        } else {
+            Liveness::Alive
+        };
     }
     // libproc-invisible: gone, a ZOMBIE, or an EPERM-hidden LIVE process (an unprivileged
     // cross-user query — pid 1 on darwin CI proved a miss is NOT always gone-or-zombie).
     // The fallback keeps the same shape — token-guarded, zombie-EXCLUSIVE via `p_stat` —
     // and a kinfo layout drift fails safe to the pre-fix answer (token mismatch => false).
-    let Some(info) = kinfo::kinfo(pid) else {
-        return false; // gone => not running
-    };
-    if token_of_kinfo(&info) != start {
-        return false; // reused PID
+    match kinfo::kinfo(pid) {
+        Resolved::Found(info) => {
+            if token_of_kinfo(&info) != start {
+                Liveness::Dead // reused PID
+            } else if info.kp_proc.p_stat as u32 == libc::SZOMB {
+                Liveness::Dead
+            } else {
+                Liveness::Alive
+            }
+        }
+        Resolved::Gone => Liveness::Dead,
+        Resolved::Unknown => Liveness::Unknown,
     }
-    info.kp_proc.p_stat as u32 != libc::SZOMB
 }
 
 pub(super) fn created_at(start: StartToken) -> Option<SystemTime> {

--- a/src/identity/macos/kinfo.rs
+++ b/src/identity/macos/kinfo.rs
@@ -5,7 +5,7 @@
 //! below, the kernel-size oracle, and the token-vs-libproc oracle (kinfo_tests.rs).
 #![allow(non_camel_case_types)]
 
-use super::super::RawPid;
+use super::super::{RawPid, Resolved};
 
 /// `struct kinfo_proc` (LP64): `extern_proc` head + opaque `eproc` tail.
 #[repr(C)]
@@ -90,14 +90,14 @@ const _: () = assert!(std::mem::size_of::<extern_proc>() == 296);
 /// a nonexistent pid (sysctl SUCCESS with `size == 0`); a real sysctl failure or a
 /// wrong-sized record is a contract violation and leaves a trace before the same `None`.
 /// EINTR retries, per the codebase convention (see `wait/linux.rs`, `wait/macos.rs`).
-pub(super) fn kinfo(pid: RawPid) -> Option<kinfo_proc> {
+pub(super) fn kinfo(pid: RawPid) -> Resolved<kinfo_proc> {
     read_record(pid, libc::KERN_PROC_PID)
 }
 
 /// The selector-parameterized core. The `selector` parameter is a TEST SEAM (production
 /// always passes `KERN_PROC_PID` via `kinfo()`) — it lets a unit test drive the
 /// contract-violation arm with an invalid selector.
-fn read_record(pid: RawPid, selector: libc::c_int) -> Option<kinfo_proc> {
+fn read_record(pid: RawPid, selector: libc::c_int) -> Resolved<kinfo_proc> {
     let mut mib = [libc::CTL_KERN, libc::KERN_PROC, selector, pid as libc::c_int];
     loop {
         let mut info: kinfo_proc = unsafe { std::mem::zeroed() };
@@ -115,14 +115,31 @@ fn read_record(pid: RawPid, selector: libc::c_int) -> Option<kinfo_proc> {
         };
         if rc != 0 {
             let e = std::io::Error::last_os_error();
-            if e.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            super::contract_violation(format_args!("sysctl(KERN_PROC selector {selector}, {pid}) failed: {e}"));
-            return None;
+            return match e.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                // The OS positively says there is no such process.
+                Some(libc::ESRCH) => Resolved::Gone,
+                // A sandbox or hardened runtime refusing the query is the DESIGNED Unknown,
+                // not a contract violation - `debug`, like every other per-pid probe.
+                Some(libc::EPERM) | Some(libc::EACCES) => {
+                    log::debug!("sysctl(KERN_PROC selector {selector}, {pid}) refused: {e}");
+                    Resolved::Unknown
+                }
+                // ENOMEM/EINVAL are neither race- nor permission-reachable. ENOMEM in
+                // particular is the ONLY runtime detector for a kernel `kinfo_proc` that has
+                // grown past our 648-byte definition: it fails before the size check below
+                // is ever reached, and the compile-time size assert cannot fire because the
+                // Rust definition is what stayed still. Keep it loud.
+                _ => {
+                    super::contract_violation(format_args!(
+                        "sysctl(KERN_PROC selector {selector}, {pid}) failed: {e}"
+                    ));
+                    Resolved::Unknown
+                }
+            };
         }
         if size == 0 {
-            return None;
+            return Resolved::Gone;
         }
         if size != std::mem::size_of::<kinfo_proc>() {
             // Layout drift — never trust a partial/foreign-sized record.
@@ -130,9 +147,9 @@ fn read_record(pid: RawPid, selector: libc::c_int) -> Option<kinfo_proc> {
                 "sysctl(KERN_PROC selector {selector}, {pid}) wrote {size} bytes, expected {}",
                 std::mem::size_of::<kinfo_proc>()
             ));
-            return None;
+            return Resolved::Unknown;
         }
-        return Some(info);
+        return Resolved::Found(info);
     }
 }
 

--- a/src/identity/macos/kinfo.rs
+++ b/src/identity/macos/kinfo.rs
@@ -131,9 +131,7 @@ fn read_record(pid: RawPid, selector: libc::c_int) -> Resolved<kinfo_proc> {
                 // is ever reached, and the compile-time size assert cannot fire because the
                 // Rust definition is what stayed still. Keep it loud.
                 _ => {
-                    super::contract_violation(format_args!(
-                        "sysctl(KERN_PROC selector {selector}, {pid}) failed: {e}"
-                    ));
+                    super::contract_violation(format_args!("sysctl(KERN_PROC selector {selector}, {pid}) failed: {e}"));
                     Resolved::Unknown
                 }
             };

--- a/src/identity/macos/kinfo_tests.rs
+++ b/src/identity/macos/kinfo_tests.rs
@@ -40,11 +40,15 @@ fn kernel_writes_exactly_our_kinfo_proc_size() {
 // debug builds the tripwire panics AFTER the warn executed (this test expects the panic);
 // in the release lane the same straight-line code minus the compiled-out assert runs to
 // `None`, which the assert below pins.
+// SCOPE: the EPERM arm - a sandboxed sysctl refusal - is a DIFFERENT arm, reached by no
+// test on any available machine.
 #[cfg_attr(debug_assertions, should_panic(expected = "sysctl(KERN_PROC"))]
 #[test]
-fn read_record_flags_an_invalid_selector() {
+fn an_undiagnosable_sysctl_failure_trips_the_tripwire_and_reports_unknown() {
     let r = super::read_record(std::process::id() as super::super::RawPid, -1);
-    assert!(r.is_none(), "an invalid selector must never yield a record");
+    // `assert_eq!` is impossible here: `Resolved`-s derives are T-bounded and `kinfo_proc`
+    // embeds a union, so it can never be `PartialEq`/`Debug`.
+    assert!(r.is_unknown(), "a failed sysctl must never yield a record - or a Gone");
 }
 
 // Verifies contract_violation's warn is actually captured, not just that debug panics —
@@ -69,7 +73,9 @@ fn contract_violation_traces_then_trips() {
 fn sysctl_token_matches_libproc_for_a_live_process() {
     let pid = std::process::id() as libc::c_int;
 
-    let ours = kinfo(pid as super::super::RawPid).expect("self resolves via sysctl");
+    let crate::identity::Resolved::Found(ours) = kinfo(pid as super::super::RawPid) else {
+        panic!("self resolves via sysctl");
+    };
     let ours = {
         // SAFETY: as in token_of — the kernel fills p_starttime for KERN_PROC copies.
         let t = unsafe { ours.kp_proc.p_un.p_starttime };

--- a/src/identity/probe.rs
+++ b/src/identity/probe.rs
@@ -1,0 +1,45 @@
+//! The pure part of the Unix "is this pid gone, or merely unreadable?" decision.
+//!
+//! Kept separate and free of syscalls so it is compiled and EXECUTED on every host,
+//! including the Windows development machine — the Linux path would otherwise ship with
+//! compile-only coverage.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use super::{RawPid, Resolved};
+
+/// What `kill(pid, 0)` said about a pid whose `/proc` entry we could not read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SignalProbe {
+    /// `kill` returned 0: the process exists and we may signal it.
+    Signalable,
+    /// `ESRCH`: no such process.
+    NoSuchProcess,
+    /// `EPERM` (or any other errno): it exists, or we cannot tell.
+    Denied,
+    /// The value is not a single-process target at all, so no probe was issued.
+    NotAPid,
+}
+
+/// The `kill(2)` target for `pid`, or `None` when `pid` is not a single-process target at
+/// all. Rejecting those WITHOUT issuing the call is load-bearing: `kill(0, sig)` signals the
+/// caller's own process group, and any value above `i32::MAX` wraps negative, where
+/// `kill(-N, sig)` targets a whole group and `kill(-1, sig)` everything we may signal. All
+/// of those succeed, so a leak here would fake a live process — or, at a real signal site,
+/// SIGKILL the caller.
+pub(crate) fn signal_target(pid: RawPid) -> Option<i32> {
+    let p = i32::try_from(pid).ok()?;
+    (p > 0).then_some(p)
+}
+
+/// `Resolved::Gone` only when the OS positively says "no such process". Everything else is
+/// `Unknown`: an unreadable `/proc` entry is not evidence of death.
+pub(crate) fn classify_unreadable(probe: SignalProbe) -> Resolved<()> {
+    match probe {
+        SignalProbe::NoSuchProcess | SignalProbe::NotAPid => Resolved::Gone,
+        SignalProbe::Signalable | SignalProbe::Denied => Resolved::Unknown,
+    }
+}
+
+#[cfg(test)]
+#[path = "probe_tests.rs"]
+mod probe_tests;

--- a/src/identity/probe_tests.rs
+++ b/src/identity/probe_tests.rs
@@ -1,0 +1,46 @@
+use super::{classify_unreadable, signal_target, SignalProbe};
+use crate::identity::Resolved;
+
+#[test]
+fn only_no_such_process_means_gone() {
+    assert_eq!(classify_unreadable(SignalProbe::NoSuchProcess), Resolved::Gone);
+}
+
+#[test]
+fn a_signalable_pid_is_live_but_unreadable() {
+    // hidepid: /proc/<pid> is invisible to us, yet the process answers a signal probe.
+    assert_eq!(classify_unreadable(SignalProbe::Signalable), Resolved::Unknown);
+}
+
+#[test]
+fn a_denied_probe_is_unknown_not_gone() {
+    // EPERM: someone else's live process — must read as Unknown, not Gone.
+    assert_eq!(classify_unreadable(SignalProbe::Denied), Resolved::Unknown);
+}
+
+#[test]
+fn a_value_that_is_not_a_pid_is_gone() {
+    assert_eq!(classify_unreadable(SignalProbe::NotAPid), Resolved::Gone);
+}
+
+#[test]
+fn signal_target_rejects_every_non_single_process_value() {
+    assert_eq!(signal_target(0), None);
+    assert_eq!(signal_target(u32::MAX), None);
+    assert_eq!(signal_target(i32::MAX as u32 + 1), None);
+    assert_eq!(signal_target(1), Some(1));
+    assert_eq!(signal_target(i32::MAX as u32), Some(i32::MAX));
+}
+
+#[test]
+fn signal_target_is_the_guard_for_real_signals_not_just_the_probe() {
+    // The `sig 0` probe merely misreports if this leaks; `treewalk::kill_by_identity` and
+    // `wait::macos::{kill, terminate}` would SIGKILL the caller's own process group, so pin
+    // the two values that make `kill(2)` group-directed rather than process-directed.
+    assert_eq!(signal_target(0), None, "kill(0, sig) signals our own process group");
+    assert_eq!(
+        signal_target(u32::MAX),
+        None,
+        "kill(-1, sig) signals every process we may signal"
+    );
+}

--- a/src/identity/stat_parse.rs
+++ b/src/identity/stat_parse.rs
@@ -29,17 +29,21 @@ pub(crate) fn parse_ppid(stat: &[u8]) -> Option<u32> {
     tail(stat)?.split_whitespace().nth(1)?.parse::<u32>().ok()
 }
 
-/// Decide whether a process is *running* from its raw `/proc/<pid>/stat` bytes:
-/// the starttime token must match `start` (reject a reused PID) AND the state
-/// must not be zombie ('Z') or dead ('X'/'x'). Pure, so it is host-testable.
-pub(super) fn running_from_stat(stat: &[u8], start: super::StartToken) -> bool {
+/// Decide whether a process is *running* from its raw `/proc/<pid>/stat` bytes: the
+/// starttime token must match `start` (reject a reused PID) AND the state must not be zombie
+/// ('Z') or dead ('X'/'x'). An unparseable record is `Unknown` — we read the file, so the
+/// process is there; we just could not read its state. Pure, so it is host-testable.
+pub(super) fn running_from_stat(stat: &[u8], start: super::StartToken) -> super::Liveness {
+    use super::Liveness;
     match parse_starttime_jiffies(stat) {
         Some(j) if super::StartToken::from_raw(j) == start => {}
-        _ => return false,
+        Some(_) => return Liveness::Dead, // reused PID
+        None => return Liveness::Unknown, // unparseable — not evidence of death
     }
     match parse_state(stat) {
-        Some(s) => !matches!(s, b'Z' | b'X' | b'x'),
-        None => false,
+        Some(b'Z' | b'X' | b'x') => Liveness::Dead,
+        Some(_) => Liveness::Alive,
+        None => Liveness::Unknown,
     }
 }
 

--- a/src/identity/stat_parse_tests.rs
+++ b/src/identity/stat_parse_tests.rs
@@ -1,4 +1,5 @@
 use super::super::StartToken;
+use crate::identity::Liveness;
 use super::{parse_ppid, parse_starttime_jiffies, parse_state, running_from_stat};
 
 fn tok(v: u64) -> StartToken {
@@ -73,35 +74,42 @@ fn stat_fixture(state: &str, starttime: u64) -> Vec<u8> {
 #[test]
 fn running_from_stat_running_state_matching_token() {
     let stat = stat_fixture("R", 8675309);
-    assert!(running_from_stat(&stat, tok(8675309)));
+    assert_eq!(running_from_stat(&stat, tok(8675309)), Liveness::Alive);
 }
 
 #[test]
 fn running_from_stat_sleeping_state_matching_token() {
     let stat = stat_fixture("S", 8675309);
-    assert!(running_from_stat(&stat, tok(8675309)));
+    assert_eq!(running_from_stat(&stat, tok(8675309)), Liveness::Alive);
 }
 
 #[test]
-fn running_from_stat_zombie_returns_false() {
+fn running_from_stat_zombie_is_dead() {
     let stat = stat_fixture("Z", 8675309);
-    assert!(!running_from_stat(&stat, tok(8675309)));
+    assert_eq!(running_from_stat(&stat, tok(8675309)), Liveness::Dead);
 }
 
 #[test]
-fn running_from_stat_dead_uppercase_returns_false() {
+fn running_from_stat_dead_uppercase_is_dead() {
     let stat = stat_fixture("X", 8675309);
-    assert!(!running_from_stat(&stat, tok(8675309)));
+    assert_eq!(running_from_stat(&stat, tok(8675309)), Liveness::Dead);
 }
 
 #[test]
-fn running_from_stat_dead_lowercase_returns_false() {
+fn running_from_stat_dead_lowercase_is_dead() {
     let stat = stat_fixture("x", 8675309);
-    assert!(!running_from_stat(&stat, tok(8675309)));
+    assert_eq!(running_from_stat(&stat, tok(8675309)), Liveness::Dead);
 }
 
 #[test]
-fn running_from_stat_token_mismatch_returns_false() {
+fn running_from_stat_token_mismatch_is_dead() {
     let stat = stat_fixture("R", 8675309);
-    assert!(!running_from_stat(&stat, tok(9999999)));
+    assert_eq!(running_from_stat(&stat, tok(9999999)), Liveness::Dead);
+}
+
+#[test]
+fn running_from_stat_unparseable_record_is_unknown() {
+    // We read the file, so the process is there — we just could not read its state.
+    // Distinct from a token mismatch, which positively identifies a stranger.
+    assert_eq!(running_from_stat(b"not a stat line at all", tok(1)), Liveness::Unknown);
 }

--- a/src/identity/stat_parse_tests.rs
+++ b/src/identity/stat_parse_tests.rs
@@ -1,6 +1,6 @@
 use super::super::StartToken;
-use crate::identity::Liveness;
 use super::{parse_ppid, parse_starttime_jiffies, parse_state, running_from_stat};
+use crate::identity::Liveness;
 
 fn tok(v: u64) -> StartToken {
     StartToken::from_raw(v)

--- a/src/identity/state.rs
+++ b/src/identity/state.rs
@@ -1,0 +1,82 @@
+//! Tri-state answers for the identity layer.
+//!
+//! Every identity question has three outcomes, not two: yes, no, and *we were not allowed
+//! to ask*. Collapsing the third into the second makes an unprivileged caller read a live,
+//! healthy service as gone, so none of these types offer a `bool` conversion, a `Default`,
+//! or an `unwrap_or`: narrowing to two states must name the variant being folded away.
+
+/// Whether a `ProcessId` still resolves (zombie-inclusive — see
+/// [`ProcessId::exists`](super::ProcessId::exists)).
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Existence {
+    /// The pid resolves to this exact identity.
+    Present,
+    /// The pid resolves to nothing, or to a different identity (recycled).
+    Gone,
+    /// The OS refused the query; the process may well be present.
+    Unknown,
+}
+
+impl Existence {
+    pub fn is_unknown(self) -> bool {
+        matches!(self, Existence::Unknown)
+    }
+}
+
+/// Whether a process is currently running (zombie-*exclusive* — see
+/// [`ProcessId::is_alive`](super::ProcessId::is_alive)).
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Liveness {
+    /// Running: this exact identity, not exited.
+    Alive,
+    /// Exited, reaped, or the pid now names a different process.
+    Dead,
+    /// The OS refused the query, or answered ambiguously; the process may well be alive.
+    Unknown,
+}
+
+impl Liveness {
+    pub fn is_unknown(self) -> bool {
+        matches!(self, Liveness::Unknown)
+    }
+}
+
+/// The outcome of resolving something by pid.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Resolved<T> {
+    Found(T),
+    /// No such process.
+    Gone,
+    /// The OS refused the query; a process may well be there.
+    Unknown,
+}
+
+impl<T> Resolved<T> {
+    /// The value if resolved. Discards *why* it did not resolve — use only where `Gone` and
+    /// `Unknown` genuinely warrant the same handling.
+    pub fn found(self) -> Option<T> {
+        match self {
+            Resolved::Found(v) => Some(v),
+            Resolved::Gone | Resolved::Unknown => None,
+        }
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Resolved::Unknown)
+    }
+
+    pub(crate) fn map<U>(self, f: impl FnOnce(T) -> U) -> Resolved<U> {
+        match self {
+            Resolved::Found(v) => Resolved::Found(f(v)),
+            Resolved::Gone => Resolved::Gone,
+            Resolved::Unknown => Resolved::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod state_tests;

--- a/src/identity/state_tests.rs
+++ b/src/identity/state_tests.rs
@@ -1,0 +1,34 @@
+use super::{Existence, Liveness, Resolved};
+
+#[test]
+fn unknown_is_distinct_from_the_negative_state() {
+    assert_ne!(Existence::Unknown, Existence::Gone);
+    assert_ne!(Liveness::Unknown, Liveness::Dead);
+    assert_ne!(Resolved::<u8>::Unknown, Resolved::<u8>::Gone);
+}
+
+#[test]
+fn is_unknown_reports_only_the_unknown_variant() {
+    assert!(Existence::Unknown.is_unknown());
+    assert!(!Existence::Present.is_unknown());
+    assert!(!Existence::Gone.is_unknown());
+    assert!(Liveness::Unknown.is_unknown());
+    assert!(!Liveness::Alive.is_unknown());
+    assert!(!Liveness::Dead.is_unknown());
+    assert!(Resolved::<u8>::Unknown.is_unknown());
+    assert!(!Resolved::Found(1u8).is_unknown());
+}
+
+#[test]
+fn found_yields_the_value_only_for_found() {
+    assert_eq!(Resolved::Found(7u8).found(), Some(7));
+    assert_eq!(Resolved::<u8>::Gone.found(), None);
+    assert_eq!(Resolved::<u8>::Unknown.found(), None);
+}
+
+#[test]
+fn map_preserves_the_non_found_variants() {
+    assert_eq!(Resolved::Found(2u8).map(|v| v + 1), Resolved::Found(3u8));
+    assert_eq!(Resolved::<u8>::Gone.map(|v| v + 1), Resolved::<u8>::Gone);
+    assert_eq!(Resolved::<u8>::Unknown.map(|v| v + 1), Resolved::<u8>::Unknown);
+}

--- a/src/identity/windows.rs
+++ b/src/identity/windows.rs
@@ -2,53 +2,134 @@
 //!
 //! - `start_token`: raw creation `FILETIME` (identity, NOT epoch-adjusted).
 //! - `created_at`: that 100 ns-since-1601 value converted to `SystemTime`.
-//! - `is_running`: authoritative "not exited" via `WaitForSingleObject(_, 0)`,
-//!   which tests the process's *signaled state* — so it flips to dead the
-//!   instant the process exits, without the object-teardown window that an
-//!   existence check (`OpenProcess` succeeding) would have.
+//! - `is_running`: authoritative "not exited" via `WaitForSingleObject(_, 0)`, which tests
+//!   the process's *signaled state* — so it flips to dead the instant the process exits,
+//!   without the object-teardown window that an existence check (`OpenProcess` succeeding)
+//!   would have. Reading the signaled state needs `SYNCHRONIZE`; when only
+//!   `PROCESS_QUERY_LIMITED_INFORMATION` is granted, `GetExitCodeProcess` can still prove an
+//!   exit but not the absence of one.
+//!
+//! An `OpenProcess` failure is classified, never collapsed: `ERROR_INVALID_PARAMETER` is the
+//! OS saying "no such pid" and is the ONLY failure that means absence. Everything else —
+//! `ERROR_ACCESS_DENIED` above all — means we were not allowed to ask.
 
 use std::time::{Duration, SystemTime};
 
-use windows::Win32::Foundation::{CloseHandle, FILETIME, HANDLE, WAIT_TIMEOUT};
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_INVALID_PARAMETER, FILETIME, HANDLE, STILL_ACTIVE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
 use windows::Win32::System::Threading::{
-    GetProcessTimes, OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+    GetCurrentProcess, GetExitCodeProcess, GetProcessTimes, OpenProcess, WaitForSingleObject, PROCESS_ACCESS_RIGHTS,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
 };
 
-use super::{RawPid, StartToken};
+use super::{Liveness, RawPid, Resolved, StartToken};
 
 /// 100 ns intervals between 1601-01-01 (FILETIME epoch) and 1970-01-01 (Unix).
 const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
 
-/// Read the creation FILETIME of an open process handle as a raw token.
+/// The `OpenProcess` failure that means "no such pid". Derived, never hand-packed: this
+/// constant is the crate's whole classification rule, and one wrong nibble in a literal
+/// would silently reclassify every access-denied process as gone.
+pub(crate) const ERROR_INVALID_PARAMETER_HRESULT: windows::core::HRESULT =
+    windows::core::HRESULT::from_win32(ERROR_INVALID_PARAMETER.0);
+
+/// The outcome of a classified `OpenProcess`. `Denied` carries the failure because a caller
+/// that has to report it cannot recover it afterwards: `GetLastError` is thread-global and
+/// every intervening call overwrites it.
+pub(crate) enum Opened {
+    Found(HANDLE),
+    /// `ERROR_INVALID_PARAMETER` — the OS's "no such pid". The ONLY failure meaning absence.
+    Gone,
+    /// Anything else, `ERROR_ACCESS_DENIED` above all: we were not allowed to ask.
+    Denied(windows::core::Error),
+}
+
+/// `OpenProcess` with `mask`, classified. The crate's single rule. The caller closes the
+/// handle.
+pub(crate) fn open_classified(pid: RawPid, mask: PROCESS_ACCESS_RIGHTS) -> Opened {
+    // SAFETY: OpenProcess tolerates any pid value (it returns Err).
+    match unsafe { OpenProcess(mask, false, pid) } {
+        Ok(h) => Opened::Found(h),
+        Err(e) if e.code() == ERROR_INVALID_PARAMETER_HRESULT => Opened::Gone,
+        // `debug`, not `warn`: the tree-walk calls this once per pid per sweep. The event is
+        // reported at `warn` exactly once, by the call site that decided what the denial
+        // means; this line is the per-call detail — which pid, which mask — that those
+        // messages cannot carry.
+        Err(e) => {
+            log::debug!("OpenProcess({pid}, {mask:?}) failed: {e} — reporting Unknown, not absence");
+            Opened::Denied(e)
+        }
+    }
+}
+
+pub(crate) fn close(handle: HANDLE) {
+    // SAFETY: `handle` is an owned process handle.
+    if let Err(e) = unsafe { CloseHandle(handle) } {
+        log::warn!("CloseHandle of an owned process handle failed: {e}");
+        debug_assert!(false, "CloseHandle of an owned process handle should not fail: {e}");
+    }
+}
+
+/// Read the creation FILETIME of an open process handle as a raw token, preserving the
+/// failure. `creation_token` is this with the error dropped.
 // SAFETY: `handle` must be a live process handle with QUERY_LIMITED rights.
-pub(super) fn creation_token(handle: HANDLE) -> Option<StartToken> {
+pub(crate) fn creation_token_result(handle: HANDLE) -> windows::core::Result<StartToken> {
     let mut creation = FILETIME::default();
     let mut exit = FILETIME::default();
     let mut kernel = FILETIME::default();
     let mut user = FILETIME::default();
-    let res = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
-    res.ok()?;
+    unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) }?;
     let ft = ((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64;
-    Some(StartToken::from_raw(ft))
+    Ok(StartToken::from_raw(ft))
 }
 
-/// Build a `ProcessId` from an already-open Windows process handle and its pid,
-/// reusing the creation-token read. Avoids a second `OpenProcess` (which can fail
-/// and would otherwise force dropping a live elevated child).
+pub(super) fn creation_token(handle: HANDLE) -> Option<StartToken> {
+    creation_token_result(handle).ok()
+}
+
+/// Build a `ProcessId` from an already-open Windows process handle and its pid, reusing the
+/// creation-token read. Avoids a second `OpenProcess` (which can fail and would otherwise
+/// force dropping a live elevated child).
 pub(crate) fn windows_identity_from_handle(handle: HANDLE, pid: RawPid) -> Option<crate::identity::ProcessId> {
     let start = creation_token(handle)?;
     Some(crate::identity::ProcessId { pid, start })
 }
 
-pub(super) fn start_token(pid: RawPid) -> Option<StartToken> {
-    // PROCESS_QUERY_LIMITED_INFORMATION works without elevation for most
-    // processes (incl. services). SAFETY: OpenProcess tolerates an invalid pid
-    // (returns Err); the handle is closed before return.
-    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
-    let token = creation_token(handle);
-    let closed = unsafe { CloseHandle(handle) };
-    debug_assert!(closed.is_ok(), "CloseHandle of an owned process handle should not fail");
-    token
+/// This process's own start token, read from the pseudo-handle. `GetCurrentProcess` performs
+/// NO access check, so unlike a by-pid open this cannot be denied — which matters for a
+/// process whose own DACL is restricted (AppContainer, low integrity).
+pub(super) fn current_token() -> Resolved<StartToken> {
+    // SAFETY: the pseudo-handle is always valid and must not be closed.
+    match creation_token(unsafe { GetCurrentProcess() }) {
+        Some(t) => Resolved::Found(t),
+        // No log: `ProcessId::current()` turns this into a panic whose message says the same
+        // thing, louder.
+        None => Resolved::Unknown,
+    }
+}
+
+pub(super) fn start_token(pid: RawPid) -> Resolved<StartToken> {
+    // PROCESS_QUERY_LIMITED_INFORMATION is the weakest mask that can read the creation time,
+    // and it is not universally granted to an unelevated caller — a failure here is
+    // classified rather than treated as absence.
+    let handle = match open_classified(pid, PROCESS_QUERY_LIMITED_INFORMATION) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Resolved::Gone,
+        Opened::Denied(_) => return Resolved::Unknown,
+    };
+    let token = creation_token_result(handle);
+    close(handle);
+    match token {
+        Ok(t) => Resolved::Found(t),
+        // The open SUCCEEDED, so the process object exists. A GetProcessTimes failure is not
+        // evidence of absence — and it is reachable when the process exits mid-query, so it
+        // must not be an assertion.
+        Err(e) => {
+            log::debug!("GetProcessTimes failed on an opened handle for pid {pid}: {e}");
+            Resolved::Unknown
+        }
+    }
 }
 
 pub(super) fn created_at(start: StartToken) -> Option<SystemTime> {
@@ -58,27 +139,76 @@ pub(super) fn created_at(start: StartToken) -> Option<SystemTime> {
     Some(SystemTime::UNIX_EPOCH + Duration::new(secs, nanos as u32))
 }
 
-pub(super) fn is_running(pid: RawPid, start: StartToken) -> bool {
-    // SYNCHRONIZE lets us WaitForSingleObject; QUERY_LIMITED lets us read the
-    // creation time to reject a reused PID. SAFETY: OpenProcess tolerates an
-    // invalid pid; the handle is closed before every return path.
-    let handle = match unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE, false, pid) } {
-        Ok(h) => h,
-        Err(_) => return false, // gone (or unopenable) => not running
+pub(super) fn is_running(pid: RawPid, start: StartToken) -> Liveness {
+    // Fast path: one open for both rights. SYNCHRONIZE lets us WaitForSingleObject;
+    // QUERY_LIMITED lets us read the creation time to reject a reused PID.
+    let both = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE;
+    let handle = match open_classified(pid, both) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Liveness::Dead,
+        Opened::Denied(_) => return liveness_without_synchronize(pid, start),
     };
-    let running = match creation_token(handle) {
-        // Same identity AND not signaled (WAIT_TIMEOUT) => still running.
-        Some(t) if t == start => {
-            // SAFETY: `handle` is live; a 0 ms wait never blocks. (A `let` binding
-            // is required here: `unsafe { .. } == X` does not parse as a bare arm body.)
+    let verdict = match creation_token_result(handle) {
+        Ok(t) if t == start => {
+            // SAFETY: `handle` is live; a 0 ms wait never blocks. (A `let` binding is
+            // required: `unsafe { .. } == X` does not parse as a bare arm body.)
             let signaled = unsafe { WaitForSingleObject(handle, 0) };
-            signaled == WAIT_TIMEOUT
+            match signaled {
+                WAIT_TIMEOUT => Liveness::Alive,
+                WAIT_OBJECT_0 => Liveness::Dead,
+                // WAIT_FAILED and anything undocumented: the wait never reported on the
+                // process, so we learned nothing.
+                other => {
+                    log::debug!("WaitForSingleObject(pid {pid}, 0) returned {other:?}");
+                    Liveness::Unknown
+                }
+            }
         }
-        _ => false, // reused PID (different creation time) or unreadable
+        Ok(_) => Liveness::Dead, // reused PID: a different process holds it now
+        Err(e) => {
+            // Opened but unreadable — never claim Dead.
+            log::debug!("GetProcessTimes failed on an opened handle for pid {pid}: {e}");
+            Liveness::Unknown
+        }
     };
-    let closed = unsafe { CloseHandle(handle) };
-    debug_assert!(closed.is_ok(), "CloseHandle of an owned process handle should not fail");
-    running
+    close(handle);
+    verdict
+}
+
+/// The `SYNCHRONIZE`-denied path. `QUERY_LIMITED` alone still rejects a reused pid and still
+/// lets `GetExitCodeProcess` PROVE an exit. It cannot prove the converse: a process that
+/// exits with code 259 reports `STILL_ACTIVE` forever, so `STILL_ACTIVE` yields `Unknown`,
+/// never `Alive`.
+fn liveness_without_synchronize(pid: RawPid, start: StartToken) -> Liveness {
+    let handle = match open_classified(pid, PROCESS_QUERY_LIMITED_INFORMATION) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Liveness::Dead,
+        Opened::Denied(_) => return Liveness::Unknown,
+    };
+    // The identity check runs on the HELD handle, which pins the kernel object, so no
+    // recycle can slip between the check and the exit-code read.
+    let verdict = match creation_token_result(handle) {
+        Err(e) => {
+            log::debug!("GetProcessTimes failed on an opened handle for pid {pid}: {e}");
+            Liveness::Unknown
+        }
+        Ok(t) if t != start => Liveness::Dead, // reused PID
+        Ok(_) => {
+            let mut code = 0u32;
+            // SAFETY: `handle` is live and carries QUERY_LIMITED, which is what
+            // GetExitCodeProcess requires.
+            match unsafe { GetExitCodeProcess(handle, &mut code) } {
+                Ok(()) if code != STILL_ACTIVE.0 as u32 => Liveness::Dead,
+                Ok(()) => Liveness::Unknown,
+                Err(e) => {
+                    log::debug!("GetExitCodeProcess failed on an opened handle for pid {pid}: {e}");
+                    Liveness::Unknown
+                }
+            }
+        }
+    };
+    close(handle);
+    verdict
 }
 
 #[cfg(test)]

--- a/src/identity/windows_fixture.rs
+++ b/src/identity/windows_fixture.rs
@@ -1,6 +1,6 @@
 //! Test-only: a REAL live child process whose process-object DACL denies us rights.
 #![allow(dead_code)] // consumed by later tasks' tests; without this the `-D warnings`
-                     // pre-commit hook rejects this module's own commit.
+// pre-commit hook rejects this module's own commit.
 //!
 //! A live process we may not `OpenProcess` is needed to reproduce an access-denied identity
 //! read. Depending on a system service will not do — an elevated CI runner can open those.
@@ -24,9 +24,9 @@ use std::mem::size_of;
 use windows::core::PWSTR;
 use windows::Win32::Foundation::{CloseHandle, HANDLE, STILL_ACTIVE, WAIT_OBJECT_0};
 use windows::Win32::Security::{
-    AddAccessAllowedAce, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
-    SetSecurityDescriptorDacl, TokenUser, ACL, ACL_REVISION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
-    SECURITY_DESCRIPTOR, TOKEN_QUERY, TOKEN_USER,
+    AddAccessAllowedAce, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor, SetSecurityDescriptorDacl,
+    TokenUser, ACL, ACL_REVISION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, TOKEN_QUERY,
+    TOKEN_USER,
 };
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
@@ -85,7 +85,11 @@ impl RestrictedChild {
     pub(crate) fn await_exit(&self) {
         // SAFETY: `self.handle` is our live, owned process handle.
         let waited = unsafe { WaitForSingleObject(self.handle, INFINITE) };
-        assert_eq!(waited, WAIT_OBJECT_0, "fixture: wait on pid {} returned {waited:?}", self.pid);
+        assert_eq!(
+            waited, WAIT_OBJECT_0,
+            "fixture: wait on pid {} returned {waited:?}",
+            self.pid
+        );
     }
 
     /// The pid of this fixture's first child, once the shell has spawned it. Polls the
@@ -132,13 +136,19 @@ impl RestrictedChild {
             }
             // Do NOT fall through to the wait: nothing asked the child to exit, so the wait
             // would park forever.
-            return Err(format!("fixture teardown: TerminateProcess(pid {}) failed: {e}", self.pid));
+            return Err(format!(
+                "fixture teardown: TerminateProcess(pid {}) failed: {e}",
+                self.pid
+            ));
         }
         // SAFETY: `self.handle` is live and we just asked the child to exit, so this wait is
         // bounded by that exit.
         let waited = unsafe { WaitForSingleObject(self.handle, INFINITE) };
         if waited != WAIT_OBJECT_0 {
-            return Err(format!("fixture teardown: wait on pid {} returned {waited:?}", self.pid));
+            return Err(format!(
+                "fixture teardown: wait on pid {} returned {waited:?}",
+                self.pid
+            ));
         }
         Ok(())
     }
@@ -327,7 +337,10 @@ fn spawn_with_ace_cmdline(granted: u32, cmdline: &str) -> RestrictedChild {
     };
     // A child that died on startup would still keep its kernel object alive through our
     // handle, so every OpenProcess verdict would look right while testing nothing.
-    assert!(child.is_running(), "the fixture child exited immediately — the command line is wrong");
+    assert!(
+        child.is_running(),
+        "the fixture child exited immediately — the command line is wrong"
+    );
     child
 }
 

--- a/src/identity/windows_fixture.rs
+++ b/src/identity/windows_fixture.rs
@@ -6,8 +6,12 @@
 //! read. Depending on a system service will not do — an elevated CI runner can open those.
 //! So we create one: `CreateProcessW` accepts a `SECURITY_ATTRIBUTES` for the new process
 //! object, and a DACL holding a single access-allowed ACE for our own user SID denies every
-//! right that ACE omits — to us and to an elevated caller with the same SID, since
-//! `OpenProcess` never enables `SeDebugPrivilege` on our behalf.
+//! right that ACE omits — to us and to an elevated caller with the same SID.
+//!
+//! One privilege defeats that: a token holding `SeDebugPrivilege` **enabled** bypasses the
+//! DACL outright. An interactive session does not hold it enabled; CI runners do. So
+//! [`drop_se_debug_privilege`] strips it from this process once, up front, making the DACL
+//! authoritative everywhere.
 //!
 //! Teardown is safe: the handle `CreateProcessW` hands the creator carries full access
 //! regardless of the DACL, and the child is assigned to a kill-on-close job object so any
@@ -22,11 +26,13 @@
 use std::mem::size_of;
 
 use windows::core::PWSTR;
+use windows::Win32::Foundation::LUID;
 use windows::Win32::Foundation::{CloseHandle, HANDLE, STILL_ACTIVE, WAIT_OBJECT_0};
 use windows::Win32::Security::{
-    AddAccessAllowedAce, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor, SetSecurityDescriptorDacl,
-    TokenUser, ACL, ACL_REVISION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, TOKEN_QUERY,
-    TOKEN_USER,
+    AddAccessAllowedAce, AdjustTokenPrivileges, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
+    LookupPrivilegeValueW, SetSecurityDescriptorDacl, TokenUser, ACL, ACL_REVISION, LUID_AND_ATTRIBUTES,
+    PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, SE_DEBUG_NAME, SE_PRIVILEGE_REMOVED,
+    TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER,
 };
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
@@ -37,6 +43,53 @@ use windows::Win32::System::Threading::{
     WaitForSingleObject, CREATE_NO_WINDOW, CREATE_SUSPENDED, INFINITE, PROCESS_INFORMATION,
     PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, STARTUPINFOW,
 };
+
+/// Runs [`drop_se_debug_privilege`] exactly once per test binary. Mirrors the crate's
+/// existing one-time test-setup idiom (`log_capture::install`).
+static SE_DEBUG_DROPPED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+/// Remove `SeDebugPrivilege` from THIS process's token.
+///
+/// A token holding that privilege **enabled** bypasses a process object's DACL outright, so
+/// every denial this module constructs would be quietly openable and every access-denied
+/// test would report green while proving nothing. An interactive session does not hold it
+/// enabled, which is why the fixture works locally; GitHub's Windows runners do, which is
+/// why it does not work there.
+///
+/// Removing it makes the DACL authoritative on every runner, so this is a real fix rather
+/// than a skip: if the precondition still fails to hold, `spawn_unkillable_denies_everything`
+/// and its siblings fail loudly instead of passing vacuously.
+///
+/// `SE_PRIVILEGE_REMOVED` is irreversible for the token, so this runs ONCE, before the first
+/// fixture exists — not lazily inside whichever denial test happens to run first. Tests run
+/// in parallel, and a privilege that vanished partway through a run would make behaviour
+/// depend on test order even though nothing currently reads it.
+fn drop_se_debug_privilege() {
+    SE_DEBUG_DROPPED.get_or_init(|| {
+        let mut token = HANDLE::default();
+        // SAFETY: GetCurrentProcess returns a pseudo-handle needing no close.
+        unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &mut token) }
+            .expect("OpenProcessToken(TOKEN_ADJUST_PRIVILEGES)");
+        let mut luid = LUID::default();
+        // SAFETY: `SE_DEBUG_NAME` is a static NUL-terminated wide string.
+        unsafe { LookupPrivilegeValueW(None, SE_DEBUG_NAME, &mut luid) }
+            .expect("LookupPrivilegeValueW(SeDebugPrivilege)");
+        let privileges = TOKEN_PRIVILEGES {
+            PrivilegeCount: 1,
+            Privileges: [LUID_AND_ATTRIBUTES {
+                Luid: luid,
+                Attributes: SE_PRIVILEGE_REMOVED,
+            }],
+        };
+        // Succeeds with ERROR_NOT_ALL_ASSIGNED when the token never held the privilege —
+        // the normal local case, and exactly the state we want either way.
+        // SAFETY: `privileges` describes one LUID and `PrivilegeCount` matches.
+        let adjusted = unsafe { AdjustTokenPrivileges(token, false, Some(&privileges), 0, None, None) };
+        // SAFETY: `token` is an owned handle we are done with.
+        unsafe { CloseHandle(token) }.expect("CloseHandle(process token)");
+        adjusted.expect("AdjustTokenPrivileges(SeDebugPrivilege, SE_PRIVILEGE_REMOVED)");
+    });
+}
 
 /// Sentinel for [`spawn_with_ace`]: build the DACL with no ACE at all.
 const NO_ACE: u32 = u32::MAX;
@@ -219,6 +272,10 @@ fn spawn_with_ace(granted: u32) -> RestrictedChild {
 /// Panics on any Win32 failure: a fixture that silently degrades would make its consumers
 /// pass vacuously.
 fn spawn_with_ace_cmdline(granted: u32, cmdline: &str) -> RestrictedChild {
+    // Before ANY fixture exists, so no denial assertion can observe a token that still
+    // bypasses DACLs. Idempotent and one-shot.
+    drop_se_debug_privilege();
+
     // Our own user SID, from our own token. `token` is a real handle — closed below.
     let mut token = HANDLE::default();
     // SAFETY: GetCurrentProcess returns a pseudo-handle needing no close.

--- a/src/identity/windows_fixture.rs
+++ b/src/identity/windows_fixture.rs
@@ -1,0 +1,336 @@
+//! Test-only: a REAL live child process whose process-object DACL denies us rights.
+#![allow(dead_code)] // consumed by later tasks' tests; without this the `-D warnings`
+                     // pre-commit hook rejects this module's own commit.
+//!
+//! A live process we may not `OpenProcess` is needed to reproduce an access-denied identity
+//! read. Depending on a system service will not do — an elevated CI runner can open those.
+//! So we create one: `CreateProcessW` accepts a `SECURITY_ATTRIBUTES` for the new process
+//! object, and a DACL holding a single access-allowed ACE for our own user SID denies every
+//! right that ACE omits — to us and to an elevated caller with the same SID, since
+//! `OpenProcess` never enables `SeDebugPrivilege` on our behalf.
+//!
+//! Teardown is safe: the handle `CreateProcessW` hands the creator carries full access
+//! regardless of the DACL, and the child is assigned to a kill-on-close job object so any
+//! grandchild dies with it.
+//!
+//! Both scratch buffers below are `Vec<u64>` / `Vec<u32>`, not `Vec<u8>`: `TOKEN_USER` holds
+//! a pointer (align 8) and `InitializeAcl` requires a DWORD-aligned `ACL`. A `Vec<u8>` is
+//! align-1, so casting one to either type is an unaligned access and can produce a malformed
+//! DACL — which would silently grant more than intended and make every downstream denial
+//! test pass for the wrong reason.
+
+use std::mem::size_of;
+
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, STILL_ACTIVE, WAIT_OBJECT_0};
+use windows::Win32::Security::{
+    AddAccessAllowedAce, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
+    SetSecurityDescriptorDacl, TokenUser, ACL, ACL_REVISION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    SECURITY_DESCRIPTOR, TOKEN_QUERY, TOKEN_USER,
+};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+    JOBOBJECT_BASIC_LIMIT_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows::Win32::System::Threading::{
+    CreateProcessW, GetCurrentProcess, GetExitCodeProcess, OpenProcessToken, ResumeThread, TerminateProcess,
+    WaitForSingleObject, CREATE_NO_WINDOW, CREATE_SUSPENDED, INFINITE, PROCESS_INFORMATION,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, STARTUPINFOW,
+};
+
+/// Sentinel for [`spawn_with_ace`]: build the DACL with no ACE at all.
+const NO_ACE: u32 = u32::MAX;
+
+/// A live child whose process object grants us only the mask passed to [`spawn_restricted`].
+/// Terminated and closed on drop.
+pub(crate) struct RestrictedChild {
+    handle: HANDLE,
+    thread: HANDLE,
+    /// Kills the whole tree when closed. `TerminateProcess` does NOT cascade, so without
+    /// this `spawn_restricted_shell`'s `cmd.exe` would die while the `ping.exe` it launched
+    /// ran on for an hour. That orphan is not just a leak: `wait_for_child` scans a
+    /// host-wide `(pid, ppid)` snapshot, so a stranded grandchild whose dead parent pid
+    /// Windows later recycles onto a new fixture shell would be mistaken for its child.
+    job: HANDLE,
+    pid: u32,
+}
+
+impl RestrictedChild {
+    pub(crate) fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// The creator's full-access handle — the only way to read this child's identity.
+    pub(crate) fn handle(&self) -> HANDLE {
+        self.handle
+    }
+
+    /// `STILL_ACTIVE` while running, else the recorded exit code. Read through the owned
+    /// handle, so the DACL never affects it.
+    pub(crate) fn exit_code(&self) -> u32 {
+        let mut code = 0u32;
+        // SAFETY: `self.handle` is our live, owned, full-access process handle.
+        unsafe { GetExitCodeProcess(self.handle, &mut code) }.expect("GetExitCodeProcess on an owned handle");
+        code
+    }
+
+    /// The fixture command is chosen so it never exits with 259, making this read
+    /// unambiguous for our own child (it is not, in general, for arbitrary processes).
+    pub(crate) fn is_running(&self) -> bool {
+        self.exit_code() == STILL_ACTIVE.0 as u32
+    }
+
+    /// Block until the child's exit is recorded. Not a timeout: the wait is bounded by an
+    /// exit someone has already requested (`terminate`, or a `kill_by_identity` under test).
+    pub(crate) fn await_exit(&self) {
+        // SAFETY: `self.handle` is our live, owned process handle.
+        let waited = unsafe { WaitForSingleObject(self.handle, INFINITE) };
+        assert_eq!(waited, WAIT_OBJECT_0, "fixture: wait on pid {} returned {waited:?}", self.pid);
+    }
+
+    /// The pid of this fixture's first child, once the shell has spawned it. Polls the
+    /// `(pid, ppid)` snapshot the crate already builds — bounded by the child's appearance,
+    /// which `cmd /c` guarantees, and asserted rather than timed out.
+    pub(crate) fn wait_for_child(&self) -> u32 {
+        // Windows never reparents and recycles pids from a small dense table, so a raw
+        // `ppid == self.pid` scan can match a pre-existing orphan whose real parent exited
+        // and whose pid was then handed to this fixture. Route through the crate-s own
+        // stale-ppid defense (`children_of` applies the start-token order rule) so only a
+        // genuine child is returned.
+        let me = crate::identity::windows_identity_from_handle(self.handle, self.pid)
+            .expect("the owned handle always yields an identity");
+        loop {
+            assert!(self.is_running(), "the fixture shell exited before spawning its child");
+            let parents = crate::containment::enumerate::process_parents();
+            if let Some(kid) = crate::containment::treewalk::children_of(me, &parents).first() {
+                return kid.pid();
+            }
+            std::thread::yield_now();
+        }
+    }
+
+    /// Terminate with exit code 1 and wait for the kernel to record it. Ask forgiveness, not
+    /// permission: `TerminateProcess` on an already-exited child fails with ACCESS_DENIED,
+    /// which is success here — a pre-check would race the child's own exit. Panics on a
+    /// genuine teardown failure, so a test never quietly leaks a live process.
+    pub(crate) fn terminate(&self) {
+        if let Err(what) = self.try_terminate() {
+            log::error!("{what}");
+            if !std::thread::panicking() {
+                panic!("{what}");
+            }
+        }
+    }
+
+    /// The non-panicking core, so `Drop` can report a failure without unwinding out of
+    /// itself and skipping the handle closes.
+    fn try_terminate(&self) -> Result<(), String> {
+        // SAFETY: `self.handle` is our live, owned, full-access process handle.
+        if let Err(e) = unsafe { TerminateProcess(self.handle, 1) } {
+            if !self.is_running() {
+                return Ok(()); // it exited on its own between our read and the call — fine
+            }
+            // Do NOT fall through to the wait: nothing asked the child to exit, so the wait
+            // would park forever.
+            return Err(format!("fixture teardown: TerminateProcess(pid {}) failed: {e}", self.pid));
+        }
+        // SAFETY: `self.handle` is live and we just asked the child to exit, so this wait is
+        // bounded by that exit.
+        let waited = unsafe { WaitForSingleObject(self.handle, INFINITE) };
+        if waited != WAIT_OBJECT_0 {
+            return Err(format!("fixture teardown: wait on pid {} returned {waited:?}", self.pid));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RestrictedChild {
+    fn drop(&mut self) {
+        // Never let a teardown failure unwind out of `drop` before the closes below: the
+        // child is still ALIVE on that path (that is what makes it a failure), so leaking
+        // its handles would strand a process with no owner.
+        let failure = self.try_terminate().err();
+        // The job goes last: closing it is what kills any grandchildren.
+        for (h, what) in [(self.thread, "thread"), (self.handle, "process"), (self.job, "job")] {
+            // SAFETY: all three handles are ours and still open.
+            if let Err(e) = unsafe { CloseHandle(h) } {
+                log::error!("fixture teardown: CloseHandle({what}) for pid {} failed: {e}", self.pid);
+            }
+        }
+        if let Some(what) = failure {
+            log::error!("{what}");
+            if !std::thread::panicking() {
+                panic!("{what}");
+            }
+        }
+    }
+}
+
+/// Spawn a long-running child whose process-object DACL allows our user SID exactly
+/// `granted | PROCESS_TERMINATE` and nothing else.
+pub(crate) fn spawn_restricted(granted: u32) -> RestrictedChild {
+    spawn_with_ace(granted | PROCESS_TERMINATE.0)
+}
+
+/// Spawn a child that even `PROCESS_TERMINATE` cannot open by pid. `Drop` still tears it
+/// down through the owned handle.
+///
+/// Uses an EMPTY DACL, not an ACE with a zero access mask: an empty DACL is Windows'
+/// documented "grant nothing to anyone" form, whereas a zero-mask ACE is unspecified — it
+/// might be rejected by `AddAccessAllowedAce` (panicking the fixture) or normalized away
+/// (silently granting access, which would send all of its consumers down the `Opened::Found`
+/// path while still reporting green).
+pub(crate) fn spawn_unkillable() -> RestrictedChild {
+    spawn_with_ace(NO_ACE)
+}
+
+/// Grants `PROCESS_QUERY_LIMITED_INFORMATION` and nothing else — identity is readable by pid
+/// but `PROCESS_TERMINATE` is denied, which is the only shape that drives `wait::kill`'s
+/// `Opened::Denied` arm (its mask is `TERMINATE | QUERY_LIMITED`, so `spawn_restricted` —
+/// which always ORs in `PROCESS_TERMINATE` — opens successfully and never reaches it).
+pub(crate) fn spawn_query_only() -> RestrictedChild {
+    spawn_with_ace(PROCESS_QUERY_LIMITED_INFORMATION.0)
+}
+
+/// Like [`spawn_restricted`], but the restricted process is a shell that spawns an ordinary
+/// grandchild. A DACL is not inherited, so the grandchild is freely openable while its
+/// parent is not — the only way to build "my parent is access-denied" from a test.
+pub(crate) fn spawn_restricted_shell(granted: u32) -> RestrictedChild {
+    spawn_with_ace_cmdline(
+        granted | PROCESS_TERMINATE.0,
+        "C:\\Windows\\System32\\cmd.exe /c ping.exe -n 3600 127.0.0.1",
+    )
+}
+
+fn spawn_with_ace(granted: u32) -> RestrictedChild {
+    spawn_with_ace_cmdline(granted, "C:\\Windows\\System32\\ping.exe -n 3600 127.0.0.1")
+}
+
+/// Panics on any Win32 failure: a fixture that silently degrades would make its consumers
+/// pass vacuously.
+fn spawn_with_ace_cmdline(granted: u32, cmdline: &str) -> RestrictedChild {
+    // Our own user SID, from our own token. `token` is a real handle — closed below.
+    let mut token = HANDLE::default();
+    // SAFETY: GetCurrentProcess returns a pseudo-handle needing no close.
+    unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) }.expect("OpenProcessToken");
+    let mut needed = 0u32;
+    // SAFETY: a null buffer with length 0 is the documented size query; it fails with
+    // ERROR_INSUFFICIENT_BUFFER and writes the required size.
+    let _ = unsafe { GetTokenInformation(token, TokenUser, None, 0, &mut needed) };
+    // u64-backed so the TOKEN_USER cast below is 8-aligned.
+    let mut sid_buf = vec![0u64; (needed as usize).div_ceil(8).max(1)];
+    // SAFETY: `sid_buf` is at least `needed` bytes.
+    let info = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            Some(sid_buf.as_mut_ptr().cast()),
+            (sid_buf.len() * 8) as u32,
+            &mut needed,
+        )
+    };
+    // SAFETY: `token` is an owned handle we are done with.
+    unsafe { CloseHandle(token) }.expect("CloseHandle(process token)");
+    info.expect("GetTokenInformation(TokenUser)");
+    // SAFETY: the kernel wrote a TOKEN_USER at the head of an 8-aligned buffer, and
+    // `sid_buf` outlives every use of `sid` (dropped at the end of this function, after
+    // CreateProcessW).
+    let sid = unsafe { (*sid_buf.as_ptr().cast::<TOKEN_USER>()).User.Sid };
+
+    // A DACL with ONE allow-ACE: everything it does not name is denied. u32-backed so the
+    // ACL is DWORD-aligned, as InitializeAcl requires.
+    let mut acl_buf = vec![0u32; 256];
+    let acl = acl_buf.as_mut_ptr().cast::<ACL>();
+    // SAFETY: `acl_buf` is 1024 bytes, far more than one ACE needs.
+    unsafe { InitializeAcl(acl, (acl_buf.len() * 4) as u32, ACL_REVISION) }.expect("InitializeAcl");
+    if granted != NO_ACE {
+        // SAFETY: `acl` is initialized above; `sid` is a valid SID owned by `sid_buf`.
+        unsafe { AddAccessAllowedAce(acl, ACL_REVISION, granted, sid) }.expect("AddAccessAllowedAce");
+    }
+
+    let mut sd = SECURITY_DESCRIPTOR::default();
+    let psd = PSECURITY_DESCRIPTOR(&mut sd as *mut _ as *mut _);
+    // SAFETY: `sd` is a stack SECURITY_DESCRIPTOR; 1 is the only defined revision.
+    unsafe { InitializeSecurityDescriptor(psd, 1) }.expect("InitializeSecurityDescriptor");
+    // SAFETY: `psd` is initialized; `acl_buf` stays alive until after CreateProcessW.
+    unsafe { SetSecurityDescriptorDacl(psd, true, Some(acl), false) }.expect("SetSecurityDescriptorDacl");
+
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: psd.0,
+        bInheritHandle: false.into(),
+    };
+
+    // NUL-terminated HERE, centrally: `CreateProcessW` takes a `PWSTR` and reads until the
+    // terminator, so a caller that forgot one would send it reading past the end of the
+    // allocation. No call site can get this wrong.
+    let mut cmdline: Vec<u16> = cmdline.encode_utf16().chain(std::iter::once(0)).collect();
+    let si = STARTUPINFOW {
+        cb: size_of::<STARTUPINFOW>() as u32,
+        ..Default::default()
+    };
+    let mut pi = PROCESS_INFORMATION::default();
+    // SAFETY: `cmdline` is a NUL-terminated writable UTF-16 buffer; `sa` and the DACL it
+    // points at are alive for the duration of the call.
+    unsafe {
+        CreateProcessW(
+            None,
+            Some(PWSTR(cmdline.as_mut_ptr())),
+            Some(&sa),
+            None,
+            false,
+            CREATE_NO_WINDOW | CREATE_SUSPENDED,
+            None,
+            None,
+            &si,
+            &mut pi,
+        )
+    }
+    .expect("CreateProcessW for the restricted fixture child");
+
+    // SAFETY: an unnamed job object has no preconditions; the handle is owned by the
+    // RestrictedChild and closed in Drop.
+    let job = unsafe { CreateJobObjectW(None, None) }.expect("CreateJobObjectW");
+    let limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
+            LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    // SAFETY: `limits` matches the class being set.
+    unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &limits as *const _ as *const core::ffi::c_void,
+            size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    }
+    .expect("SetInformationJobObject");
+    // SAFETY: both handles are live and ours.
+    unsafe { AssignProcessToJobObject(job, pi.hProcess) }.expect("AssignProcessToJobObject");
+
+    // Only NOW may the child run. Windows enrols a process-s children in its job only from
+    // the moment the parent is already a member, so a child that started running before the
+    // assignment could spawn a grandchild permanently outside the job - which is exactly the
+    // orphan the job exists to prevent. CREATE_SUSPENDED closes that window by construction.
+    // SAFETY: `pi.hThread` is the freshly created, still-suspended main thread.
+    let prev = unsafe { ResumeThread(pi.hThread) };
+    assert_eq!(prev, 1, "the fixture child must resume from exactly one suspend");
+
+    let child = RestrictedChild {
+        handle: pi.hProcess,
+        thread: pi.hThread,
+        job,
+        pid: pi.dwProcessId,
+    };
+    // A child that died on startup would still keep its kernel object alive through our
+    // handle, so every OpenProcess verdict would look right while testing nothing.
+    assert!(child.is_running(), "the fixture child exited immediately — the command line is wrong");
+    child
+}
+
+#[cfg(test)]
+#[path = "windows_fixture_tests.rs"]
+mod windows_fixture_tests;

--- a/src/identity/windows_fixture_tests.rs
+++ b/src/identity/windows_fixture_tests.rs
@@ -1,0 +1,103 @@
+//! The fixture must spawn a process that is genuinely LIVE and genuinely denied. If these
+//! fail, every access-denied test downstream is vacuous — so they assert the raw Win32
+//! verdicts, not our wrappers.
+
+use windows::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED};
+use windows::Win32::System::Threading::{
+    OpenProcess, PROCESS_ACCESS_RIGHTS, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+};
+
+use super::{spawn_query_only, spawn_restricted, spawn_unkillable};
+
+/// The raw Win32 error code for `OpenProcess(mask, pid)`, or `None` if it succeeded.
+fn open_err(pid: u32, mask: PROCESS_ACCESS_RIGHTS) -> Option<u32> {
+    // SAFETY: OpenProcess tolerates any pid; the handle is closed before return.
+    match unsafe { OpenProcess(mask, false, pid) } {
+        Ok(h) => {
+            unsafe { CloseHandle(h) }.expect("CloseHandle of an owned process handle");
+            None
+        }
+        // HRESULT_FROM_WIN32 packs the Win32 code in the low 16 bits.
+        Err(e) => Some(e.code().0 as u32 & 0xFFFF),
+    }
+}
+
+#[test]
+fn the_fixture_child_is_actually_running() {
+    let child = spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    assert!(
+        child.is_running(),
+        "the fixture must hand back a LIVE process, or every denial test below is vacuous"
+    );
+}
+
+#[test]
+fn query_limited_is_denied_when_not_granted() {
+    let child = spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    assert_eq!(
+        open_err(child.pid(), PROCESS_QUERY_LIMITED_INFORMATION),
+        Some(ERROR_ACCESS_DENIED.0),
+        "the fixture must make QUERY_LIMITED genuinely unopenable"
+    );
+    assert!(child.is_running(), "and it must still be live at the point of the claim");
+}
+
+#[test]
+fn synchronize_is_denied_while_query_limited_is_granted() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    assert_eq!(open_err(child.pid(), PROCESS_QUERY_LIMITED_INFORMATION), None);
+    assert_eq!(
+        open_err(child.pid(), PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE),
+        Some(ERROR_ACCESS_DENIED.0),
+        "the fixture must make the SYNCHRONIZE upgrade genuinely fail"
+    );
+    assert!(child.is_running());
+}
+
+#[test]
+fn spawn_unkillable_denies_everything() {
+    // The empty DACL is load-bearing for four downstream tests; if it ever granted anything
+    // they would all take the Opened::Found path and pass vacuously.
+    let child = spawn_unkillable();
+    assert_eq!(
+        open_err(child.pid(), PROCESS_QUERY_LIMITED_INFORMATION),
+        Some(ERROR_ACCESS_DENIED.0)
+    );
+    assert_eq!(open_err(child.pid(), PROCESS_TERMINATE), Some(ERROR_ACCESS_DENIED.0));
+    assert!(child.is_running(), "precondition: the subject must be live");
+}
+
+#[test]
+fn spawn_query_only_denies_terminate_and_grants_query_limited() {
+    // Its denial property is what makes `wait::kill`'s Denied arm reachable at all; without
+    // this the test that depends on it would pass by terminating a corpse instead.
+    let child = spawn_query_only();
+    assert_eq!(open_err(child.pid(), PROCESS_QUERY_LIMITED_INFORMATION), None);
+    assert_eq!(
+        open_err(child.pid(), PROCESS_TERMINATE),
+        Some(ERROR_ACCESS_DENIED.0),
+        "spawn_query_only must deny PROCESS_TERMINATE"
+    );
+    assert!(child.is_running(), "precondition: the subject must be live");
+}
+
+#[test]
+fn terminate_is_granted_by_spawn_restricted_and_denied_by_spawn_unkillable() {
+    // Bound, not temporaries: the fixture's own handle keeps a dead child's kernel object
+    // (and pid) alive, so both verdicts below hold on a corpse. Liveness must be asserted.
+    let granted = spawn_restricted(0);
+    assert_eq!(open_err(granted.pid(), PROCESS_TERMINATE), None);
+    assert!(granted.is_running(), "precondition: the subject must be live");
+
+    let denied = spawn_unkillable();
+    assert_eq!(open_err(denied.pid(), PROCESS_TERMINATE), Some(ERROR_ACCESS_DENIED.0));
+    assert!(denied.is_running(), "precondition: the subject must be live");
+}
+
+#[test]
+fn terminate_records_the_exit_and_is_idempotent() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    child.terminate();
+    assert!(!child.is_running(), "terminate must record an exit");
+    child.terminate(); // second call must not panic — Drop calls it again
+}

--- a/src/identity/windows_fixture_tests.rs
+++ b/src/identity/windows_fixture_tests.rs
@@ -39,7 +39,10 @@ fn query_limited_is_denied_when_not_granted() {
         Some(ERROR_ACCESS_DENIED.0),
         "the fixture must make QUERY_LIMITED genuinely unopenable"
     );
-    assert!(child.is_running(), "and it must still be live at the point of the claim");
+    assert!(
+        child.is_running(),
+        "and it must still be live at the point of the claim"
+    );
 }
 
 #[test]

--- a/src/identity/windows_tests.rs
+++ b/src/identity/windows_tests.rs
@@ -28,7 +28,11 @@ fn is_running_alive_for_self_dead_for_wrong_token() {
     };
     assert_eq!(is_running(pid, tok), Liveness::Alive, "we are obviously running");
     let wrong = StartToken::from_raw(tok.raw().wrapping_add(1));
-    assert_eq!(is_running(pid, wrong), Liveness::Dead, "a wrong token is a different process");
+    assert_eq!(
+        is_running(pid, wrong),
+        Liveness::Dead,
+        "a wrong token is a different process"
+    );
 }
 
 /// A LIVE process we may not open at all: ERROR_ACCESS_DENIED must NOT read as absence.
@@ -193,7 +197,10 @@ fn wait_on_a_stale_identity_over_an_unreadable_pid_is_an_error() {
     let real = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
         .expect("the owned handle always yields an identity");
     let stale = crate::identity::ProcessId::from_parts_for_test(real.pid(), real.start_token_raw() ^ 1);
-    assert!(child.is_running(), "precondition: the pid's occupant is live and unreadable");
+    assert!(
+        child.is_running(),
+        "precondition: the pid's occupant is live and unreadable"
+    );
     crate::wait::block_until_exit(stale, Some(std::time::Duration::ZERO))
         .expect_err("an unreadable occupant cannot prove the original identity exited");
 }

--- a/src/identity/windows_tests.rs
+++ b/src/identity/windows_tests.rs
@@ -1,19 +1,199 @@
-use super::{is_running, start_token};
+use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
+use windows::Win32::System::Threading::{PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE};
+
+use super::{creation_token, current_token, is_running, start_token};
+use crate::identity::windows_fixture::spawn_restricted;
+use crate::identity::{Liveness, Resolved, StartToken};
 
 #[test]
 fn start_token_of_current_process_is_stable() {
     let pid = std::process::id();
-    let a = start_token(pid).expect("the current process has a start token");
-    let b = start_token(pid).expect("re-read should also succeed");
-    assert_eq!(a, b); // raw creation FILETIME is fixed for a process's lifetime
+    let a = start_token(pid);
+    assert!(matches!(a, Resolved::Found(_)), "our own token must resolve: {a:?}");
+    assert_eq!(a, start_token(pid), "the same pid must yield the same token");
+}
+
+/// `current_token` reads the pseudo-handle, so it must agree with the by-pid read on a
+/// process that permits both — and, unlike it, can never be denied.
+#[test]
+fn current_token_agrees_with_the_by_pid_read() {
+    assert_eq!(current_token(), start_token(std::process::id()));
 }
 
 #[test]
-fn current_process_reads_as_running() {
+fn is_running_alive_for_self_dead_for_wrong_token() {
     let pid = std::process::id();
-    let tok = start_token(pid).expect("token");
-    assert!(is_running(pid, tok), "we are obviously running");
-    // A wrong token (PID reuse) must not read as running, even for a live pid.
-    let wrong = super::StartToken::from_raw(tok.raw().wrapping_add(1));
-    assert!(!is_running(pid, wrong));
+    let Resolved::Found(tok) = start_token(pid) else {
+        panic!("our own token must resolve");
+    };
+    assert_eq!(is_running(pid, tok), Liveness::Alive, "we are obviously running");
+    let wrong = StartToken::from_raw(tok.raw().wrapping_add(1));
+    assert_eq!(is_running(pid, wrong), Liveness::Dead, "a wrong token is a different process");
+}
+
+/// A LIVE process we may not open at all: ERROR_ACCESS_DENIED must NOT read as absence.
+#[test]
+fn denied_query_limited_reads_unknown_not_gone() {
+    let child = spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    let token = creation_token(child.handle()).expect("the owned handle can always read the token");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(
+        start_token(child.pid()),
+        Resolved::Unknown,
+        "an access-denied live process must not resolve as Gone"
+    );
+    assert_eq!(
+        is_running(child.pid(), token),
+        Liveness::Unknown,
+        "an access-denied live process must not read as Dead"
+    );
+    assert!(child.is_running(), "and it must still have been live throughout");
+}
+
+/// QUERY_LIMITED granted, SYNCHRONIZE denied: the identity resolves, but the signaled state
+/// cannot be read and GetExitCodeProcess reports STILL_ACTIVE, which does not distinguish
+/// "running" from "exited with code 259". Unknown, not Alive, not Dead.
+#[test]
+fn denied_synchronize_resolves_identity_but_liveness_is_unknown_while_running() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    let token = creation_token(child.handle()).expect("owned handle reads the token");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(start_token(child.pid()), Resolved::Found(token));
+    assert_eq!(
+        is_running(child.pid(), token),
+        Liveness::Unknown,
+        "SYNCHRONIZE is denied and STILL_ACTIVE is ambiguous — never Alive, never Dead"
+    );
+    assert!(child.is_running());
+}
+
+/// The same process after it exits with a concrete code: GetExitCodeProcess PROVES the exit
+/// through QUERY_LIMITED alone, so this must be Dead — not Unknown, or every already-dead
+/// `kill` on such a process would report failure.
+#[test]
+fn exited_process_denying_synchronize_reads_dead() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    let token = creation_token(child.handle()).expect("owned handle reads the token");
+    child.terminate(); // exit code 1
+    assert!(!child.is_running(), "precondition: the subject must have exited");
+    assert_eq!(is_running(child.pid(), token), Liveness::Dead);
+}
+
+/// A pid that cannot exist classifies as definitely-gone, not Unknown — otherwise the
+/// tri-state would degenerate to always-Unknown.
+#[test]
+fn nonexistent_pid_is_gone_not_unknown() {
+    // OpenProcess for an unused pid returns ERROR_INVALID_PARAMETER, the "no such process"
+    // signal. The value is chosen, not arbitrary: Windows allocates pids from a low, densely
+    // packed table (multiples of 4), so a value near u32::MAX is unallocatable rather than
+    // merely unlikely — the "gone" precondition holds by construction, the way the denied
+    // tests assert theirs by fixture.
+    let ghost = 0xFFFF_FFF0u32;
+    assert_eq!(start_token(ghost), Resolved::Gone);
+    assert_eq!(is_running(ghost, StartToken::from_raw(1)), Liveness::Dead);
+}
+
+/// `Process::kill` documents "a real failure (no rights / access-denied on a live process)
+/// => Err". An access-denied live process must therefore not produce Ok.
+#[test]
+fn kill_of_an_access_denied_live_process_is_an_error() {
+    let child = crate::identity::windows_fixture::spawn_unkillable();
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    let err = crate::wait::kill(id).expect_err("killing a process we may not open must not report success");
+    let crate::error::Error::Unassessable { source, .. } = err else {
+        panic!("a denial must not read as an I/O failure: {err:?}");
+    };
+    let io = source.expect("the OS error is preserved");
+    // `From<windows::core::Error> for io::Error` stores the HRESULT, not the bare Win32
+    // code, so compare against the wrapped form — `Some(5)` would never match.
+    assert_eq!(
+        io.raw_os_error(),
+        Some(windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0).0),
+        "{io}"
+    );
+    assert!(child.is_running(), "and it must still be running — nothing killed it");
+}
+
+/// `Process::wait` must not report an exit it never observed.
+#[test]
+fn block_until_exit_of_an_access_denied_live_process_is_an_error() {
+    let child = crate::identity::windows_fixture::spawn_unkillable();
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    let err = crate::wait::block_until_exit(id, Some(std::time::Duration::ZERO))
+        .expect_err("an unopenable live process must not be reported as exited");
+    let crate::error::Error::Unassessable { source, .. } = err else {
+        panic!("a denial must not read as an I/O failure: {err:?}");
+    };
+    let io = source.expect("the OS error is preserved");
+    assert_eq!(
+        io.raw_os_error(),
+        Some(windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0).0),
+        "{io}"
+    );
+}
+
+/// The other side of the same branch: `Denied` plus a provably-Dead target must still report
+/// success, or every already-exited kill or wait on such a process would start failing. The
+/// two entry points need DIFFERENT fixtures, because their masks differ.
+#[test]
+fn wait_of_a_synchronize_denied_but_exited_process_reports_exited() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    child.terminate();
+    assert!(!child.is_running(), "precondition: the subject must have exited");
+    assert_eq!(id.is_alive(), Liveness::Dead, "precondition: provably dead");
+    assert!(crate::wait::block_until_exit(id, Some(std::time::Duration::ZERO))
+        .expect("waiting on an already-exited process is success"));
+}
+
+#[test]
+fn kill_of_a_terminate_denied_but_exited_process_reports_success() {
+    use windows::Win32::System::Threading::PROCESS_TERMINATE;
+    let child = crate::identity::windows_fixture::spawn_query_only();
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    // Precondition: kill's own mask must actually be refused, or this exercises the
+    // Opened::Found path and never reaches the arm under test.
+    assert!(
+        matches!(
+            super::open_classified(child.pid(), PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION),
+            super::Opened::Denied(_)
+        ),
+        "precondition: wait::kill's open must be denied"
+    );
+    child.terminate();
+    assert!(!child.is_running(), "precondition: the subject must have exited");
+    assert_eq!(id.is_alive(), Liveness::Dead, "precondition: provably dead");
+    crate::wait::kill(id).expect("killing an already-exited process is success");
+}
+
+/// A stale identity over a pid whose occupant we CAN read: the token comparison runs, finds
+/// a different process, and reports the original exited.
+#[test]
+fn wait_on_a_stale_identity_over_a_readable_pid_reports_exited() {
+    let child = spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    let real = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    let stale = crate::identity::ProcessId::from_parts_for_test(real.pid(), real.start_token_raw() ^ 1);
+    assert!(child.is_running(), "precondition: the pid's occupant is live");
+    assert!(crate::wait::block_until_exit(stale, Some(std::time::Duration::ZERO))
+        .expect("a readable stranger on the pid proves the stale identity is gone"));
+}
+
+/// The other half of the documented asymmetry: when the pid's occupant cannot be read
+/// either, the original's exit cannot be established. `Err`, not a guessed `Ok`.
+#[test]
+fn wait_on_a_stale_identity_over_an_unreadable_pid_is_an_error() {
+    let child = crate::identity::windows_fixture::spawn_unkillable();
+    let real = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    let stale = crate::identity::ProcessId::from_parts_for_test(real.pid(), real.start_token_raw() ^ 1);
+    assert!(child.is_running(), "precondition: the pid's occupant is live and unreadable");
+    crate::wait::block_until_exit(stale, Some(std::time::Duration::ZERO))
+        .expect_err("an unreadable occupant cannot prove the original identity exited");
 }

--- a/src/identity_tests.rs
+++ b/src/identity_tests.rs
@@ -1,4 +1,4 @@
-use super::{ProcessId, RawPid, StartToken};
+use super::{Existence, Liveness, ProcessId, RawPid, Resolved, StartToken};
 use std::collections::HashSet;
 
 // Build a ProcessId directly from parts (this test module can access the
@@ -46,9 +46,9 @@ fn is_copy_and_exposes_pid() {
 #[test]
 fn current_process_resolves_exists_and_is_alive() {
     let me = ProcessId::current();
-    assert!(me.exists());
-    assert!(me.is_alive());
-    assert_eq!(Some(me), ProcessId::of(me.pid()));
+    assert_eq!(me.exists(), crate::identity::Existence::Present);
+    assert_eq!(me.is_alive(), crate::identity::Liveness::Alive);
+    assert_eq!(ProcessId::of(me.pid()), Resolved::Found(me));
     assert!(me.created_at().is_some());
 }
 
@@ -58,7 +58,7 @@ fn start_token_raw_is_stable_and_matches_reresolved() {
     // Stable across two calls on the same identity.
     assert_eq!(me.start_token_raw(), me.start_token_raw());
     // Equals the token of a freshly re-resolved identity for the same pid.
-    let again = ProcessId::of(me.pid()).expect("current pid resolves");
+    let again = ProcessId::of(me.pid()).found().expect("current pid resolves");
     assert_eq!(me.start_token_raw(), again.start_token_raw());
 }
 
@@ -70,6 +70,40 @@ fn imposter_token_neither_exists_nor_is_alive() {
         pid: me.pid(),
         start: StartToken::from_raw(me.start.raw().wrapping_add(1)),
     };
-    assert!(!imposter.exists(), "wrong token must not resolve to our process");
-    assert!(!imposter.is_alive(), "wrong token is not a running process");
+    assert_eq!(imposter.exists(), crate::identity::Existence::Gone, "wrong token must not resolve to our process");
+    assert_eq!(imposter.is_alive(), crate::identity::Liveness::Dead, "wrong token is not a running process");
+}
+
+#[cfg(windows)]
+#[test]
+fn an_access_denied_live_process_is_unknown_everywhere() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    // We cannot name it by pid at all...
+    assert_eq!(ProcessId::of(child.pid()), Resolved::Unknown);
+    // ...and every question about the identity we DO hold is Unknown.
+    assert_eq!(id.exists(), Existence::Unknown, "denied must not read as Gone");
+    assert_eq!(id.is_alive(), Liveness::Unknown, "denied must not read as Dead");
+    assert!(child.is_running(), "and it must still have been live throughout");
+}
+
+#[cfg(windows)]
+#[test]
+fn a_process_denying_only_synchronize_exists_but_has_unknown_liveness() {
+    use windows::Win32::System::Threading::PROCESS_QUERY_LIMITED_INFORMATION;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_QUERY_LIMITED_INFORMATION.0);
+    assert!(child.is_running(), "precondition: the subject must be live");
+    let Resolved::Found(id) = ProcessId::of(child.pid()) else {
+        panic!("QUERY_LIMITED is granted, so the identity must resolve");
+    };
+    assert_eq!(id.exists(), Existence::Present);
+    assert_eq!(
+        id.is_alive(),
+        Liveness::Unknown,
+        "is_alive must never claim Dead for a process whose exit it could not establish"
+    );
+    assert!(child.is_running());
 }

--- a/src/identity_tests.rs
+++ b/src/identity_tests.rs
@@ -1,4 +1,6 @@
-use super::{Existence, Liveness, ProcessId, RawPid, Resolved, StartToken};
+#[cfg(windows)]
+use super::{Existence, Liveness};
+use super::{ProcessId, RawPid, Resolved, StartToken};
 use std::collections::HashSet;
 
 // Build a ProcessId directly from parts (this test module can access the
@@ -70,8 +72,16 @@ fn imposter_token_neither_exists_nor_is_alive() {
         pid: me.pid(),
         start: StartToken::from_raw(me.start.raw().wrapping_add(1)),
     };
-    assert_eq!(imposter.exists(), crate::identity::Existence::Gone, "wrong token must not resolve to our process");
-    assert_eq!(imposter.is_alive(), crate::identity::Liveness::Dead, "wrong token is not a running process");
+    assert_eq!(
+        imposter.exists(),
+        crate::identity::Existence::Gone,
+        "wrong token must not resolve to our process"
+    );
+    assert_eq!(
+        imposter.is_alive(),
+        crate::identity::Liveness::Dead,
+        "wrong token is not a running process"
+    );
 }
 
 #[cfg(windows)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -46,7 +46,7 @@ impl Process {
         ProcessId::of(pid).map(|id| Process { id })
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, windows))]
     pub(crate) fn from_parts_for_test(id: ProcessId) -> Process {
         Process { id }
     }
@@ -97,7 +97,10 @@ impl Process {
             Existence::Present => {}
             Existence::Gone => return None,
             Existence::Unknown => {
-                log::warn!("Process::parent: pid {} is unassessable — returning None", self.id.pid());
+                log::warn!(
+                    "Process::parent: pid {} is unassessable — returning None",
+                    self.id.pid()
+                );
                 return None;
             }
         }
@@ -143,7 +146,10 @@ impl Process {
             Existence::Present => {}
             Existence::Gone => return Vec::new(),
             Existence::Unknown => {
-                log::warn!("Process::children: pid {} is unassessable — returning none", self.id.pid());
+                log::warn!(
+                    "Process::children: pid {} is unassessable — returning none",
+                    self.id.pid()
+                );
                 return Vec::new();
             }
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use crate::error::Error;
-use crate::identity::{ProcessId, RawPid};
+use crate::identity::{Existence, Liveness, ProcessId, RawPid, Resolved};
 
 #[path = "process/graceful.rs"]
 mod graceful;
@@ -29,15 +29,26 @@ pub struct Process {
 }
 
 impl Process {
-    /// Resolve a foreign process by a saved identity. `None` if that exact identity is
-    /// gone or the pid was recycled.
-    pub fn from_id(id: ProcessId) -> Option<Process> {
-        (ProcessId::of(id.pid()) == Some(id)).then_some(Process { id })
+    /// Resolve a foreign process by a saved identity. [`Resolved::Gone`] if that exact
+    /// identity is gone or the pid was recycled; [`Resolved::Unknown`] if the OS refused the
+    /// query — the process may well be running.
+    pub fn from_id(id: ProcessId) -> Resolved<Process> {
+        match ProcessId::of(id.pid()) {
+            Resolved::Found(live) if live == id => Resolved::Found(Process { id }),
+            Resolved::Found(_) | Resolved::Gone => Resolved::Gone,
+            Resolved::Unknown => Resolved::Unknown,
+        }
     }
 
-    /// Resolve the process currently holding `pid`. `None` if no live process has it.
-    pub fn from_pid(pid: RawPid) -> Option<Process> {
+    /// Resolve the process currently holding `pid`. [`Resolved::Gone`] if no process has it;
+    /// [`Resolved::Unknown`] if the OS refused the query.
+    pub fn from_pid(pid: RawPid) -> Resolved<Process> {
         ProcessId::of(pid).map(|id| Process { id })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts_for_test(id: ProcessId) -> Process {
+        Process { id }
     }
 
     /// This process's own handle. Infallible.
@@ -53,7 +64,8 @@ impl Process {
     }
 
     /// Whether the process is still running (zombie-exclusive; see [`ProcessId::is_alive`]).
-    pub fn is_alive(&self) -> bool {
+    /// [`Liveness::Unknown`] when the OS refuses the query.
+    pub fn is_alive(&self) -> Liveness {
         self.id.is_alive()
     }
 
@@ -78,9 +90,16 @@ impl Process {
     /// modulo the per-OS same-tick residual the whole crate shares. `None` if there is no
     /// resolvable parent or `self` itself was recycled.
     pub fn parent(&self) -> Option<Process> {
-        // Anchor: a query against a recycled self pid is meaningless.
-        if !self.id.exists() {
-            return None;
+        // Anchor: a query against a recycled self pid is meaningless. An Unknown anchor
+        // cannot rule that out either, so it is treated the same — the alternative is
+        // enumerating a stranger's tree.
+        match self.id.exists() {
+            Existence::Present => {}
+            Existence::Gone => return None,
+            Existence::Unknown => {
+                log::warn!("Process::parent: pid {} is unassessable — returning None", self.id.pid());
+                return None;
+            }
         }
         let parents = crate::containment::enumerate::process_parents();
         let ppid = parents
@@ -91,7 +110,17 @@ impl Process {
         if ppid == self.id.pid() {
             return None;
         }
-        let parent = ProcessId::of(ppid)?;
+        // The SECOND collapse point in this function: folding an access-denied parent into
+        // "no parent" with no trace would reproduce the same Unknown-into-absence collapse
+        // the anchor check above exists to avoid.
+        let parent = match ProcessId::of(ppid) {
+            Resolved::Found(p) => p,
+            Resolved::Gone => return None,
+            Resolved::Unknown => {
+                log::warn!("Process::parent: ppid {ppid} could not be queried (access denied?) — reporting no parent");
+                return None;
+            }
+        };
         // Identity guard: a genuine parent predates this child, so the child's start token
         // orders at-or-after the parent's. A recycled ppid names a process created AFTER
         // this one (later token) — reject it.
@@ -108,9 +137,15 @@ impl Process {
     /// candidate is kept only if its start token orders at-or-after this process). Snapshot;
     /// best-effort.
     pub fn children(&self, recursive: Recursive) -> Vec<Process> {
-        // Anchor: a recycled self pid maps the whole query onto a stranger.
-        if !self.id.exists() {
-            return Vec::new();
+        // Anchor: a recycled self pid maps the whole query onto a stranger. An Unknown
+        // anchor cannot rule that out either.
+        match self.id.exists() {
+            Existence::Present => {}
+            Existence::Gone => return Vec::new(),
+            Existence::Unknown => {
+                log::warn!("Process::children: pid {} is unassessable — returning none", self.id.pid());
+                return Vec::new();
+            }
         }
         let parents = crate::containment::enumerate::process_parents();
         let ids = match recursive {

--- a/src/process/graceful_tests.rs
+++ b/src/process/graceful_tests.rs
@@ -37,7 +37,7 @@ fn spawn_term_ignoring_sleeper() -> std::process::Child {
 #[test]
 fn foreign_graceful_lone_watch_error_still_escalates() {
     let mut child = spawn_term_ignoring_sleeper();
-    let p = crate::Process::from_pid(child.id()).expect("resolves");
+    let p = crate::Process::from_pid(child.id()).found().expect("resolves");
     fault::set_force_watch_error(true);
     let err = p
         .graceful_shutdown(Duration::from_secs(30))
@@ -63,7 +63,7 @@ fn foreign_graceful_lone_watch_error_still_escalates() {
 #[test]
 fn foreign_graceful_tree_watch_error_still_sweeps() {
     let mut child = spawn_term_ignoring_sleeper();
-    let p = crate::Process::from_pid(child.id()).expect("resolves");
+    let p = crate::Process::from_pid(child.id()).found().expect("resolves");
     fault::set_force_watch_error(true);
     let err = p
         .graceful_shutdown_tree(Duration::from_secs(30))

--- a/src/process_tests.rs
+++ b/src/process_tests.rs
@@ -4,9 +4,9 @@ use crate::identity::ProcessId;
 #[test]
 fn current_resolves_and_is_alive() {
     let me = Process::current();
-    assert!(me.is_alive());
-    assert_eq!(Process::from_id(me.id()), Some(me));
-    assert_eq!(Process::from_pid(me.id().pid()), Some(me));
+    assert_eq!(me.is_alive(), crate::identity::Liveness::Alive);
+    assert_eq!(Process::from_id(me.id()), crate::identity::Resolved::Found(me));
+    assert_eq!(Process::from_pid(me.id().pid()), crate::identity::Resolved::Found(me));
 }
 
 #[test]
@@ -18,7 +18,7 @@ fn from_id_rejects_a_recycled_pid() {
     let stale = ProcessId::from_parts_for_test(real.pid(), real.start_token_raw().wrapping_add(1));
     assert_eq!(
         Process::from_id(stale),
-        None,
+        crate::identity::Resolved::Gone,
         "a mismatched start token must not resolve"
     );
 }
@@ -27,4 +27,77 @@ fn from_id_rejects_a_recycled_pid() {
 fn process_is_send_and_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Process>();
+}
+
+#[cfg(windows)]
+#[test]
+fn from_pid_is_unknown_for_an_access_denied_process() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(
+        Process::from_pid(child.pid()),
+        crate::identity::Resolved::Unknown,
+        "a live process we may not query must not resolve as Gone"
+    );
+}
+
+/// `from_id` reaches Unknown through a different path than `from_pid` - it additionally
+/// compares the resolved identity against the caller-s, and that comparison is where an
+/// Unknown-into-Gone collapse would hide.
+#[cfg(windows)]
+#[test]
+fn from_id_is_unknown_for_an_access_denied_process() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(Process::from_id(id), crate::identity::Resolved::Unknown);
+}
+
+/// Pinned default: an unassessable anchor yields the same empty answers as a gone one.
+#[cfg(windows)]
+#[test]
+fn parent_and_children_of_an_unassessable_anchor_are_empty() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    assert_eq!(id.exists(), crate::identity::Existence::Unknown, "precondition: unassessable");
+    let p = Process::from_parts_for_test(id);
+    assert!(p.parent().is_none());
+    assert!(p.children(crate::Recursive::No).is_empty());
+    assert!(p.children(crate::Recursive::Yes).is_empty());
+}
+
+/// The ppid branch, distinct from the anchor branch: the subject resolves fine, but its
+/// PARENT is access-denied. Built by having the restricted fixture itself be the parent - a
+/// DACL is not inherited, so `cmd.exe` is unopenable while the `ping` it spawns is not.
+#[cfg(windows)]
+#[test]
+fn parent_of_a_process_whose_parent_is_access_denied_is_none_and_warns() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    crate::log_capture::install();
+    let parent = crate::identity::windows_fixture::spawn_restricted_shell(PROCESS_SYNCHRONIZE.0);
+    let kid_pid = parent.wait_for_child();
+    assert!(parent.is_running(), "precondition: the denied parent must be live");
+    let crate::identity::Resolved::Found(kid) = Process::from_pid(kid_pid) else {
+        panic!("the grandchild is not DACL-restricted, so it must resolve");
+    };
+    assert_eq!(
+        ProcessId::of(parent.pid()),
+        crate::identity::Resolved::Unknown,
+        "precondition: the parent must be unassessable"
+    );
+    let mark = crate::log_capture::mark();
+    assert!(kid.parent().is_none(), "an unassessable ppid yields no parent");
+    // Pinned to THIS fixture-s ppid and to this site-s prefix: `contains_since` bounds time
+    // only, and `treewalk::resolve_or_drop` emits a message sharing the "could not be
+    // queried" tail from any concurrent teardown in the same test process.
+    assert!(crate::log_capture::contains_since(
+        mark,
+        &format!("Process::parent: ppid {} could not be queried", parent.pid())
+    ));
 }

--- a/src/process_tests.rs
+++ b/src/process_tests.rs
@@ -65,7 +65,11 @@ fn parent_and_children_of_an_unassessable_anchor_are_empty() {
     let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
         .expect("the owned handle always yields an identity");
     assert!(child.is_running(), "precondition: the subject must be live");
-    assert_eq!(id.exists(), crate::identity::Existence::Unknown, "precondition: unassessable");
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Unknown,
+        "precondition: unassessable"
+    );
     let p = Process::from_parts_for_test(id);
     assert!(p.parent().is_none());
     assert!(p.children(crate::Recursive::No).is_empty());

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -101,7 +101,7 @@ impl Child {
     pub fn id(&self) -> ProcessId {
         self.id
     }
-    pub fn is_alive(&self) -> bool {
+    pub fn is_alive(&self) -> crate::identity::Liveness {
         self.id.is_alive()
     }
     pub fn containment(&self) -> Containment {

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -34,7 +34,9 @@ async fn async_graceful_tree_watch_error_still_sweeps_and_reaps() {
     // zombie-inclusive); Windows skips the assert — exists() stays true there while
     // `child` still holds the process handle.
     #[cfg(unix)]
-    assert_eq!(id.exists(), crate::identity::Existence::Gone,
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
         "root must be swept AND reaped despite the watch error (a zombie would still exist)"
     );
     #[cfg(windows)]
@@ -69,7 +71,9 @@ async fn async_graceful_lone_watch_error_still_escalates_and_reaps() {
         "seam not consumed — the watch did not run on this thread"
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
-    assert_eq!(id.exists(), crate::identity::Existence::Gone,
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
         "child must be killed AND reaped despite the watch error (a zombie would still exist)"
     );
     let status = child

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -34,8 +34,7 @@ async fn async_graceful_tree_watch_error_still_sweeps_and_reaps() {
     // zombie-inclusive); Windows skips the assert — exists() stays true there while
     // `child` still holds the process handle.
     #[cfg(unix)]
-    assert!(
-        !id.exists(),
+    assert_eq!(id.exists(), crate::identity::Existence::Gone,
         "root must be swept AND reaped despite the watch error (a zombie would still exist)"
     );
     #[cfg(windows)]
@@ -70,8 +69,7 @@ async fn async_graceful_lone_watch_error_still_escalates_and_reaps() {
         "seam not consumed — the watch did not run on this thread"
     );
     assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
-    assert!(
-        !id.exists(),
+    assert_eq!(id.exists(), crate::identity::Existence::Gone,
         "child must be killed AND reaped despite the watch error (a zombie would still exist)"
     );
     let status = child

--- a/src/tokio/process.rs
+++ b/src/tokio/process.rs
@@ -27,12 +27,12 @@ impl From<crate::process::Process> for Process {
 impl Process {
     /// Resolve a foreign process by a saved identity. `None` if that exact identity is
     /// gone or the pid was recycled.
-    pub fn from_id(id: ProcessId) -> Option<Process> {
+    pub fn from_id(id: ProcessId) -> crate::identity::Resolved<Process> {
         crate::process::Process::from_id(id).map(Process::from)
     }
 
     /// Resolve the process currently holding `pid`. `None` if no live process has it.
-    pub fn from_pid(pid: RawPid) -> Option<Process> {
+    pub fn from_pid(pid: RawPid) -> crate::identity::Resolved<Process> {
         crate::process::Process::from_pid(pid).map(Process::from)
     }
 
@@ -47,7 +47,7 @@ impl Process {
     }
 
     /// Whether the process is still running (zombie-exclusive; see [`ProcessId::is_alive`]).
-    pub fn is_alive(&self) -> bool {
+    pub fn is_alive(&self) -> crate::identity::Liveness {
         self.inner.is_alive()
     }
 

--- a/src/tokio/process/graceful_tests.rs
+++ b/src/tokio/process/graceful_tests.rs
@@ -34,7 +34,7 @@ fn spawn_term_ignoring_sleeper() -> std::process::Child {
 #[tokio::test]
 async fn async_foreign_graceful_watch_error_still_escalates() {
     let mut child = spawn_term_ignoring_sleeper();
-    let p = crate::tokio::Process::from_pid(child.id()).expect("resolves");
+    let p = crate::tokio::Process::from_pid(child.id()).found().expect("resolves");
     fault::set_force_watch_error(true);
     let err = p
         .graceful_shutdown(Duration::from_secs(30))
@@ -58,7 +58,7 @@ async fn async_foreign_graceful_watch_error_still_escalates() {
 #[tokio::test]
 async fn async_foreign_graceful_tree_watch_error_still_sweeps() {
     let mut child = spawn_term_ignoring_sleeper();
-    let p = crate::tokio::Process::from_pid(child.id()).expect("resolves");
+    let p = crate::tokio::Process::from_pid(child.id()).found().expect("resolves");
     fault::set_force_watch_error(true);
     let err = p
         .graceful_shutdown_tree(Duration::from_secs(30))

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -295,14 +295,12 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     // pins the pid against reuse, so `ProcessId::of` still resolves it (as the sync spawn documents).
     let pid = child.id().expect("a freshly spawned, un-awaited tokio child has a pid");
     let id = match resolve_identity(pid) {
-        Some(id) => id,
+        crate::identity::Resolved::Found(id) => id,
         // Mirror the attach-failure path below: tear the child down so a vanished-identity error
         // never leaks a live (Windows: still CREATE_SUSPENDED) process.
-        None => {
+        other => {
             reap_now(&mut child, pid, false); // never awaited — an already-Done child is impossible
-            return Err(Error::Io(std::io::Error::other(
-                "spawned async child vanished before identity read",
-            )));
+            return Err(crate::child::spawn::spawn_identity_error(other));
         }
     };
 

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -378,12 +378,10 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
         }
     };
     let id = match resolve_identity(pid) {
-        Some(id) => id,
-        None => {
+        crate::identity::Resolved::Found(id) => id,
+        other => {
             sync_raw::raw_spawn_teardown(proc, pid);
-            return Err(Error::Io(std::io::Error::other(
-                "spawned async child vanished before its identity could be read",
-            )));
+            return Err(crate::child::spawn::spawn_identity_error(other));
         }
     };
 

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -148,7 +148,7 @@ pub(crate) mod fault_observer {
 async fn exit_watch(id: ProcessId) -> Result<(), Error> {
     use ::tokio::io::unix::AsyncFd;
     use ::tokio::io::Interest;
-    let Some(pidfd) = crate::wait::backend::open_verified(id)? else {
+    let Some(pidfd) = crate::wait::backend::open_verified(id, "its exit cannot be observed")? else {
         return Ok(());
     };
     // The pidfd becomes readable (POLLIN) when the task becomes a zombie; POLLHUP once

--- a/src/tokio/wait_tests.rs
+++ b/src/tokio/wait_tests.rs
@@ -239,7 +239,11 @@ async fn wait_exit_cancel_leaves_child_untouched() {
             panic!("unbounded watch resolved at first poll on a live child: {r:?}");
         }
     } // <- future dropped here; on Windows the drop-guard releases the blocking watcher
-    assert_eq!(id.is_alive(), crate::identity::Liveness::Alive, "a cancelled watch must not affect the child");
+    assert_eq!(
+        id.is_alive(),
+        crate::identity::Liveness::Alive,
+        "a cancelled watch must not affect the child"
+    );
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }
@@ -263,7 +267,11 @@ async fn wait_exit_drop_releases_the_windows_watcher() {
     } // <- drop signals the cancel event
     rx.recv()
         .expect("the blocking watcher must return after the drop released it");
-    assert_eq!(id.is_alive(), crate::identity::Liveness::Alive, "release must be signal-free");
+    assert_eq!(
+        id.is_alive(),
+        crate::identity::Liveness::Alive,
+        "release must be signal-free"
+    );
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }

--- a/src/tokio/wait_tests.rs
+++ b/src/tokio/wait_tests.rs
@@ -22,7 +22,7 @@ fn std_blocker() -> std::process::Child {
 #[tokio::test]
 async fn grace_wait_true_for_exited_unreaped_child() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     child.kill().expect("kill");
     // NOT reaped yet (no wait): on Unix the child is a zombie — the watch must still see the
     // exit.
@@ -34,7 +34,7 @@ async fn grace_wait_true_for_exited_unreaped_child() {
 #[tokio::test]
 async fn grace_wait_false_for_live_child_at_zero_grace() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let exited = grace_wait(id, Duration::ZERO).await.expect("grace_wait");
     assert!(!exited, "a live child at ZERO grace must report still-alive");
     child.kill().expect("cleanup");
@@ -44,7 +44,7 @@ async fn grace_wait_false_for_live_child_at_zero_grace() {
 #[tokio::test]
 async fn grace_wait_true_for_stale_identity() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     child.kill().expect("kill");
     child.wait().expect("reap"); // fully gone; the pid may even be recycled
     let exited = grace_wait(id, Duration::from_secs(30)).await.expect("grace_wait");
@@ -57,7 +57,7 @@ async fn grace_wait_true_when_child_dies_mid_wait() {
     // exit event (our own kill). Whether the kill lands before or after arming, the result
     // must be `true`.
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let watch = ::tokio::spawn(grace_wait(id, Duration::from_secs(30)));
     child.kill().expect("kill mid-wait");
     let exited = watch.await.expect("join").expect("grace_wait");
@@ -73,7 +73,7 @@ async fn grace_wait_true_when_child_dies_mid_wait() {
 #[test]
 fn cancel_event_releases_the_blocking_wait() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let cancel = crate::wait::backend::new_cancel_event().expect("event");
     crate::wait::backend::signal_cancel(&cancel);
     let exited = crate::wait::backend::block_until_exit_or_cancel(id, None, &cancel).expect("cancellable wait");
@@ -90,7 +90,7 @@ fn cancel_event_releases_the_blocking_wait() {
 #[test]
 fn cancel_event_signaled_mid_wait_releases_the_blocking_wait() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let cancel = std::sync::Arc::new(crate::wait::backend::new_cancel_event().expect("event"));
     let watcher = std::thread::spawn({
         let cancel = cancel.clone();
@@ -113,7 +113,7 @@ fn cancel_event_signaled_mid_wait_releases_the_blocking_wait() {
 async fn watch_loop_survives_a_non_exit_drain_cycle() {
     let mut decoy = std_blocker();
     let target = std_blocker();
-    let target_id = ProcessId::of(target.id()).expect("identity of live target");
+    let target_id = ProcessId::of(target.id()).found().expect("identity of live target");
     let kq = crate::wait::backend::arm_proc_exit(target_id)
         .expect("arm target")
         .expect("a live target arms");
@@ -189,7 +189,7 @@ mod classify {
 #[tokio::test]
 async fn wait_exit_resolves_for_exited_unreaped_child() {
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     child.kill().expect("kill");
     // NOT reaped: the exit event precedes the call, so the unbounded watch must resolve.
     wait_exit(id).await.expect("wait_exit");
@@ -200,7 +200,7 @@ async fn wait_exit_resolves_for_exited_unreaped_child() {
 async fn wait_exit_resolves_when_child_dies_mid_wait() {
     // Arm on a LIVE child; our own kill is the real exit event. Race-tolerant either side.
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let watch = ::tokio::spawn(wait_exit(id));
     child.kill().expect("kill mid-wait");
     watch.await.expect("join").expect("wait_exit");
@@ -213,7 +213,7 @@ async fn grace_wait_zero_reports_an_observed_exit() {
     // parity case a plain timeout(ZERO, ..) gets wrong (the AsyncFd readiness of a zombie
     // needs a reactor round-trip the zero timer would win against).
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     child.kill().expect("kill");
     // Observe the exit as a real event WITHOUT reaping: wait for it via the unbounded watch
     // (30 s-class bound is the harness), then probe at ZERO.
@@ -231,7 +231,7 @@ async fn wait_exit_cancel_leaves_child_untouched() {
     // Poll the unbounded watch exactly once (arms it), then drop — the watch is signal-free,
     // so the child must still be alive; it dies only by the test's own kill.
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     {
         let mut fut = std::pin::pin!(wait_exit(id));
         let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
@@ -239,7 +239,7 @@ async fn wait_exit_cancel_leaves_child_untouched() {
             panic!("unbounded watch resolved at first poll on a live child: {r:?}");
         }
     } // <- future dropped here; on Windows the drop-guard releases the blocking watcher
-    assert!(id.is_alive(), "a cancelled watch must not affect the child");
+    assert_eq!(id.is_alive(), crate::identity::Liveness::Alive, "a cancelled watch must not affect the child");
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }
@@ -253,7 +253,7 @@ async fn wait_exit_drop_releases_the_windows_watcher() {
     let (tx, rx) = std::sync::mpsc::channel();
     super::fault_observer::install_release_observer(tx);
     let mut child = std_blocker();
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     {
         let mut fut = std::pin::pin!(wait_exit(id));
         let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
@@ -263,7 +263,7 @@ async fn wait_exit_drop_releases_the_windows_watcher() {
     } // <- drop signals the cancel event
     rx.recv()
         .expect("the blocking watcher must return after the drop released it");
-    assert!(id.is_alive(), "release must be signal-free");
+    assert_eq!(id.is_alive(), crate::identity::Liveness::Alive, "release must be signal-free");
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }

--- a/src/wait/linux.rs
+++ b/src/wait/linux.rs
@@ -8,10 +8,10 @@ use rustix::event::{poll, PollFd, PollFlags};
 use rustix::process::{pidfd_open, pidfd_send_signal, Pid, PidfdFlags, Signal};
 
 use crate::error::Error;
-use crate::identity::ProcessId;
+use crate::identity::{Existence, ProcessId};
 
 /// Open a pidfd for `id`, re-verifying identity. `Ok(None)` => already gone (treat as exited).
-pub(crate) fn open_verified(id: ProcessId) -> Result<Option<rustix::fd::OwnedFd>, Error> {
+pub(crate) fn open_verified(id: ProcessId, what: &'static str) -> Result<Option<rustix::fd::OwnedFd>, Error> {
     debug_assert!(
         id.pid() <= i32::MAX as u32,
         "pid {} exceeds i32::MAX; pidfd cast would truncate",
@@ -30,15 +30,24 @@ pub(crate) fn open_verified(id: ProcessId) -> Result<Option<rustix::fd::OwnedFd>
         }
         Err(e) => return Err(Error::Io(std::io::Error::from(e))),
     };
-    // Re-verify: a pid recycled before open means the original is already gone.
-    if !id.exists() {
-        return Ok(None);
+    // Re-verify: a pid recycled before open means the original is already gone. An
+    // unassessable pid (hidepid, EPERM) is NOT gone and must not be treated as one.
+    match id.exists() {
+        Existence::Present => Ok(Some(pidfd)),
+        Existence::Gone => Ok(None),
+        Existence::Unknown => {
+            // The decision site `read_stat`-s debug-level probe relies on.
+            log::warn!("wait: pid {} identity could not be confirmed; {what}", id.pid());
+            Err(Error::Unassessable {
+                detail: format!("pid {} identity could not be confirmed; {what}", id.pid()),
+                source: None,
+            })
+        }
     }
-    Ok(Some(pidfd))
 }
 
 pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>) -> Result<bool, Error> {
-    let Some(pidfd) = open_verified(id)? else {
+    let Some(pidfd) = open_verified(id, "its exit cannot be observed")? else {
         return Ok(true);
     };
     loop {
@@ -70,7 +79,7 @@ pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>)
 }
 
 pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
-    let Some(pidfd) = open_verified(id)? else { return Ok(()) };
+    let Some(pidfd) = open_verified(id, "no signal was sent")? else { return Ok(()) };
     match pidfd_send_signal(&pidfd, Signal::KILL) {
         Ok(()) => Ok(()),
         Err(rustix::io::Errno::SRCH) => Ok(()), // exited between re-verify and signal
@@ -79,7 +88,7 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
 }
 
 pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
-    let Some(pidfd) = open_verified(id)? else { return Ok(()) };
+    let Some(pidfd) = open_verified(id, "no signal was sent")? else { return Ok(()) };
     match pidfd_send_signal(&pidfd, Signal::TERM) {
         Ok(()) => Ok(()),
         Err(rustix::io::Errno::SRCH) => Ok(()), // exited between re-verify and signal

--- a/src/wait/linux.rs
+++ b/src/wait/linux.rs
@@ -79,7 +79,9 @@ pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>)
 }
 
 pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
-    let Some(pidfd) = open_verified(id, "no signal was sent")? else { return Ok(()) };
+    let Some(pidfd) = open_verified(id, "no signal was sent")? else {
+        return Ok(());
+    };
     match pidfd_send_signal(&pidfd, Signal::KILL) {
         Ok(()) => Ok(()),
         Err(rustix::io::Errno::SRCH) => Ok(()), // exited between re-verify and signal
@@ -88,7 +90,9 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
 }
 
 pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
-    let Some(pidfd) = open_verified(id, "no signal was sent")? else { return Ok(()) };
+    let Some(pidfd) = open_verified(id, "no signal was sent")? else {
+        return Ok(());
+    };
     match pidfd_send_signal(&pidfd, Signal::TERM) {
         Ok(()) => Ok(()),
         Err(rustix::io::Errno::SRCH) => Ok(()), // exited between re-verify and signal

--- a/src/wait/macos.rs
+++ b/src/wait/macos.rs
@@ -56,10 +56,18 @@ pub(crate) fn arm_proc_exit(id: ProcessId) -> Result<Option<Kqueue>, Error> {
     if arm_note_exit_on(&kq, id.pid())?.is_none() {
         return Ok(None); // pid already gone
     }
-    if !id.exists() {
-        return Ok(None); // recycled before the filter armed
+    // An unassessable identity is NOT gone and must not be reported as an exit.
+    match id.exists() {
+        crate::identity::Existence::Present => Ok(Some(kq)),
+        crate::identity::Existence::Gone => Ok(None), // recycled before the filter armed
+        crate::identity::Existence::Unknown => {
+            log::warn!("wait: pid {} identity could not be confirmed; its exit cannot be observed", id.pid());
+            Err(Error::Unassessable {
+                detail: format!("pid {} identity could not be confirmed; its exit cannot be observed", id.pid()),
+                source: None,
+            })
+        }
     }
-    Ok(Some(kq))
 }
 
 /// Drain one pending event from an armed kqueue without blocking. `Ok(Some(()))` = the exit
@@ -115,15 +123,31 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
     // Re-verify identity immediately before signaling. The window between this check
     // and kill(2) is irreducible on macOS (no pidfd); a recycled pid in that window is
     // a documented best-effort limitation, mirroring treewalk::kill_by_identity.
-    if ProcessId::of(id.pid()) != Some(id) {
-        return Ok(()); // gone (or recycled) => already-dead is success
+    match ProcessId::of(id.pid()) {
+        crate::identity::Resolved::Found(live) if live == id => {}
+        // gone (or recycled) => already-dead is success
+        crate::identity::Resolved::Found(_) | crate::identity::Resolved::Gone => return Ok(()),
+        crate::identity::Resolved::Unknown => {
+            log::warn!("wait: pid {} identity could not be confirmed - no signal was sent", id.pid());
+            return Err(Error::Unassessable {
+                detail: format!("pid {} identity could not be confirmed; no signal was sent", id.pid()),
+                source: None,
+            });
+        }
     }
-    debug_assert!(
-        id.pid() <= i32::MAX as u32,
-        "pid {} exceeds i32::MAX; signal target cast would truncate",
-        id.pid()
-    );
-    match nix_kill(Pid::from_raw(id.pid() as i32), Signal::SIGKILL) {
+    // `nix::unistd::Pid::from_raw` is infallible and accepts 0, and `kill(0, sig)` signals
+    // the CALLER-S ENTIRE PROCESS GROUP. `kernel_task` is pid 0 and macOS RESOLVES it, so the
+    // re-verify above does not rule the value out, and a `debug_assert` would vanish in
+    // release. Use the same total guard the `sig 0` probe uses.
+    let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
+        // A discard site: the Result can carry this, so it must not read as a silent success.
+        log::warn!("wait: pid {} is not a single-process signal target - not signaled", id.pid());
+        return Err(Error::Unassessable {
+            detail: format!("pid {} is not a signalable single-process target", id.pid()),
+            source: None,
+        });
+    };
+    match nix_kill(Pid::from_raw(target), Signal::SIGKILL) {
         Ok(()) => Ok(()),
         Err(nix::errno::Errno::ESRCH) => Ok(()), // exited between re-verify and kill
         Err(e) => Err(Error::Io(e.into())),      // EPERM etc. surfaced, not swallowed
@@ -134,15 +158,31 @@ pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
     use nix::sys::signal::{kill as nix_kill, Signal};
     use nix::unistd::Pid;
     // Re-verify identity immediately before signaling.
-    if ProcessId::of(id.pid()) != Some(id) {
-        return Ok(()); // gone (or recycled) => already-dead is success
+    match ProcessId::of(id.pid()) {
+        crate::identity::Resolved::Found(live) if live == id => {}
+        // gone (or recycled) => already-dead is success
+        crate::identity::Resolved::Found(_) | crate::identity::Resolved::Gone => return Ok(()),
+        crate::identity::Resolved::Unknown => {
+            log::warn!("wait: pid {} identity could not be confirmed - no signal was sent", id.pid());
+            return Err(Error::Unassessable {
+                detail: format!("pid {} identity could not be confirmed; no signal was sent", id.pid()),
+                source: None,
+            });
+        }
     }
-    debug_assert!(
-        id.pid() <= i32::MAX as u32,
-        "pid {} exceeds i32::MAX; signal target cast would truncate",
-        id.pid()
-    );
-    match nix_kill(Pid::from_raw(id.pid() as i32), Signal::SIGTERM) {
+    // `nix::unistd::Pid::from_raw` is infallible and accepts 0, and `kill(0, sig)` signals
+    // the CALLER-S ENTIRE PROCESS GROUP. `kernel_task` is pid 0 and macOS RESOLVES it, so the
+    // re-verify above does not rule the value out, and a `debug_assert` would vanish in
+    // release. Use the same total guard the `sig 0` probe uses.
+    let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
+        // A discard site: the Result can carry this, so it must not read as a silent success.
+        log::warn!("wait: pid {} is not a single-process signal target - not signaled", id.pid());
+        return Err(Error::Unassessable {
+            detail: format!("pid {} is not a signalable single-process target", id.pid()),
+            source: None,
+        });
+    };
+    match nix_kill(Pid::from_raw(target), Signal::SIGTERM) {
         Ok(()) => Ok(()),
         Err(nix::errno::Errno::ESRCH) => Ok(()),
         Err(e) => Err(Error::Io(e.into())),

--- a/src/wait/macos.rs
+++ b/src/wait/macos.rs
@@ -61,9 +61,15 @@ pub(crate) fn arm_proc_exit(id: ProcessId) -> Result<Option<Kqueue>, Error> {
         crate::identity::Existence::Present => Ok(Some(kq)),
         crate::identity::Existence::Gone => Ok(None), // recycled before the filter armed
         crate::identity::Existence::Unknown => {
-            log::warn!("wait: pid {} identity could not be confirmed; its exit cannot be observed", id.pid());
+            log::warn!(
+                "wait: pid {} identity could not be confirmed; its exit cannot be observed",
+                id.pid()
+            );
             Err(Error::Unassessable {
-                detail: format!("pid {} identity could not be confirmed; its exit cannot be observed", id.pid()),
+                detail: format!(
+                    "pid {} identity could not be confirmed; its exit cannot be observed",
+                    id.pid()
+                ),
                 source: None,
             })
         }
@@ -128,7 +134,10 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
         // gone (or recycled) => already-dead is success
         crate::identity::Resolved::Found(_) | crate::identity::Resolved::Gone => return Ok(()),
         crate::identity::Resolved::Unknown => {
-            log::warn!("wait: pid {} identity could not be confirmed - no signal was sent", id.pid());
+            log::warn!(
+                "wait: pid {} identity could not be confirmed - no signal was sent",
+                id.pid()
+            );
             return Err(Error::Unassessable {
                 detail: format!("pid {} identity could not be confirmed; no signal was sent", id.pid()),
                 source: None,
@@ -141,7 +150,10 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
     // release. Use the same total guard the `sig 0` probe uses.
     let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
         // A discard site: the Result can carry this, so it must not read as a silent success.
-        log::warn!("wait: pid {} is not a single-process signal target - not signaled", id.pid());
+        log::warn!(
+            "wait: pid {} is not a single-process signal target - not signaled",
+            id.pid()
+        );
         return Err(Error::Unassessable {
             detail: format!("pid {} is not a signalable single-process target", id.pid()),
             source: None,
@@ -163,7 +175,10 @@ pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
         // gone (or recycled) => already-dead is success
         crate::identity::Resolved::Found(_) | crate::identity::Resolved::Gone => return Ok(()),
         crate::identity::Resolved::Unknown => {
-            log::warn!("wait: pid {} identity could not be confirmed - no signal was sent", id.pid());
+            log::warn!(
+                "wait: pid {} identity could not be confirmed - no signal was sent",
+                id.pid()
+            );
             return Err(Error::Unassessable {
                 detail: format!("pid {} identity could not be confirmed; no signal was sent", id.pid()),
                 source: None,
@@ -176,7 +191,10 @@ pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
     // release. Use the same total guard the `sig 0` probe uses.
     let Some(target) = crate::identity::probe::signal_target(id.pid()) else {
         // A discard site: the Result can carry this, so it must not read as a silent success.
-        log::warn!("wait: pid {} is not a single-process signal target - not signaled", id.pid());
+        log::warn!(
+            "wait: pid {} is not a single-process signal target - not signaled",
+            id.pid()
+        );
         return Err(Error::Unassessable {
             detail: format!("pid {} is not a signalable single-process target", id.pid()),
             source: None,

--- a/src/wait/macos_tests.rs
+++ b/src/wait/macos_tests.rs
@@ -18,18 +18,27 @@ fn drain_reports_none_when_no_event_pending() {
     child.wait().expect("reap");
 }
 
-/// The guard that stops `kill(0, sig)` from SIGKILLing the caller-s own process group must be
-/// consulted by the real entry points, not merely exist as a pure function. `ProcessId::of(0)`
-/// resolves on macOS (`kernel_task`), so nothing upstream rules the value out.
+/// `kill(0, sig)` would signal the caller's ENTIRE process group, so pid 0 must never reach
+/// `kill(2)`. Two independent layers stop it, and this pins the outer one: the identity
+/// re-verify. `ProcessId::of(0)` resolves on macOS (`kernel_task`), but to a token that no
+/// caller-held identity matches, so a pid-0 identity is rejected as recycled before the
+/// signal is ever formed — and the test process, which is what `kill(0, ..)` would have
+/// killed, survives to make the assertion.
+///
+/// The inner layer, `probe::signal_target`, is defence in depth for a caller holding
+/// `kernel_task`'s *genuine* identity. It is not exercised here on purpose: a regression in
+/// it would SIGKILL the CI runner's process group rather than fail a test. Its own contract
+/// is pinned by `identity::probe::probe_tests::signal_target_is_the_guard_for_real_signals`.
 #[test]
-fn kill_and_terminate_refuse_a_group_directed_target() {
+fn a_pid_zero_identity_never_reaches_kill() {
     let bogus = crate::identity::ProcessId::from_parts_for_test(0, 1);
-    assert!(matches!(
-        crate::wait::kill(bogus),
-        Err(crate::error::Error::Unassessable { .. })
-    ));
-    assert!(matches!(
-        crate::wait::terminate(bogus),
-        Err(crate::error::Error::Unassessable { .. })
-    ));
+    // Already-gone is success: the pid holds a process, but not the one named.
+    crate::wait::kill(bogus).expect("a pid-0 identity resolves to a stranger, i.e. already gone");
+    crate::wait::terminate(bogus).expect("same for the graceful signal");
+    // If either call had reached `kill(2)`, this process would have died with it.
+    assert_eq!(
+        crate::identity::ProcessId::current().is_alive(),
+        crate::identity::Liveness::Alive,
+        "the caller must have survived - nothing may signal process group 0"
+    );
 }

--- a/src/wait/macos_tests.rs
+++ b/src/wait/macos_tests.rs
@@ -8,7 +8,7 @@ fn drain_reports_none_when_no_event_pending() {
         .arg("30")
         .spawn()
         .expect("spawn blocker");
-    let id = ProcessId::of(child.id()).expect("identity of live child");
+    let id = ProcessId::of(child.id()).found().expect("identity of live child");
     let kq = super::arm_proc_exit(id).expect("arm").expect("a live child arms");
     assert!(
         super::drain_proc_exit(&kq).expect("drain").is_none(),
@@ -16,4 +16,20 @@ fn drain_reports_none_when_no_event_pending() {
     );
     child.kill().expect("cleanup");
     child.wait().expect("reap");
+}
+
+/// The guard that stops `kill(0, sig)` from SIGKILLing the caller-s own process group must be
+/// consulted by the real entry points, not merely exist as a pure function. `ProcessId::of(0)`
+/// resolves on macOS (`kernel_task`), so nothing upstream rules the value out.
+#[test]
+fn kill_and_terminate_refuse_a_group_directed_target() {
+    let bogus = crate::identity::ProcessId::from_parts_for_test(0, 1);
+    assert!(matches!(
+        crate::wait::kill(bogus),
+        Err(crate::error::Error::Unassessable { .. })
+    ));
+    assert!(matches!(
+        crate::wait::terminate(bogus),
+        Err(crate::error::Error::Unassessable { .. })
+    ));
 }

--- a/src/wait/windows.rs
+++ b/src/wait/windows.rs
@@ -7,12 +7,12 @@ use std::time::{Duration, Instant};
 
 use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Threading::{
-    CreateEventW, OpenProcess, SetEvent, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject, INFINITE,
-    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+    CreateEventW, SetEvent, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject,
+    INFINITE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
 };
 
 use crate::error::Error;
-use crate::identity::ProcessId;
+use crate::identity::{HandleIdentity, Liveness, Opened, ProcessId};
 
 fn close(handle: HANDLE) {
     // Match identity/windows.rs: a failed CloseHandle of an owned handle is a contract
@@ -22,18 +22,48 @@ fn close(handle: HANDLE) {
 }
 
 pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>) -> Result<bool, Error> {
-    // SAFETY: OpenProcess tolerates a dead/invalid pid (returns Err); the handle is
-    // closed on every return path below.
-    let handle = match unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, false, id.pid()) }
-    {
-        Ok(h) => h,
-        // gone / unopenable => exited (an access-denied live process reads as exited here,
-        // mirroring ProcessId::is_alive, which also treats open-failure as not-running).
-        Err(_) => return Ok(true),
+    let handle = match crate::identity::windows_open_classified(
+        id.pid(),
+        PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+    ) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Ok(true), // no such pid => exited
+        // Denied on a LIVE process => a real failure: reporting "exited" would let a
+        // supervisor conclude a healthy service had died. The error comes from the
+        // classifier, not `last_os_error()`: `is_alive()` below runs a whole
+        // open/query/wait cycle that would overwrite the thread-s last-error first.
+        Opened::Denied(e) => {
+            return match id.is_alive() {
+                Liveness::Dead => Ok(true),
+                Liveness::Alive | Liveness::Unknown => {
+                    log::warn!(
+                        "wait: pid {} could not be opened to watch for its exit ({e}) - reporting an error, not an exit",
+                        id.pid()
+                    );
+                    Err(Error::Unassessable {
+                        detail: format!("pid {} could not be opened to watch for its exit", id.pid()),
+                        source: Some(e.into()),
+                    })
+                }
+            }
+        }
     };
-    if !id.exists() {
-        close(handle);
-        return Ok(true); // recycled before open
+    // The handle already in hand answers the recycle question with no race; a second by-pid
+    // lookup would not.
+    match crate::identity::windows_handle_identity(handle, id) {
+        HandleIdentity::Same => {}
+        HandleIdentity::Different => {
+            close(handle);
+            return Ok(true); // recycled before open - the original is gone
+        }
+        HandleIdentity::Unreadable(e) => {
+            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            close(handle);
+            return Err(Error::Unassessable {
+                detail: format!("pid {} opened but its identity could not be verified", id.pid()),
+                source: Some(e.into()),
+            });
+        }
     }
     let ms: u32 = match crate::wait::remaining(deadline) {
         None => INFINITE,
@@ -91,17 +121,48 @@ pub(crate) fn block_until_exit_or_cancel(
     grace: Option<Duration>,
     cancel: &OwnedHandle,
 ) -> Result<bool, Error> {
-    // SAFETY: OpenProcess tolerates a dead/invalid pid (returns Err); the handle is
-    // closed on every return path below.
-    let handle = match unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, false, id.pid()) }
-    {
-        Ok(h) => h,
-        // gone / unopenable => exited (mirroring block_until_exit).
-        Err(_) => return Ok(true),
+    let handle = match crate::identity::windows_open_classified(
+        id.pid(),
+        PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+    ) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Ok(true), // no such pid => exited
+        // Denied on a LIVE process => a real failure: reporting "exited" would let a
+        // supervisor conclude a healthy service had died. The error comes from the
+        // classifier, not `last_os_error()`: `is_alive()` below runs a whole
+        // open/query/wait cycle that would overwrite the thread-s last-error first.
+        Opened::Denied(e) => {
+            return match id.is_alive() {
+                Liveness::Dead => Ok(true),
+                Liveness::Alive | Liveness::Unknown => {
+                    log::warn!(
+                        "wait: pid {} could not be opened to watch for its exit ({e}) - reporting an error, not an exit",
+                        id.pid()
+                    );
+                    Err(Error::Unassessable {
+                        detail: format!("pid {} could not be opened to watch for its exit", id.pid()),
+                        source: Some(e.into()),
+                    })
+                }
+            }
+        }
     };
-    if !id.exists() {
-        close(handle);
-        return Ok(true); // recycled before open
+    // The handle already in hand answers the recycle question with no race; a second by-pid
+    // lookup would not.
+    match crate::identity::windows_handle_identity(handle, id) {
+        HandleIdentity::Same => {}
+        HandleIdentity::Different => {
+            close(handle);
+            return Ok(true); // recycled before open - the original is gone
+        }
+        HandleIdentity::Unreadable(e) => {
+            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            close(handle);
+            return Err(Error::Unassessable {
+                detail: format!("pid {} opened but its identity could not be verified", id.pid()),
+                source: Some(e.into()),
+            });
+        }
     }
     let ms = match grace {
         None => INFINITE,
@@ -143,35 +204,65 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
     // Open for terminate AND query, so the SAME held handle both pins the kernel object
     // (pid-reuse-safe) and lets us re-verify identity before terminating.
     // SAFETY: OpenProcess tolerates an invalid pid; the handle is closed on every path below.
-    let handle = match unsafe { OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION, false, id.pid()) } {
-        Ok(h) => h,
-        // Can't open: gone => already-dead Ok; live but denied => Err (is_alive is the
-        // signaled-state check, synchronously correct on exit — not zombie-inclusive exists).
-        Err(e) => {
-            return if id.is_alive() {
-                Err(Error::Io(e.into()))
-            } else {
+    let handle = match crate::identity::windows_open_classified(
+        id.pid(),
+        PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
+    ) {
+        Opened::Found(h) => h,
+        Opened::Gone => return Ok(()), // no such pid => already dead is success
+        // Live-or-unassessable => Err. An Unknown liveness must NOT be reported as a
+        // successful kill.
+        Opened::Denied(e) => {
+            return if id.is_alive() == Liveness::Dead {
                 Ok(())
+            } else {
+                log::warn!(
+                    "wait: pid {} could not be opened to terminate it ({e}) - reporting an error, not a kill",
+                    id.pid()
+                );
+                Err(Error::Unassessable {
+                    detail: format!("pid {} could not be opened to terminate it", id.pid()),
+                    source: Some(e.into()),
+                })
             }
         }
     };
-    // Re-verify identity on the HELD handle: a pid recycled before OpenProcess pins the
-    // NEW process, whose creation token won't match — abort (the original is already gone).
-    if !crate::identity::windows_handle_is(handle, id) {
-        close(handle);
-        return Ok(());
+    // Re-verify identity on the HELD handle: a pid recycled before the open pins the NEW
+    // process, whose creation token will not match. An UNREADABLE token is not proof the
+    // target is gone, so it must not report a successful kill.
+    match crate::identity::windows_handle_identity(handle, id) {
+        HandleIdentity::Same => {}
+        HandleIdentity::Different => {
+            close(handle);
+            return Ok(()); // pid recycled; the original is already gone
+        }
+        HandleIdentity::Unreadable(e) => {
+            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            close(handle);
+            return Err(Error::Unassessable {
+                detail: format!("pid {} opened but its identity could not be verified", id.pid()),
+                source: Some(e.into()),
+            });
+        }
     }
     // SAFETY: handle is live; close on every path.
     let res = unsafe { TerminateProcess(handle, 1) };
+    // Re-check BEFORE close: the held handle pins the kernel object, so the by-pid resolve
+    // inside `is_alive` cannot land on a recycled pid. After `close` it could. Windows denies
+    // TerminateProcess on an already-exited process, so this arm is reached routinely on a
+    // successful shutdown, and `is_alive` reads the SIGNALED STATE - unambiguous, unlike
+    // GetExitCodeProcess, which cannot tell a live process from one that exited with 259.
+    let verdict = res.is_err().then(|| id.is_alive());
     close(handle);
     match res {
         Ok(()) => Ok(()),
+        Err(_) if verdict == Some(Liveness::Dead) => Ok(()),
         Err(e) => {
-            if id.is_alive() {
-                Err(Error::Io(e.into()))
-            } else {
-                Ok(())
-            }
+            log::warn!(
+                "wait: TerminateProcess(pid {}) failed and the target is not provably dead ({e})",
+                id.pid()
+            );
+            Err(Error::Io(e.into()))
         }
     }
 }

--- a/src/wait/windows.rs
+++ b/src/wait/windows.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Threading::{
-    CreateEventW, SetEvent, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject,
-    INFINITE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+    CreateEventW, SetEvent, TerminateProcess, WaitForMultipleObjects, WaitForSingleObject, INFINITE,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
 };
 
 use crate::error::Error;
@@ -57,7 +57,10 @@ pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>)
             return Ok(true); // recycled before open - the original is gone
         }
         HandleIdentity::Unreadable(e) => {
-            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            log::warn!(
+                "wait: pid {} opened but its identity could not be verified ({e})",
+                id.pid()
+            );
             close(handle);
             return Err(Error::Unassessable {
                 detail: format!("pid {} opened but its identity could not be verified", id.pid()),
@@ -156,7 +159,10 @@ pub(crate) fn block_until_exit_or_cancel(
             return Ok(true); // recycled before open - the original is gone
         }
         HandleIdentity::Unreadable(e) => {
-            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            log::warn!(
+                "wait: pid {} opened but its identity could not be verified ({e})",
+                id.pid()
+            );
             close(handle);
             return Err(Error::Unassessable {
                 detail: format!("pid {} opened but its identity could not be verified", id.pid()),
@@ -204,29 +210,28 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
     // Open for terminate AND query, so the SAME held handle both pins the kernel object
     // (pid-reuse-safe) and lets us re-verify identity before terminating.
     // SAFETY: OpenProcess tolerates an invalid pid; the handle is closed on every path below.
-    let handle = match crate::identity::windows_open_classified(
-        id.pid(),
-        PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
-    ) {
-        Opened::Found(h) => h,
-        Opened::Gone => return Ok(()), // no such pid => already dead is success
-        // Live-or-unassessable => Err. An Unknown liveness must NOT be reported as a
-        // successful kill.
-        Opened::Denied(e) => {
-            return if id.is_alive() == Liveness::Dead {
-                Ok(())
-            } else {
-                log::warn!(
-                    "wait: pid {} could not be opened to terminate it ({e}) - reporting an error, not a kill",
-                    id.pid()
-                );
-                Err(Error::Unassessable {
-                    detail: format!("pid {} could not be opened to terminate it", id.pid()),
-                    source: Some(e.into()),
-                })
+    let handle =
+        match crate::identity::windows_open_classified(id.pid(), PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION)
+        {
+            Opened::Found(h) => h,
+            Opened::Gone => return Ok(()), // no such pid => already dead is success
+            // Live-or-unassessable => Err. An Unknown liveness must NOT be reported as a
+            // successful kill.
+            Opened::Denied(e) => {
+                return if id.is_alive() == Liveness::Dead {
+                    Ok(())
+                } else {
+                    log::warn!(
+                        "wait: pid {} could not be opened to terminate it ({e}) - reporting an error, not a kill",
+                        id.pid()
+                    );
+                    Err(Error::Unassessable {
+                        detail: format!("pid {} could not be opened to terminate it", id.pid()),
+                        source: Some(e.into()),
+                    })
+                }
             }
-        }
-    };
+        };
     // Re-verify identity on the HELD handle: a pid recycled before the open pins the NEW
     // process, whose creation token will not match. An UNREADABLE token is not proof the
     // target is gone, so it must not report a successful kill.
@@ -237,7 +242,10 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
             return Ok(()); // pid recycled; the original is already gone
         }
         HandleIdentity::Unreadable(e) => {
-            log::warn!("wait: pid {} opened but its identity could not be verified ({e})", id.pid());
+            log::warn!(
+                "wait: pid {} opened but its identity could not be verified ({e})",
+                id.pid()
+            );
             close(handle);
             return Err(Error::Unassessable {
                 detail: format!("pid {} opened but its identity could not be verified", id.pid()),

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -195,7 +195,7 @@ fn process_terminate_sends_sigterm() {
     use std::io::Read;
     use std::os::unix::process::ExitStatusExt;
     let (child, mut sock) = common::spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.terminate().expect("foreign terminate");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf); // dead — EOF
@@ -210,7 +210,7 @@ fn process_graceful_shutdown_graceful_path() {
     use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     let (child, mut sock) = common::spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown(Duration::from_secs(30)).expect("foreign graceful");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf);
@@ -227,7 +227,7 @@ fn process_graceful_shutdown_escalates() {
     // SIGTERM is ignored → SIGKILL is the only terminating signal the child can receive, so the
     // reaped status is unambiguously SIGKILL.
     let (child, mut sock) = common::spawn_control("control-block-ignore-term", &["R"], false);
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown(Duration::ZERO).expect("foreign escalates");
     let mut buf = [0u8; 1];
     let _ = sock.read(&mut buf);
@@ -240,7 +240,7 @@ fn process_graceful_shutdown_escalates() {
 fn process_lone_graceful_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     assert!(matches!(p.terminate(), Err(cosca::error::Error::Unsupported { .. })));
     assert!(matches!(
         p.graceful_shutdown(Duration::from_secs(1)),
@@ -256,7 +256,7 @@ fn process_kill_tree_tears_down_tree() {
     // An UNcontained 2-level tree (root R + grandchild G). Take the root foreign and kill_tree
     // it: the identity-walk (snapshot-then-kill) reaches both. Both sockets EOF. All OSes.
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.kill_tree().expect("kill_tree");
     for (i, s) in socks.iter_mut().enumerate() {
         let mut buf = [0u8; 1];
@@ -275,7 +275,7 @@ fn process_graceful_shutdown_tree_tears_down_tree() {
     use std::io::Read;
     use std::time::Duration;
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown_tree(Duration::from_secs(30))
         .expect("foreign tree graceful");
     for (i, s) in socks.iter_mut().enumerate() {
@@ -294,7 +294,7 @@ fn process_graceful_shutdown_tree_tears_down_tree() {
 fn process_soft_tree_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     assert!(matches!(
         p.terminate_tree(),
         Err(cosca::error::Error::Unsupported { .. })

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -44,8 +44,16 @@ fn child_is_alive_while_running_then_not_after_exit() {
     let pid = child.id();
 
     let id = ProcessId::of(pid).found().expect("a running child has an identity");
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child must be alive (running) right after spawn");
-    assert_eq!(id.exists(), cosca::identity::Existence::Present, "child must be resolvable right after spawn");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "child must be alive (running) right after spawn"
+    );
+    assert_eq!(
+        id.exists(),
+        cosca::identity::Existence::Present,
+        "child must be resolvable right after spawn"
+    );
     assert_ne!(id, ProcessId::current(), "child identity differs from ours");
 
     // End the child deterministically: close its stdin (EOF) and reap it.
@@ -57,7 +65,11 @@ fn child_is_alive_while_running_then_not_after_exit() {
     // synchronously — no teardown-window wait. (exists() may still be true here
     // on Windows during teardown; that is exists()'s documented behavior, so we
     // do not assert on it.)
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "child must read not-running immediately after it exits");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "child must read not-running immediately after it exits"
+    );
 
     drop(child);
 }
@@ -88,8 +100,14 @@ fn identity_resolves_an_exited_unreaped_child() {
         .expect("piped stdout")
         .read_to_end(&mut buf)
         .expect("EOF");
-    let id = ProcessId::of(child.id()).found().expect("an unreaped exit must resolve by pid");
-    assert_eq!(id.exists(), cosca::identity::Existence::Present, "an unreaped exit must remain visible to exists()");
+    let id = ProcessId::of(child.id())
+        .found()
+        .expect("an unreaped exit must resolve by pid");
+    assert_eq!(
+        id.exists(),
+        cosca::identity::Existence::Present,
+        "an unreaped exit must remain visible to exists()"
+    );
     child.wait().expect("reap");
 }
 
@@ -117,8 +135,16 @@ fn identity_survives_the_alive_to_zombie_transition() {
         )
     };
     assert_eq!(rc, 0, "waitid(WNOWAIT): {}", std::io::Error::last_os_error());
-    assert_eq!(id.exists(), cosca::identity::Existence::Present, "the pre-exit token must still match the unreaped zombie");
+    assert_eq!(
+        id.exists(),
+        cosca::identity::Existence::Present,
+        "the pre-exit token must still match the unreaped zombie"
+    );
     assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "a zombie is not alive");
     child.wait().expect("reap");
-    assert_eq!(id.exists(), cosca::identity::Existence::Gone, "a reaped process is gone");
+    assert_eq!(
+        id.exists(),
+        cosca::identity::Existence::Gone,
+        "a reaped process is gone"
+    );
 }

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -43,9 +43,9 @@ fn child_is_alive_while_running_then_not_after_exit() {
     let mut child = spawn_blocking_child();
     let pid = child.id();
 
-    let id = ProcessId::of(pid).expect("a running child has an identity");
-    assert!(id.is_alive(), "child must be alive (running) right after spawn");
-    assert!(id.exists(), "child must be resolvable right after spawn");
+    let id = ProcessId::of(pid).found().expect("a running child has an identity");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child must be alive (running) right after spawn");
+    assert_eq!(id.exists(), cosca::identity::Existence::Present, "child must be resolvable right after spawn");
     assert_ne!(id, ProcessId::current(), "child identity differs from ours");
 
     // End the child deterministically: close its stdin (EOF) and reap it.
@@ -57,7 +57,7 @@ fn child_is_alive_while_running_then_not_after_exit() {
     // synchronously — no teardown-window wait. (exists() may still be true here
     // on Windows during teardown; that is exists()'s documented behavior, so we
     // do not assert on it.)
-    assert!(!id.is_alive(), "child must read not-running immediately after it exits");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "child must read not-running immediately after it exits");
 
     drop(child);
 }
@@ -88,8 +88,8 @@ fn identity_resolves_an_exited_unreaped_child() {
         .expect("piped stdout")
         .read_to_end(&mut buf)
         .expect("EOF");
-    let id = ProcessId::of(child.id()).expect("an unreaped exit must resolve by pid");
-    assert!(id.exists(), "an unreaped exit must remain visible to exists()");
+    let id = ProcessId::of(child.id()).found().expect("an unreaped exit must resolve by pid");
+    assert_eq!(id.exists(), cosca::identity::Existence::Present, "an unreaped exit must remain visible to exists()");
     child.wait().expect("reap");
 }
 
@@ -101,9 +101,9 @@ fn identity_resolves_an_exited_unreaped_child() {
 fn identity_survives_the_alive_to_zombie_transition() {
     // _sock must stay alive: dropping our socket end would unblock the child early.
     let (child, _sock) = common::spawn_blocker();
-    let id = ProcessId::of(child.id().pid()).expect("live child resolves");
-    assert!(id.exists(), "live child exists");
-    assert!(id.is_alive(), "live child is alive");
+    let id = ProcessId::of(child.id().pid()).found().expect("live child resolves");
+    assert_eq!(id.exists(), cosca::identity::Existence::Present, "live child exists");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "live child is alive");
     child.kill().expect("kill");
     // WNOWAIT: leaves the zombie unreaped.
     let mut si: libc::siginfo_t = unsafe { std::mem::zeroed() };
@@ -117,8 +117,8 @@ fn identity_survives_the_alive_to_zombie_transition() {
         )
     };
     assert_eq!(rc, 0, "waitid(WNOWAIT): {}", std::io::Error::last_os_error());
-    assert!(id.exists(), "the pre-exit token must still match the unreaped zombie");
-    assert!(!id.is_alive(), "a zombie is not alive");
+    assert_eq!(id.exists(), cosca::identity::Existence::Present, "the pre-exit token must still match the unreaped zombie");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "a zombie is not alive");
     child.wait().expect("reap");
-    assert!(!id.exists(), "a reaped process is gone");
+    assert_eq!(id.exists(), cosca::identity::Existence::Gone, "a reaped process is gone");
 }

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -12,7 +12,7 @@ use common::spawn_blocker;
 #[test]
 fn foreign_wait_returns_when_the_process_exits() {
     let (child, mut sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("foreign process resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("foreign process resolves");
     sock.write_all(b"x").expect("trigger child exit");
     p.wait().expect("foreign wait");
     // Prove the exit via a real event (the dead child's socket EOFs), not is_alive().
@@ -30,7 +30,7 @@ fn foreign_wait_timeout_times_out_on_a_live_process() {
     // The blocker is structurally wedged on its never-written socket, so it cannot
     // exit; wait_timeout returns Ok(false) regardless of the (short) duration.
     let (child, _sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     let exited = p.wait_timeout(Duration::from_millis(200)).expect("wait_timeout");
     assert!(
         !exited,
@@ -43,7 +43,7 @@ fn foreign_wait_timeout_times_out_on_a_live_process() {
 #[test]
 fn foreign_wait_timeout_observes_an_exit() {
     let (child, mut sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     sock.write_all(b"x").expect("trigger child exit");
     assert!(p.wait_timeout(Duration::from_secs(30)).expect("wait_timeout"));
     let _ = child.wait();
@@ -53,7 +53,7 @@ fn foreign_wait_timeout_observes_an_exit() {
 fn foreign_wait_timeout_zero_returns_immediately_on_a_live_process() {
     // ZERO is the poll-once edge in each backend; a wedged child must yield Ok(false).
     let (child, _sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     assert!(!p.wait_timeout(Duration::ZERO).expect("wait_timeout"));
     child.kill().expect("kill cleanup");
     let _ = child.wait();
@@ -64,7 +64,7 @@ fn foreign_wait_timeout_huge_duration_does_not_panic() {
     // Duration::MAX overflows Instant + Duration; the saturating deadline must make
     // it unbounded, not panic. Trigger the exit first so the wait completes.
     let (child, mut sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     sock.write_all(b"x").expect("trigger child exit");
     assert!(p.wait_timeout(Duration::MAX).expect("wait_timeout"));
     let _ = child.wait();
@@ -73,8 +73,8 @@ fn foreign_wait_timeout_huge_duration_does_not_panic() {
 #[test]
 fn current_and_from_id_round_trip() {
     let me = cosca::Process::current();
-    assert!(me.is_alive());
-    assert_eq!(cosca::Process::from_id(me.id()).map(|p| p.id()), Some(me.id()));
+    assert_eq!(me.is_alive(), cosca::identity::Liveness::Alive);
+    assert_eq!(cosca::Process::from_id(me.id()).found().map(|p| p.id()), Some(me.id()));
 }
 
 #[test]
@@ -84,19 +84,19 @@ fn from_pid_resolves_a_live_foreign_child_then_reports_it_dead() {
     // liveness check, distinct from the zombie-inclusive exists()). Death is proven by the
     // reap, never by sleep.
     let (child, _sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("live foreign child resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("live foreign child resolves");
     assert_eq!(p.id(), child.id());
-    assert!(p.is_alive(), "a freshly spawned foreign child is alive");
+    assert_eq!(p.is_alive(), cosca::identity::Liveness::Alive, "a freshly spawned foreign child is alive");
     child.kill().expect("kill");
     child.wait().expect("reap"); // synchronously confirm exit before the liveness assertion
-    assert!(!p.is_alive(), "a killed+reaped foreign process must report not-alive");
+    assert_eq!(p.is_alive(), cosca::identity::Liveness::Dead, "a killed+reaped foreign process must report not-alive");
 }
 
 #[test]
 fn parent_and_children_resolve_the_spawned_tree() {
     let (child, mut sock) = spawn_blocker();
     let me = cosca::Process::current();
-    let kid = cosca::Process::from_pid(child.id().pid()).expect("child resolves");
+    let kid = cosca::Process::from_pid(child.id().pid()).found().expect("child resolves");
 
     assert_eq!(kid.parent().expect("child has a parent").id(), me.id());
     assert!(me.children(cosca::Recursive::No).iter().any(|p| p.id() == kid.id()));
@@ -127,7 +127,7 @@ fn children_recursive_distinguishes_direct_from_descendant() {
         socks.push(s);
     }
     let me = cosca::Process::current();
-    let kid = cosca::Process::from_pid(child.id().pid()).expect("child resolves");
+    let kid = cosca::Process::from_pid(child.id().pid()).found().expect("child resolves");
     // The grandchild is kid's only direct child — use it to learn the grandchild's identity.
     let grandkids = kid.children(cosca::Recursive::No);
     assert_eq!(
@@ -165,7 +165,7 @@ fn children_recursive_distinguishes_direct_from_descendant() {
 #[test]
 fn foreign_kill_terminates_the_process() {
     let (child, mut sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).expect("resolves");
+    let p = cosca::Process::from_pid(child.id().pid()).found().expect("resolves");
     p.kill().expect("kill");
     let mut buf = [0u8; 1];
     match sock.read(&mut buf) {
@@ -187,8 +187,8 @@ fn foreign_kill_terminates_the_process() {
 #[cfg(unix)]
 #[test]
 fn foreign_kill_surfaces_permission_denied() {
-    let init = cosca::Process::from_pid(1).expect("pid 1 resolves");
-    assert!(init.is_alive(), "init must be alive");
+    let init = cosca::Process::from_pid(1).found().expect("pid 1 resolves");
+    assert_eq!(init.is_alive(), cosca::identity::Liveness::Alive, "init must be alive");
     // SAFETY: geteuid() takes no arguments and is always safe.
     let root = unsafe { libc::geteuid() } == 0;
     #[cfg(not(target_os = "linux"))]
@@ -208,7 +208,7 @@ fn foreign_kill_surfaces_permission_denied() {
     } else {
         assert!(r.is_ok(), "as root, SIGKILL to init is kernel-ignored => Ok, got {r:?}");
     }
-    assert!(init.is_alive(), "init must survive");
+    assert_eq!(init.is_alive(), cosca::identity::Liveness::Alive, "init must survive");
 }
 
 #[cfg(unix)]
@@ -232,15 +232,15 @@ fn is_alive_is_false_for_a_real_zombie() {
     let mut tag = [0u8; 1];
     sock.read_exact(&mut tag).expect("read tag");
 
-    let p = cosca::Process::from_pid(raw.id()).expect("raw child resolves");
+    let p = cosca::Process::from_pid(raw.id()).found().expect("raw child resolves");
     sock.write_all(b"x").expect("trigger exit");
     p.wait().expect("death-watch"); // returns at the zombie instant (no reap yet)
 
-    assert!(!p.is_alive(), "an exited-but-unreaped child is a zombie => not alive");
+    assert_eq!(p.is_alive(), cosca::identity::Liveness::Dead, "an exited-but-unreaped child is a zombie => not alive");
     // exists() is zombie-inclusive on ALL Unixes: Linux `/proc` persists, and macOS
     // resolves zombies via `sysctl KERN_PROC` (identity.rs).
     assert!(
-        cosca::Process::from_id(p.id()).is_some(),
+        matches!(cosca::Process::from_id(p.id()), cosca::identity::Resolved::Found(_)),
         "a zombie identity still resolves"
     );
     raw.wait().expect("reap the zombie");

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -12,7 +12,9 @@ use common::spawn_blocker;
 #[test]
 fn foreign_wait_returns_when_the_process_exits() {
     let (child, mut sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).found().expect("foreign process resolves");
+    let p = cosca::Process::from_pid(child.id().pid())
+        .found()
+        .expect("foreign process resolves");
     sock.write_all(b"x").expect("trigger child exit");
     p.wait().expect("foreign wait");
     // Prove the exit via a real event (the dead child's socket EOFs), not is_alive().
@@ -84,19 +86,31 @@ fn from_pid_resolves_a_live_foreign_child_then_reports_it_dead() {
     // liveness check, distinct from the zombie-inclusive exists()). Death is proven by the
     // reap, never by sleep.
     let (child, _sock) = spawn_blocker();
-    let p = cosca::Process::from_pid(child.id().pid()).found().expect("live foreign child resolves");
+    let p = cosca::Process::from_pid(child.id().pid())
+        .found()
+        .expect("live foreign child resolves");
     assert_eq!(p.id(), child.id());
-    assert_eq!(p.is_alive(), cosca::identity::Liveness::Alive, "a freshly spawned foreign child is alive");
+    assert_eq!(
+        p.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "a freshly spawned foreign child is alive"
+    );
     child.kill().expect("kill");
     child.wait().expect("reap"); // synchronously confirm exit before the liveness assertion
-    assert_eq!(p.is_alive(), cosca::identity::Liveness::Dead, "a killed+reaped foreign process must report not-alive");
+    assert_eq!(
+        p.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "a killed+reaped foreign process must report not-alive"
+    );
 }
 
 #[test]
 fn parent_and_children_resolve_the_spawned_tree() {
     let (child, mut sock) = spawn_blocker();
     let me = cosca::Process::current();
-    let kid = cosca::Process::from_pid(child.id().pid()).found().expect("child resolves");
+    let kid = cosca::Process::from_pid(child.id().pid())
+        .found()
+        .expect("child resolves");
 
     assert_eq!(kid.parent().expect("child has a parent").id(), me.id());
     assert!(me.children(cosca::Recursive::No).iter().any(|p| p.id() == kid.id()));
@@ -127,7 +141,9 @@ fn children_recursive_distinguishes_direct_from_descendant() {
         socks.push(s);
     }
     let me = cosca::Process::current();
-    let kid = cosca::Process::from_pid(child.id().pid()).found().expect("child resolves");
+    let kid = cosca::Process::from_pid(child.id().pid())
+        .found()
+        .expect("child resolves");
     // The grandchild is kid's only direct child — use it to learn the grandchild's identity.
     let grandkids = kid.children(cosca::Recursive::No);
     assert_eq!(
@@ -236,7 +252,11 @@ fn is_alive_is_false_for_a_real_zombie() {
     sock.write_all(b"x").expect("trigger exit");
     p.wait().expect("death-watch"); // returns at the zombie instant (no reap yet)
 
-    assert_eq!(p.is_alive(), cosca::identity::Liveness::Dead, "an exited-but-unreaped child is a zombie => not alive");
+    assert_eq!(
+        p.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "an exited-but-unreaped child is a zombie => not alive"
+    );
     // exists() is zombie-inclusive on ALL Unixes: Linux `/proc` persists, and macOS
     // resolves zombies via `sysctl KERN_PROC` (identity.rs).
     assert!(

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -524,9 +524,9 @@ fn drop_kills_and_reaps_the_child() {
     cmd.stdin(Stdio::pipe()).unwrap();
     let child = cmd.spawn().expect("spawn");
     let id = child.id();
-    assert!(id.is_alive(), "child runs while its stdin stays open");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child runs while its stdin stays open");
     drop(child); // kill_on_drop default true => SIGKILL/TerminateProcess + reap
-    assert!(!id.is_alive(), "child must be dead (and reaped) after drop");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "child must be dead (and reaped) after drop");
 }
 
 #[test]
@@ -539,13 +539,13 @@ fn detach_leaves_the_child_running() {
     // Take the stdin writer BEFORE detaching, so we can end the orphan cleanly
     // (EOF) afterward without needing a wait handle (kill-by-foreign-id is Plan 6).
     let writer = child.stdin().expect("stdin pipe writer");
-    assert!(id.is_alive(), "child runs while its stdin stays open");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child runs while its stdin stays open");
 
     child.detach(); // consumes Child; with kill_on_drop=false, Drop neither kills nor reaps
 
     // The key assertion: detach did NOT kill the process — it is still blocked
     // reading its (still-open) stdin.
-    assert!(id.is_alive(), "detached child must keep running");
+    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "detached child must keep running");
 
     // Cleanup (not an assertion): closing stdin gives the child EOF so it exits
     // on its own. We do NOT assert it became dead — observing a detached

--- a/tests/spawn_io.rs
+++ b/tests/spawn_io.rs
@@ -524,9 +524,17 @@ fn drop_kills_and_reaps_the_child() {
     cmd.stdin(Stdio::pipe()).unwrap();
     let child = cmd.spawn().expect("spawn");
     let id = child.id();
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child runs while its stdin stays open");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "child runs while its stdin stays open"
+    );
     drop(child); // kill_on_drop default true => SIGKILL/TerminateProcess + reap
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Dead, "child must be dead (and reaped) after drop");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "child must be dead (and reaped) after drop"
+    );
 }
 
 #[test]
@@ -539,13 +547,21 @@ fn detach_leaves_the_child_running() {
     // Take the stdin writer BEFORE detaching, so we can end the orphan cleanly
     // (EOF) afterward without needing a wait handle (kill-by-foreign-id is Plan 6).
     let writer = child.stdin().expect("stdin pipe writer");
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "child runs while its stdin stays open");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "child runs while its stdin stays open"
+    );
 
     child.detach(); // consumes Child; with kill_on_drop=false, Drop neither kills nor reaps
 
     // The key assertion: detach did NOT kill the process — it is still blocked
     // reading its (still-open) stdin.
-    assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "detached child must keep running");
+    assert_eq!(
+        id.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "detached child must keep running"
+    );
 
     // Cleanup (not an assertion): closing stdin gives the child EOF so it exits
     // on its own. We do NOT assert it became dead — observing a detached

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -204,7 +204,7 @@ async fn async_graceful_cancel_mid_grace_leaves_child_owned() {
     // SIGTERM handler acks and returns), so its terminating signal cannot distinguish our
     // kill from an escalation — being alive here proves the cancelled graceful sent nothing
     // further.
-    assert!(child.is_alive(), "cancelled graceful must not have escalated");
+    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled graceful must not have escalated");
     child.kill().expect("explicit teardown after cancel");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await.expect("reap");
@@ -234,7 +234,7 @@ async fn async_graceful_tree_cancel_does_not_escalate_on_windows() {
             panic!("graceful future resolved at first poll instead of parking: {r:?}");
         }
     } // <- future dropped mid-grace here
-    assert!(child.is_alive(), "cancelled tree graceful must not have escalated");
+    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled tree graceful must not have escalated");
     child.kill_tree().expect("explicit sweep after cancel");
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);
@@ -265,7 +265,7 @@ async fn async_graceful_tree_cancel_does_not_escalate() {
             panic!("graceful future resolved at first poll instead of parking: {r:?}");
         }
     }
-    assert!(child.is_alive(), "cancelled tree graceful must not have escalated");
+    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled tree graceful must not have escalated");
     child.kill_tree().expect("explicit sweep after cancel");
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -204,7 +204,11 @@ async fn async_graceful_cancel_mid_grace_leaves_child_owned() {
     // SIGTERM handler acks and returns), so its terminating signal cannot distinguish our
     // kill from an escalation — being alive here proves the cancelled graceful sent nothing
     // further.
-    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled graceful must not have escalated");
+    assert_eq!(
+        child.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "cancelled graceful must not have escalated"
+    );
     child.kill().expect("explicit teardown after cancel");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await.expect("reap");
@@ -234,7 +238,11 @@ async fn async_graceful_tree_cancel_does_not_escalate_on_windows() {
             panic!("graceful future resolved at first poll instead of parking: {r:?}");
         }
     } // <- future dropped mid-grace here
-    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled tree graceful must not have escalated");
+    assert_eq!(
+        child.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "cancelled tree graceful must not have escalated"
+    );
     child.kill_tree().expect("explicit sweep after cancel");
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);
@@ -265,7 +273,11 @@ async fn async_graceful_tree_cancel_does_not_escalate() {
             panic!("graceful future resolved at first poll instead of parking: {r:?}");
         }
     }
-    assert_eq!(child.is_alive(), cosca::identity::Liveness::Alive, "cancelled tree graceful must not have escalated");
+    assert_eq!(
+        child.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "cancelled tree graceful must not have escalated"
+    );
     child.kill_tree().expect("explicit sweep after cancel");
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);

--- a/tests/tokio_foreign.rs
+++ b/tests/tokio_foreign.rs
@@ -22,7 +22,7 @@ fn expect_eof(who: &str, s: &mut std::net::TcpStream) {
 #[tokio::test]
 async fn async_foreign_wait_resolves_on_exit() {
     let (child, mut sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     let watch = ::tokio::spawn(async move { p.wait().await });
     child.kill().expect("kill");
     expect_eof("blocker", &mut sock);
@@ -36,7 +36,7 @@ async fn async_foreign_wait_resolves_on_exit() {
 #[tokio::test]
 async fn async_foreign_wait_timeout_zero_is_deterministic() {
     let (child, _sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     assert!(
         !p.wait_timeout(std::time::Duration::ZERO).await.expect("poll"),
         "live child at ZERO"
@@ -48,7 +48,7 @@ async fn async_foreign_wait_timeout_zero_is_deterministic() {
 #[tokio::test]
 async fn async_foreign_wait_timeout_observes_an_exit() {
     let (child, mut sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     child.kill().expect("kill");
     expect_eof("blocker", &mut sock); // real exit event precedes the wait
     assert!(
@@ -61,10 +61,10 @@ async fn async_foreign_wait_timeout_observes_an_exit() {
 #[tokio::test]
 async fn async_foreign_introspection_delegates() {
     let (child, _sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     assert_eq!(p.id(), child.id());
-    assert!(p.is_alive());
-    assert_eq!(Process::from_id(p.id()).expect("round-trip").id(), p.id());
+    assert_eq!(p.is_alive(), cosca::identity::Liveness::Alive);
+    assert_eq!(Process::from_id(p.id()).found().expect("round-trip").id(), p.id());
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }
@@ -72,7 +72,7 @@ async fn async_foreign_introspection_delegates() {
 #[tokio::test]
 async fn async_foreign_kill_terminates_the_process() {
     let (child, mut sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.kill().expect("foreign kill");
     expect_eof("blocker", &mut sock);
     let status = child.wait().expect("reap");
@@ -84,7 +84,7 @@ async fn async_foreign_kill_terminates_the_process() {
 async fn async_foreign_terminate_sends_sigterm() {
     use std::os::unix::process::ExitStatusExt;
     let (child, mut sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.terminate().expect("foreign terminate");
     expect_eof("blocker", &mut sock);
     let status = child.wait().expect("reap");
@@ -97,7 +97,7 @@ async fn async_foreign_graceful_shutdown_graceful_path() {
     use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     let (child, mut sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown(Duration::from_secs(30))
         .await
         .expect("foreign graceful");
@@ -114,7 +114,7 @@ async fn async_foreign_graceful_shutdown_escalates() {
     // SIG_IGN child + ZERO grace: provably alive at the single poll => deterministic
     // escalation; SIGKILL is the only terminating signal it can receive.
     let (child, mut sock) = common::spawn_control("control-block-ignore-term", &["R"], false);
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown(Duration::ZERO).await.expect("foreign escalates");
     expect_eof("blocker", &mut sock);
     let status = child.wait().expect("reap");
@@ -124,7 +124,7 @@ async fn async_foreign_graceful_shutdown_escalates() {
 #[tokio::test]
 async fn async_foreign_kill_tree_tears_down_tree() {
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.kill_tree().expect("kill_tree");
     for (i, s) in socks.iter_mut().enumerate() {
         let mut buf = [0u8; 1];
@@ -142,7 +142,7 @@ async fn async_foreign_kill_tree_tears_down_tree() {
 async fn async_foreign_graceful_shutdown_tree_tears_down_tree() {
     use std::time::Duration;
     let (child, mut socks) = common::spawn_grandchild(false);
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     p.graceful_shutdown_tree(Duration::from_secs(30))
         .await
         .expect("foreign tree graceful");
@@ -162,7 +162,7 @@ async fn async_foreign_graceful_shutdown_tree_tears_down_tree() {
 async fn async_foreign_unix_only_ops_are_unsupported_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
-    let p = Process::from_pid(child.id().pid()).expect("resolves");
+    let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     assert!(matches!(p.terminate(), Err(cosca::error::Error::Unsupported { .. })));
     assert!(matches!(
         p.graceful_shutdown(Duration::from_secs(1)).await,

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -233,7 +233,11 @@ async fn async_drop_tears_down_a_contained_tree() {
     let root_id = child.id();
     drop(child);
     // The root is deterministically dead — reap_now blocked until its exit before Drop returned.
-    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "the contained root must be torn down by Drop");
+    assert_eq!(
+        root_id.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "the contained root must be torn down by Drop"
+    );
     // The grandchild's death is proven by its control-socket EOF: a survivor blocks the read (a CI failure).
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
@@ -273,7 +277,9 @@ async fn async_detach_leaves_the_tree_running() {
     drop(child); // detached → Drop must NOT kill
                  // Positive liveness (no race — we never signaled it): a buggy detach that let Drop kill the
                  // root would make this false.
-    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Alive,
+    assert_eq!(
+        root_id.is_alive(),
+        cosca::identity::Liveness::Alive,
         "detach must leave the root running after the handle drops"
     );
     // Release it and observe a CLEAN voluntary exit (Ok(0) EOF), distinct from a kill's reset.
@@ -299,7 +305,9 @@ async fn async_kill_on_drop_false_leaves_the_root_running() {
     let (child, mut root, _grand) = common::spawn_grandchild_async_with(false, false);
     let root_id = child.id();
     drop(child); // kill_on_drop(false) → Drop early-returns; teardown must NOT run
-    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Alive,
+    assert_eq!(
+        root_id.is_alive(),
+        cosca::identity::Liveness::Alive,
         "kill_on_drop(false) must leave the root running after the handle drops"
     );
     // Release it and observe a CLEAN voluntary exit (Ok(0) EOF), best-effort tearing the tree down.
@@ -679,7 +687,11 @@ async fn async_windows_contained_spawn_runs_then_job_tears_down() {
     );
     let root_id = child.id();
     drop(child);
-    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "the contained root must be torn down by Drop");
+    assert_eq!(
+        root_id.is_alive(),
+        cosca::identity::Liveness::Dead,
+        "the contained root must be torn down by Drop"
+    );
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -19,7 +19,7 @@ async fn async_id_is_a_real_stable_identity() {
     let (mut child, mut sock) = common::spawn_blocker_async();
     let id = child.id();
     assert_eq!(
-        cosca::Process::from_id(id).map(|p| p.id()),
+        cosca::Process::from_id(id).found().map(|p| p.id()),
         Some(id),
         "id() is a resolvable identity"
     );
@@ -233,7 +233,7 @@ async fn async_drop_tears_down_a_contained_tree() {
     let root_id = child.id();
     drop(child);
     // The root is deterministically dead — reap_now blocked until its exit before Drop returned.
-    assert!(!root_id.is_alive(), "the contained root must be torn down by Drop");
+    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "the contained root must be torn down by Drop");
     // The grandchild's death is proven by its control-socket EOF: a survivor blocks the read (a CI failure).
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
@@ -254,7 +254,7 @@ async fn async_drop_after_wait_still_tears_down_the_tree() {
     let root_id = child.id();
     root.write_all(b"x").expect("release the root so it exits");
     child.wait().await.expect("wait reaps the root");
-    assert!(!root_id.is_alive(), "root exited");
+    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "root exited");
     drop(child); // root already reaped → reap_now no-op; attached.hard_kill must still kill the grandchild
     let mut buf = [0u8; 1];
     match grand.read(&mut buf) {
@@ -273,8 +273,7 @@ async fn async_detach_leaves_the_tree_running() {
     drop(child); // detached → Drop must NOT kill
                  // Positive liveness (no race — we never signaled it): a buggy detach that let Drop kill the
                  // root would make this false.
-    assert!(
-        root_id.is_alive(),
+    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Alive,
         "detach must leave the root running after the handle drops"
     );
     // Release it and observe a CLEAN voluntary exit (Ok(0) EOF), distinct from a kill's reset.
@@ -300,8 +299,7 @@ async fn async_kill_on_drop_false_leaves_the_root_running() {
     let (child, mut root, _grand) = common::spawn_grandchild_async_with(false, false);
     let root_id = child.id();
     drop(child); // kill_on_drop(false) → Drop early-returns; teardown must NOT run
-    assert!(
-        root_id.is_alive(),
+    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Alive,
         "kill_on_drop(false) must leave the root running after the handle drops"
     );
     // Release it and observe a CLEAN voluntary exit (Ok(0) EOF), best-effort tearing the tree down.
@@ -327,7 +325,7 @@ async fn async_drop_leaves_no_zombie() {
     drop(child);
     assert_ne!(
         cosca::identity::ProcessId::of(id.pid()),
-        Some(id),
+        cosca::identity::Resolved::Found(id),
         "Drop must fully reap the child (no lingering process/zombie at its identity)"
     );
 }
@@ -681,7 +679,7 @@ async fn async_windows_contained_spawn_runs_then_job_tears_down() {
     );
     let root_id = child.id();
     drop(child);
-    assert!(!root_id.is_alive(), "the contained root must be torn down by Drop");
+    assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "the contained root must be torn down by Drop");
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {


### PR DESCRIPTION
Closes #45.

Every Windows identity entry point collapsed an `OpenProcess` failure into a negative answer, so a caller lacking rights on a **live** process was told the process was gone. On an unelevated Windows 11 host, `PROCESS_QUERY_LIMITED_INFORMATION` is denied for 148 of 360 processes — `services.exe`, `lsass.exe`, `svchost.exe` — so the whole identity layer read them as nonexistent.

## What changed

**Tri-state identity.** `Existence{Present,Gone,Unknown}`, `Liveness{Alive,Dead,Unknown}`, `Resolved<T>{Found,Gone,Unknown}` replace `bool`/`Option` on `ProcessId::{of,exists,is_alive}`, `Process::{from_id,from_pid,is_alive}`, `Child::is_alive` and both tokio mirrors. None of them offer `unwrap_or` or a `bool` conversion — collapsing must name the variant being folded away.

**Classification, not collapse.** One rule, in `identity::backend::open_classified`: `ERROR_INVALID_PARAMETER` is the OS's "no such pid" and the only failure meaning absence. Everything else is `Unknown`, and `Opened::Denied` carries the `windows::core::Error` so the real cause survives (`GetLastError` is thread-global and every intervening call overwrites it).

**The two-mask asymmetry is closed.** `is_alive` used to request strictly more rights than `exists`, so a process could be `Present` and simultaneously not-alive. It now tries `QUERY_LIMITED | SYNCHRONIZE`, and on refusal falls back to `QUERY_LIMITED` alone, where `GetExitCodeProcess` still *proves* an exit. It cannot prove the converse — a process exiting with code 259 reports `STILL_ACTIVE` forever — so that maps to `Unknown`, never `Alive`.

**Unix too.** Linux disambiguates an unreadable `/proc/<pid>/stat` with a `kill(pid, 0)` probe, which `hidepid` cannot hide; macOS separates a sysctl *failure* from an empty reply and maps `ESRCH` to gone, keeping the `ENOMEM` tripwire that is the only runtime detector for `kinfo_proc` layout drift.

**`Error::Unassessable { detail, source }` + `#[non_exhaustive]` on `Error`.** Without it the distinction died at the public `Result` boundary, forcing callers to substring-match error prose to tell "it vanished" from "I may not ask". `#[non_exhaustive]` is the batch-wide decision covering #46 and #52.

**Two latent bugs found on the way.** `nix::Pid::from_raw` is infallible and accepts 0, so `kill(0, SIGKILL)` would have signalled the crate's own process group on macOS in release builds where the guarding `debug_assert` vanishes; all real-signal sites now route through a total `signal_target` guard. And Windows `kill_by_identity` re-resolved by pid and then opened the pid a second time — it now opens once and verifies on the held handle, which pins the kernel object.

## Testing

The access-denied fixture is a **real** process with a **real** restrictive DACL — a single allow-ACE for our own SID (an empty DACL for deny-all), so it denies an elevated caller with the same SID too, since `OpenProcess` never enables `SeDebugPrivilege`. It spawns `CREATE_SUSPENDED`, joins a kill-on-close job object, then resumes, so no grandchild can escape. Nothing is mocked.

That reproduces both rows of the issue's measurement table deterministically, and pins: denied-`QUERY_LIMITED` reads `Unknown` not `Gone`; denied-`SYNCHRONIZE` resolves identity but yields `Unknown` liveness while running and `Dead` once exited; `kill`/`block_until_exit` on a denied live process return `Unassessable` carrying the real `ERROR_ACCESS_DENIED`, and return success once the target provably exits.

- 551 tests pass on Windows.
- `cargo check --all-features --all-targets` clean for `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`; `clippy -D warnings` clean.
- **Not verified:** a real Linux `hidepid` or macOS sandboxed-`sysctl` denial cannot be produced on any available machine — both need CI configuration, filed as #66. Their decision logic is executed everywhere via pure functions (`identity::probe`); the OS wiring around them is compile-checked only.

## Deliberately out of scope

#63 (tree-walk drops unassessable descendants and `kill_tree` still returns `Ok` — `kill_by_identity` now returns `KillOutcome`, but the six sweep call sites discard it), #64 (Unix kill TOCTOU), #65 (`job_contains_pid`), #66 (CI denial fixtures).

Touches files #46, #47 and #49 also edit; the change is what the type demands rather than narrowed to avoid conflicts.
