### PR TITLE
feat!: persist and restore a ProcessId across a restart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,10 @@ jobs:
       - name: Run tests (tokio feature)
         run: cargo test --locked --features tokio --target ${{ matrix.target }}
 
+      # `serde` is an additive feature flag; exercise the persisted-identity wire format.
+      - name: Run tests (serde feature)
+        run: cargo test --locked --features serde --target ${{ matrix.target }}
+
       - name: Check rustdoc
         shell: bash
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,8 @@ dependencies = [
  "log",
  "nix",
  "rustix",
+ "serde",
+ "serde_json",
  "shared_child",
  "tempfile",
  "thiserror",
@@ -82,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +106,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
@@ -182,6 +196,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +302,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +342,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -301,7 +369,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -369,7 +437,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -380,7 +448,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -514,3 +582,9 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-
 [features]
 pty = []
 tokio = ["dep:tokio"]
+# Serialize a ProcessIdRecord so an identity survives a supervisor restart.
+serde = ["dep:serde"]
 
 [dependencies]
 thiserror = "2"
@@ -25,6 +27,8 @@ shared_child = { version = "1", features = ["timeout"] }
 log = "0.4"
 # Zeroize the password held for Auth::Stdin so it never lingers in freed memory.
 zeroize = "1"
+# Only ProcessIdRecord is (de)serializable; `derive` is for its field attributes.
+serde = { version = "1", optional = true, features = ["derive"] }
 # `macros` is required by the library, not only tests: `communicate` uses `tokio::try_join!`,
 # which is gated behind tokio's `macros` feature. `net` is solely for `AsyncFd` (the
 # reactor-native death-watch); `time` solely for the grace bound on it. `sync` backs the
@@ -33,6 +37,8 @@ tokio = { version = "1", optional = true, features = ["process", "rt", "io-util"
 
 [dev-dependencies]
 tempfile = "3"
+# A concrete format to pin the persisted wire form against.
+serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 # Unpredictable merge-target pipe names (std parity: std randomizes its anon-pipe names).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation.
 
-`std::process` hands you a child and little else. It cannot tell you whether the process you spawned is still the process you think it is, cannot tear down a process tree, cannot address a process it did not spawn, and cannot run one elevated. This crate covers those, with one API across Linux, macOS, and Windows, and a `tokio` mirror behind a feature flag.
+`std::process` hands you a child and little else. It cannot tell you whether the process you spawned is still the process you think it is, cannot tear down a process tree, cannot address a process it did not spawn, and cannot run one elevated. This crate covers those, with one API across Linux, macOS, and Windows, a `tokio` mirror behind a feature flag, and identities that can be written to disk and restored after a restart (`serde` feature).
 
 The API is not stable; expect breaking changes in any 0.x release.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,50 @@ pub enum ElevationErrorKind {
     CommandTooLong,
 }
 
+/// Why a [`ProcessIdRecord`](crate::identity::ProcessIdRecord) could not be produced from,
+/// or turned back into, a [`ProcessId`](crate::identity::ProcessId).
+///
+/// No variant says anything about whether the process is running — that is
+/// [`ProcessId::is_alive`](crate::identity::ProcessId::is_alive). These are all statements
+/// about whether a start token can be *compared* on this host at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum RecordErrorKind {
+    /// The record's format version is not one this build knows how to read.
+    #[error("unknown record format version")]
+    UnknownVersion,
+    /// The record was written on a different OS. Start tokens are not comparable across
+    /// platforms — Linux's are boot-relative jiffies, Windows's and macOS's are absolute
+    /// timestamps — so a cross-platform comparison is meaningless, not merely wrong.
+    #[error("the record was written on a different platform")]
+    ForeignPlatform,
+    /// The record's pid cannot name a single process on this platform: zero anywhere, or
+    /// above `i32::MAX` on Unix, where it would wrap negative and address a whole process
+    /// *group*. A restored identity is used for `kill(2)` and `pidfd_open`, so this is
+    /// rejected up front rather than left to fail — or, worse, succeed — later.
+    #[error("the record's pid cannot name a single process")]
+    InvalidPid,
+    /// Linux: the record was written in a different boot session, where the jiffy counter
+    /// started over. The saved token would alias onto an unrelated process.
+    #[error("the record was written in a different boot session")]
+    ForeignBootSession,
+    /// Linux: the record carries no boot identifier, so its boot session cannot be checked.
+    #[error("the record carries no boot session identifier")]
+    MissingBootSession,
+    /// Linux: the record was written in a different pid namespace, where the same pid
+    /// number names a different process.
+    #[error("the record was written in a different pid namespace")]
+    ForeignPidNamespace,
+    /// Linux: the record carries no pid namespace identifier.
+    #[error("the record carries no pid namespace identifier")]
+    MissingPidNamespace,
+    /// This host's own boot session could not be read, so a record could neither be
+    /// written nor checked. The only variant that is not about the record's contents; the
+    /// failing path and the OS error are in the error's `detail` and `source`.
+    #[error("this host's boot session could not be read")]
+    ScopeUnreadable,
+}
+
 /// The crate's top-level error type.
 ///
 /// `#[non_exhaustive]`: the crate is still growing failure modes, so callers carry a
@@ -104,6 +148,16 @@ pub enum Error {
     /// process — where nothing was asked of the OS at all; those carry no `source`.
     #[error("could not determine the target process's state: {detail}")]
     Unassessable {
+        detail: String,
+        #[source]
+        source: Option<std::io::Error>,
+    },
+    /// A persisted process identity could not be produced or restored — see
+    /// [`RecordErrorKind`] for why. `source` carries the OS error when the failure was a
+    /// failed read of this host's boot session rather than a rejected record.
+    #[error("persisted process identity is not usable here ({kind}): {detail}")]
+    IdentityRecord {
+        kind: RecordErrorKind,
         detail: String,
         #[source]
         source: Option<std::io::Error>,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -11,6 +11,9 @@
 //! wall-clock from boot time drifts under NTP and would silently break
 //! `Eq`/`Hash`. The human-facing wall-clock lives in `created_at()`,
 //! allowed to drift and never used for identity.
+//!
+//! The token is not portable across a reboot on every platform — see [`ProcessIdRecord`]
+//! for the persist/restore round trip and what it refuses.
 
 pub(crate) mod probe;
 pub(crate) mod stat_parse;
@@ -18,6 +21,10 @@ pub(crate) mod stat_parse;
 #[path = "identity/state.rs"]
 mod state;
 pub use state::{Existence, Liveness, Resolved};
+
+#[path = "identity/persist.rs"]
+mod persist;
+pub use persist::{Platform, ProcessIdRecord, RECORD_VERSION};
 
 #[cfg_attr(windows, path = "identity/windows.rs")]
 #[cfg_attr(target_os = "linux", path = "identity/linux.rs")]

--- a/src/identity/linux.rs
+++ b/src/identity/linux.rs
@@ -104,3 +104,61 @@ fn boot_time_secs() -> Option<u64> {
         .find_map(|l| l.strip_prefix("btime "))
         .and_then(|v| v.trim().parse::<u64>().ok())
 }
+
+// Persisted-identity session scope ====================================================
+
+use super::persist::{Scope, ScopeReadError};
+
+const BOOT_ID_PATH: &str = "/proc/sys/kernel/random/boot_id";
+const PID_NS_PATH: &str = "/proc/self/ns/pid";
+
+/// This host's boot session, as the two things a `/proc` jiffy token is relative to.
+///
+/// `boot_id` scopes the jiffy counter, which restarts at every boot; the `/proc/self/ns/pid`
+/// inode scopes the PID, because a container shares the host's `boot_id` (it is not
+/// namespaced) while numbering its processes independently. Either one alone would let a
+/// saved token be compared against an unrelated process.
+///
+/// Both reads are of the caller's own `/proc` entries, which no `hidepid` mount hides from
+/// the task itself; a failure here means `/proc` is not mounted at all.
+pub(super) fn session_scope() -> Result<Scope, ScopeReadError> {
+    session_scope_at(std::path::Path::new(BOOT_ID_PATH), std::path::Path::new(PID_NS_PATH))
+}
+
+/// [`session_scope`] with the two `/proc` paths as parameters, so a test can point them at
+/// paths that really do not exist and exercise the failure without mocking a syscall.
+pub(super) fn session_scope_at(
+    boot_id_path: &std::path::Path,
+    pid_ns_path: &std::path::Path,
+) -> Result<Scope, ScopeReadError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let boot_id = std::fs::read_to_string(boot_id_path).map_err(|source| ScopeReadError {
+        path: boot_id_path.display().to_string(),
+        source,
+    })?;
+    // Trimmed: the kernel appends a newline, and an untrimmed value would never match a
+    // record written by anything else that reads this file.
+    let boot_id = boot_id.trim();
+    // A BLANK value is refused, not stored. A container runtime that masks this file by
+    // bind-mounting /dev/null over it makes the read SUCCEED and return "", which would be
+    // stored as `Some("")` and then compare equal to the next boot's `Some("")` — silently
+    // turning the boot-session check into a no-op, which is the exact aliasing this record
+    // exists to prevent. Failing here surfaces it as `ScopeUnreadable` instead.
+    if boot_id.is_empty() {
+        return Err(ScopeReadError {
+            path: boot_id_path.display().to_string(),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, "boot_id is empty"),
+        });
+    }
+    let pid_ns = std::fs::metadata(pid_ns_path)
+        .map_err(|source| ScopeReadError {
+            path: pid_ns_path.display().to_string(),
+            source,
+        })?
+        .ino();
+    Ok(Scope {
+        boot_id: Some(boot_id.to_owned()),
+        pid_ns: Some(pid_ns),
+    })
+}

--- a/src/identity/macos.rs
+++ b/src/identity/macos.rs
@@ -111,3 +111,9 @@ pub(super) fn is_running(pid: RawPid, start: StartToken) -> Liveness {
 pub(super) fn created_at(start: StartToken) -> Option<SystemTime> {
     Some(SystemTime::UNIX_EPOCH + Duration::from_micros(start.raw()))
 }
+
+/// The `kinfo_proc` / `proc_bsdinfo` start time is absolute µs since the Unix epoch,
+/// recorded once at creation, so it survives a reboot unchanged and needs no scope.
+pub(super) fn session_scope() -> Result<super::persist::Scope, super::persist::ScopeReadError> {
+    Ok(super::persist::Scope::none())
+}

--- a/src/identity/persist.rs
+++ b/src/identity/persist.rs
@@ -1,0 +1,341 @@
+//! Persisting a [`ProcessId`](super::ProcessId) and restoring it later.
+//!
+//! A `ProcessId` is `(pid, raw start token)`, and the token is whatever the kernel keeps —
+//! which is not equally portable across the three backends:
+//!
+//! | Platform | Token | Survives a reboot? |
+//! |---|---|---|
+//! | Windows | creation `FILETIME` | yes — absolute 100 ns ticks since 1601 |
+//! | macOS | `kinfo_proc` start µs | yes — absolute µs since 1970 |
+//! | Linux | `/proc` `starttime` jiffies | **no** — counted from boot |
+//!
+//! A naively-serialized Linux token therefore aliases onto whichever process occupies that
+//! pid after a reboot, reintroducing exactly the pid-reuse hazard `ProcessId` exists to
+//! remove — and doing it silently, because the holder believes they have a strong identity.
+//!
+//! So the persisted form is an explicit, versioned, self-describing [`ProcessIdRecord`] and
+//! the only way back is [`TryFrom`], which rejects a record from another platform, another
+//! boot session, another pid namespace, or an unknown format version.
+//!
+//! A restored `ProcessId` says nothing about whether the process is still there — ask
+//! [`ProcessId::exists`](super::ProcessId::exists) or
+//! [`ProcessId::is_alive`](super::ProcessId::is_alive) for that.
+//!
+//! A record is meaningful only on the machine, boot session, and pid namespace that
+//! produced it. Nothing stops you copying one elsewhere; on Linux it is rejected by the
+//! boot identifier, and on Windows/macOS it would have to collide on both the pid and an
+//! absolute sub-microsecond creation timestamp to be accepted at all.
+
+use crate::error::{Error, RecordErrorKind};
+
+use super::{backend, ProcessId, RawPid, StartToken};
+
+/// The record format this build writes. A reader rejects any version it does not know,
+/// so a future bump can change the fields' meaning safely. Within a version, changes are
+/// additive only: a reader ignores fields it does not recognise.
+pub const RECORD_VERSION: u32 = 1;
+
+/// The OS a persisted identity was produced on. Start tokens are not comparable across
+/// platforms, so this tag is checked before anything else about the token.
+///
+/// [`Platform::Other`] exists so a record from a newer `cosca` that supports a platform
+/// this build does not still *parses* — and is then rejected by validation with a clear
+/// reason, rather than failing as malformed data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Platform {
+    Linux,
+    MacOs,
+    Windows,
+    /// A tag this build does not know.
+    Other(String),
+}
+
+impl Platform {
+    // One `cfg`-selected definition each, rather than one function branching internally:
+    // the tag must not be derivable from `std::env::consts::OS`, which is what the unit
+    // test compares against.
+    #[cfg(windows)]
+    pub fn current() -> Platform {
+        Platform::Windows
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn current() -> Platform {
+        Platform::Linux
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn current() -> Platform {
+        Platform::MacOs
+    }
+
+    /// The wire string. These three literals ARE the persisted format — never change them.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Platform::Linux => "linux",
+            Platform::MacOs => "macos",
+            Platform::Windows => "windows",
+            Platform::Other(s) => s,
+        }
+    }
+
+    /// Parse a wire string. Unknown tags become [`Platform::Other`] rather than an error,
+    /// so validation — not the decoder — decides what to do with them. Public so a caller
+    /// persisting records in an encoding of their own can produce the same leniency.
+    pub fn from_wire(s: &str) -> Platform {
+        match s {
+            "linux" => Platform::Linux,
+            "macos" => Platform::MacOs,
+            "windows" => Platform::Windows,
+            other => Platform::Other(other.to_owned()),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Platform {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+// No `use serde::Deserialize;` in the body below: a trait is already in scope inside its
+// own impl block, so the import would be unused and `-D warnings` rejects it. The identical
+// import inside `mod token_str` IS required — those are free functions, not an impl.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Platform {
+    /// Delegates to [`Platform::from_wire`], which documents the leniency policy.
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Platform, D::Error> {
+        Ok(Platform::from_wire(&String::deserialize(d)?))
+    }
+}
+
+/// `u64` as a decimal string — see the `token` field's doc for why.
+#[cfg(feature = "serde")]
+mod token_str {
+    pub(super) fn serialize<S: serde::Serializer>(v: &u64, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&v.to_string())
+    }
+
+    pub(super) fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<u64, D::Error> {
+        use serde::Deserialize;
+        let s = String::deserialize(d)?;
+        s.parse::<u64>().map_err(serde::de::Error::custom)
+    }
+}
+
+/// A [`ProcessId`](super::ProcessId) in persistable form: inert data with no invariants.
+/// Every check happens on the way back, in `TryFrom<&ProcessIdRecord> for ProcessId`.
+///
+/// Fields are public so a caller can persist it with an encoding of their own; `serde`
+/// impls are available behind the `serde` feature.
+///
+/// `token` is the RAW kernel value and is opaque — its only meaning is exact equality
+/// within one platform and boot session. Do not compare, order, or interpret it yourself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ProcessIdRecord {
+    /// [`RECORD_VERSION`] at the time of writing.
+    #[cfg_attr(feature = "serde", serde(rename = "v"))]
+    pub version: u32,
+    /// The OS that produced the token.
+    pub platform: Platform,
+    pub pid: RawPid,
+    /// The raw kernel start token. Opaque.
+    ///
+    /// On the wire it is a DECIMAL STRING, not a number: a Windows creation `FILETIME` is
+    /// around 1.3e17, well past the 2^53 a JSON consumer with double-precision numbers can
+    /// represent, and a silently-rounded token is exactly the aliasing this type prevents.
+    #[cfg_attr(feature = "serde", serde(with = "token_str"))]
+    pub token: u64,
+    /// Linux: `/proc/sys/kernel/random/boot_id`, the boot the jiffy token is counted from.
+    /// `None` on Windows and macOS, whose tokens are absolute.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub boot_id: Option<String>,
+    /// Linux: the inode of `/proc/self/ns/pid`, naming the pid namespace `pid` is in.
+    /// `None` on Windows and macOS, which have no pid namespaces.
+    ///
+    /// An additional filter, not a guarantee: the kernel reuses namespace inode numbers
+    /// once a namespace is destroyed, so a match does not prove the namespace is the same
+    /// one. With a recycled inode the record falls back to the protection it would have
+    /// had without this field — `(pid, boot_id, token)` — never less.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub pid_ns: Option<u64>,
+}
+
+/// The live session a token has to belong to, as read from THIS host. Empty on platforms
+/// whose token is an absolute timestamp and therefore self-scoping.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct Scope {
+    pub(crate) boot_id: Option<String>,
+    pub(crate) pid_ns: Option<u64>,
+}
+
+impl Scope {
+    /// Consumed only by the Windows and macOS backends, whose tokens are absolute and so
+    /// need no scope; the Linux backend builds a populated `Scope` directly. Dead on a
+    /// Linux build, which is the platform the `-D warnings` lint job runs on.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
+    pub(crate) fn none() -> Scope {
+        Scope::default()
+    }
+}
+
+/// A failed read of this host's own session scope, keeping WHICH read failed. Discarding
+/// that would leave a caller unable to tell an unmounted `/proc` from a refused read.
+#[derive(Debug)]
+pub(crate) struct ScopeReadError {
+    /// The path whose read failed, as it was actually attempted.
+    pub(crate) path: String,
+    pub(crate) source: std::io::Error,
+}
+
+/// The single mapping from a failed scope read to the crate error, shared by both
+/// directions (writing a record and restoring one). Pure, so it is tested on every host.
+pub(crate) fn scope_error(e: ScopeReadError) -> Error {
+    Error::IdentityRecord {
+        kind: RecordErrorKind::ScopeUnreadable,
+        detail: format!("{} could not be read: {}", e.path, e.source),
+        source: Some(e.source),
+    }
+}
+
+/// Whether `pid`, read from a file, can name a single process on `here`.
+///
+/// Unix reuses [`signal_target`](super::probe::signal_target) rather than restating its
+/// rule: that function is what stands between the crate and `kill(-N, sig)` hitting a whole
+/// process group, and there must be exactly one copy of it. Windows pids are full `DWORD`s
+/// and are never a `kill(2)` target, so only zero is refused there.
+fn pid_is_addressable(pid: RawPid, here: &Platform) -> bool {
+    match here {
+        Platform::Windows => pid != 0,
+        _ => super::probe::signal_target(pid).is_some(),
+    }
+}
+
+/// The crate error for a rejected record, naming the values that diverged — `kind` alone
+/// says only which category failed.
+pub(crate) fn reject(record: &ProcessIdRecord, scope: &Scope, kind: RecordErrorKind) -> Error {
+    Error::IdentityRecord {
+        kind,
+        detail: format!(
+            "record v{} from {} for pid {} (boot_id {:?} vs live {:?}, pid_ns {:?} vs live {:?})",
+            record.version,
+            record.platform.as_str(),
+            record.pid,
+            record.boot_id,
+            scope.boot_id,
+            record.pid_ns,
+            scope.pid_ns,
+        ),
+        source: None,
+    }
+}
+
+/// The whole rejection rule, pure: no OS reads, so it is compiled and tested on every host.
+///
+/// Order matters. Version is checked FIRST: a future format may reuse these fields with
+/// different meanings, so nothing else may be believed until the version is known. The
+/// platform is checked SECOND, because the pid rule below is chosen by platform.
+///
+/// The scope rule is one-sided by design: a field the host does not use (`None` in `scope`)
+/// is ignored in the record. Since the platform tag has already matched, the two sides
+/// always agree on which fields are in use.
+pub(crate) fn validate(
+    record: &ProcessIdRecord,
+    here: &Platform,
+    scope: &Scope,
+) -> Result<(RawPid, u64), RecordErrorKind> {
+    if record.version != RECORD_VERSION {
+        return Err(RecordErrorKind::UnknownVersion);
+    }
+    if &record.platform != here {
+        return Err(RecordErrorKind::ForeignPlatform);
+    }
+    if !pid_is_addressable(record.pid, here) {
+        return Err(RecordErrorKind::InvalidPid);
+    }
+    if let Some(live) = &scope.boot_id {
+        match &record.boot_id {
+            None => return Err(RecordErrorKind::MissingBootSession),
+            Some(saved) if saved != live => return Err(RecordErrorKind::ForeignBootSession),
+            Some(_) => {}
+        }
+    }
+    if let Some(live) = scope.pid_ns {
+        match record.pid_ns {
+            None => return Err(RecordErrorKind::MissingPidNamespace),
+            Some(saved) if saved != live => return Err(RecordErrorKind::ForeignPidNamespace),
+            Some(_) => {}
+        }
+    }
+    Ok((record.pid, record.token))
+}
+
+/// `to_record` with the scope read passed in, so a test can hand it a failure. Everything
+/// `to_record` does — including the `?` that decides whether a failed scope read aborts the
+/// write — lives here, where it runs on every host.
+fn record_from(id: &ProcessId, scope: Result<Scope, ScopeReadError>) -> Result<ProcessIdRecord, Error> {
+    let scope = scope.map_err(scope_error)?;
+    Ok(ProcessIdRecord {
+        version: RECORD_VERSION,
+        platform: Platform::current(),
+        pid: id.pid,
+        token: id.start.raw(),
+        boot_id: scope.boot_id,
+        pid_ns: scope.pid_ns,
+    })
+}
+
+/// `try_from` with the scope read passed in, for the same reason as [`record_from`].
+fn restore(
+    record: &ProcessIdRecord,
+    here: &Platform,
+    scope: Result<Scope, ScopeReadError>,
+) -> Result<ProcessId, Error> {
+    let scope = scope.map_err(scope_error)?;
+    let (pid, token) = validate(record, here, &scope).map_err(|kind| reject(record, &scope, kind))?;
+    Ok(ProcessId {
+        pid,
+        start: StartToken::from_raw(token),
+    })
+}
+
+impl ProcessId {
+    /// This identity in persistable form. Restore it with `ProcessId::try_from`.
+    ///
+    /// `Err` only when this host cannot describe its own boot session — on Linux, `/proc`
+    /// not being mounted. Emitting a record that could never be validated would be worse
+    /// than failing here.
+    pub fn to_record(&self) -> Result<ProcessIdRecord, Error> {
+        record_from(self, backend::session_scope())
+    }
+}
+
+impl TryFrom<&ProcessIdRecord> for ProcessId {
+    type Error = Error;
+
+    /// Restore a persisted identity. The ONLY way back from a record: there is deliberately
+    /// no infallible from-parts constructor, because a token from another platform, boot
+    /// session, or pid namespace would alias onto an unrelated process. See
+    /// [`RecordErrorKind`] for every way this refuses.
+    fn try_from(record: &ProcessIdRecord) -> Result<ProcessId, Error> {
+        restore(record, &Platform::current(), backend::session_scope())
+    }
+}
+
+impl TryFrom<ProcessIdRecord> for ProcessId {
+    type Error = Error;
+
+    fn try_from(record: ProcessIdRecord) -> Result<ProcessId, Error> {
+        ProcessId::try_from(&record)
+    }
+}
+
+#[cfg(test)]
+#[path = "persist_tests.rs"]
+mod persist_tests;
+
+#[cfg(test)]
+#[path = "persist_serde_tests.rs"]
+mod persist_serde_tests;

--- a/src/identity/persist_serde_tests.rs
+++ b/src/identity/persist_serde_tests.rs
@@ -1,0 +1,157 @@
+//! The persisted wire format. These literals ARE the format: a change here is a change
+//! every already-written record has to survive, so the expected JSON is written by hand
+//! from the documented format, never captured from the code's own output.
+
+#![cfg(feature = "serde")]
+
+use super::{Platform, ProcessIdRecord, RECORD_VERSION};
+
+fn windows_record() -> ProcessIdRecord {
+    ProcessIdRecord {
+        version: 1,
+        platform: Platform::Windows,
+        pid: 4242,
+        // A real measured creation FILETIME, larger than 2^53.
+        token: 134_301_578_477_907_396,
+        boot_id: None,
+        pid_ns: None,
+    }
+}
+
+fn linux_record() -> ProcessIdRecord {
+    ProcessIdRecord {
+        version: 1,
+        platform: Platform::Linux,
+        pid: 4242,
+        token: 162_431_157,
+        boot_id: Some("36c39237-f06e-4e88-a74d-ea99d42b817c".into()),
+        pid_ns: Some(4_026_531_836),
+    }
+}
+
+#[test]
+fn the_version_is_one() {
+    // The wire literals below hard-code v1; a bump must come with a format decision.
+    assert_eq!(RECORD_VERSION, 1);
+}
+
+#[test]
+fn a_windows_record_serializes_to_the_documented_json() {
+    let json = serde_json::to_string(&windows_record()).expect("serialize");
+    assert_eq!(
+        json,
+        r#"{"v":1,"platform":"windows","pid":4242,"token":"134301578477907396"}"#
+    );
+}
+
+#[test]
+fn a_linux_record_serializes_to_the_documented_json() {
+    let json = serde_json::to_string(&linux_record()).expect("serialize");
+    assert_eq!(
+        json,
+        r#"{"v":1,"platform":"linux","pid":4242,"token":"162431157","boot_id":"36c39237-f06e-4e88-a74d-ea99d42b817c","pid_ns":4026531836}"#
+    );
+}
+
+#[test]
+fn the_token_survives_json_without_precision_loss() {
+    // Windows tokens exceed 2^53 (9007199254740992), so a JSON *number* would be corrupted
+    // by any consumer with double-precision numbers. It is a decimal string on the wire.
+    assert!(windows_record().token > 9_007_199_254_740_992);
+    let json = serde_json::to_string(&windows_record()).expect("serialize");
+    let back: ProcessIdRecord = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.token, 134_301_578_477_907_396);
+    assert_eq!(back, windows_record());
+}
+
+#[test]
+fn records_round_trip_through_json() {
+    for r in [windows_record(), linux_record()] {
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: ProcessIdRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, r);
+    }
+}
+
+#[test]
+fn an_unknown_platform_tag_decodes_rather_than_failing() {
+    // Forward compatibility: a record from a newer cosca on a platform this build does not
+    // know must reach VALIDATION (which rejects it with a reason), not die in the decoder.
+    let json = r#"{"v":1,"platform":"freebsd","pid":7,"token":"99"}"#;
+    let r: ProcessIdRecord = serde_json::from_str(json).expect("an unknown tag must still decode");
+    assert_eq!(r.platform, Platform::Other("freebsd".into()));
+}
+
+#[test]
+fn an_unknown_version_decodes_rather_than_failing() {
+    let json = r#"{"v":999,"platform":"linux","pid":7,"token":"99"}"#;
+    let r: ProcessIdRecord = serde_json::from_str(json).expect("an unknown version must still decode");
+    assert_eq!(r.version, 999);
+}
+
+#[test]
+fn unknown_fields_are_ignored() {
+    // A v1 reader must tolerate additive fields from a later writer well enough to reach
+    // the version check.
+    let json = r#"{"v":1,"platform":"linux","pid":7,"token":"99","boot_id":"b","pid_ns":1,"future":42}"#;
+    let r: ProcessIdRecord = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(r.pid, 7);
+}
+
+#[test]
+fn a_non_numeric_token_string_is_a_decode_error() {
+    let json = r#"{"v":1,"platform":"linux","pid":7,"token":"not-a-number"}"#;
+    assert!(serde_json::from_str::<ProcessIdRecord>(json).is_err());
+}
+
+#[test]
+fn a_foreign_platform_record_is_refused_after_a_json_round_trip() {
+    // Cross-platform rejection driven entirely through the wire format, on whatever host
+    // this test runs on: the record names the OTHER platform, so it must never restore.
+    use crate::identity::ProcessId;
+    let foreign = if cfg!(windows) {
+        linux_record()
+    } else {
+        windows_record()
+    };
+    let json = serde_json::to_string(&foreign).expect("serialize");
+    let decoded: ProcessIdRecord = serde_json::from_str(&json).expect("deserialize");
+    match ProcessId::try_from(&decoded) {
+        Err(crate::error::Error::IdentityRecord { kind, .. }) => {
+            assert_eq!(kind, crate::error::RecordErrorKind::ForeignPlatform)
+        }
+        other => panic!("expected ForeignPlatform, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_newer_version_record_is_refused_after_a_json_round_trip() {
+    // Version is checked FIRST, before platform, precisely because a future format may
+    // reuse these fields with different meanings — so the record below names THIS platform
+    // and is otherwise well-formed, leaving the version as the only reason to refuse it.
+    use crate::identity::ProcessId;
+    let mut newer = if cfg!(windows) {
+        windows_record()
+    } else {
+        linux_record()
+    };
+    newer.version = RECORD_VERSION + 1;
+    newer.platform = Platform::current();
+    let json = serde_json::to_string(&newer).expect("serialize");
+    let decoded: ProcessIdRecord = serde_json::from_str(&json).expect("a newer version must still decode");
+    match ProcessId::try_from(&decoded) {
+        Err(crate::error::Error::IdentityRecord { kind, .. }) => {
+            assert_eq!(kind, crate::error::RecordErrorKind::UnknownVersion)
+        }
+        other => panic!("expected UnknownVersion, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_live_identity_survives_a_json_round_trip_on_this_host() {
+    use crate::identity::ProcessId;
+    let me = ProcessId::current();
+    let json = serde_json::to_string(&me.to_record().expect("to_record")).expect("serialize");
+    let decoded: ProcessIdRecord = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(ProcessId::try_from(&decoded).expect("restore"), me);
+}

--- a/src/identity/persist_tests.rs
+++ b/src/identity/persist_tests.rs
@@ -1,0 +1,540 @@
+//! Pure validation and error mapping for a persisted identity record. Compiled and run on
+//! EVERY host, so the Linux-only boot-session branches are exercised on Windows and macOS
+//! CI too.
+
+use super::{reject, scope_error, validate, Platform, ProcessIdRecord, Scope, ScopeReadError, RECORD_VERSION};
+use crate::error::{Error, RecordErrorKind};
+
+/// A well-formed Linux record: boot session `36c3…`, pid namespace 4026531836.
+fn linux_record() -> ProcessIdRecord {
+    ProcessIdRecord {
+        version: RECORD_VERSION,
+        platform: Platform::Linux,
+        pid: 4242,
+        token: 162_431_157,
+        boot_id: Some("36c39237-f06e-4e88-a74d-ea99d42b817c".into()),
+        pid_ns: Some(4_026_531_836),
+    }
+}
+
+fn linux_scope() -> Scope {
+    Scope {
+        boot_id: Some("36c39237-f06e-4e88-a74d-ea99d42b817c".into()),
+        pid_ns: Some(4_026_531_836),
+    }
+}
+
+/// A well-formed Windows record. The token is a real measured creation FILETIME,
+/// deliberately larger than 2^53.
+fn windows_record() -> ProcessIdRecord {
+    ProcessIdRecord {
+        version: RECORD_VERSION,
+        platform: Platform::Windows,
+        pid: 4242,
+        token: 134_301_578_477_907_396,
+        boot_id: None,
+        pid_ns: None,
+    }
+}
+
+#[test]
+fn a_matching_linux_record_validates() {
+    assert_eq!(
+        validate(&linux_record(), &Platform::Linux, &linux_scope()),
+        Ok((4242, 162_431_157))
+    );
+}
+
+#[test]
+fn a_windows_record_validates_with_an_empty_scope() {
+    assert_eq!(
+        validate(&windows_record(), &Platform::Windows, &Scope::none()),
+        Ok((4242, 134_301_578_477_907_396))
+    );
+}
+
+#[test]
+fn a_linux_record_is_rejected_on_windows() {
+    // The measured hazard: Linux jiffies are boot-relative and would be compared against
+    // an absolute FILETIME. Must never be accepted.
+    assert_eq!(
+        validate(&linux_record(), &Platform::Windows, &Scope::none()),
+        Err(RecordErrorKind::ForeignPlatform)
+    );
+}
+
+#[test]
+fn a_windows_record_is_rejected_on_linux() {
+    assert_eq!(
+        validate(&windows_record(), &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::ForeignPlatform)
+    );
+}
+
+#[test]
+fn an_unknown_platform_tag_is_rejected_not_a_parse_failure() {
+    let mut r = linux_record();
+    r.platform = Platform::Other("freebsd".into());
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::ForeignPlatform)
+    );
+}
+
+#[test]
+fn an_unknown_version_is_rejected_before_anything_else() {
+    let mut r = linux_record();
+    r.version = RECORD_VERSION + 1;
+    // Also make it foreign-platform, to pin that VERSION is checked FIRST: a future
+    // format may reuse these fields with different meanings.
+    r.platform = Platform::Other("freebsd".into());
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::UnknownVersion)
+    );
+}
+
+#[test]
+fn a_version_zero_record_is_rejected() {
+    let mut r = linux_record();
+    r.version = 0;
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::UnknownVersion)
+    );
+}
+
+#[test]
+fn a_linux_record_from_a_different_boot_is_rejected() {
+    // After a reboot the jiffy counter restarts, so a saved token would alias onto whatever
+    // now occupies the pid.
+    let scope = Scope {
+        boot_id: Some("00000000-0000-0000-0000-000000000000".into()),
+        pid_ns: Some(4_026_531_836),
+    };
+    assert_eq!(
+        validate(&linux_record(), &Platform::Linux, &scope),
+        Err(RecordErrorKind::ForeignBootSession)
+    );
+}
+
+#[test]
+fn a_linux_record_from_a_different_pid_namespace_is_rejected() {
+    // Measured: a container shares the host's boot_id but has its own pid namespace,
+    // so boot_id alone does not scope the pid.
+    let scope = Scope {
+        boot_id: Some("36c39237-f06e-4e88-a74d-ea99d42b817c".into()),
+        pid_ns: Some(4_026_532_417),
+    };
+    assert_eq!(
+        validate(&linux_record(), &Platform::Linux, &scope),
+        Err(RecordErrorKind::ForeignPidNamespace)
+    );
+}
+
+#[test]
+fn a_linux_record_without_a_boot_id_is_rejected() {
+    let mut r = linux_record();
+    r.boot_id = None;
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::MissingBootSession)
+    );
+}
+
+#[test]
+fn a_linux_record_without_a_pid_namespace_is_rejected() {
+    let mut r = linux_record();
+    r.pid_ns = None;
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::MissingPidNamespace)
+    );
+}
+
+#[test]
+fn scope_fields_the_host_does_not_use_are_ignored() {
+    // A Windows record that somehow carries Linux scope fields is still valid on Windows:
+    // the platform matched, and this host has no boot session to compare against.
+    let mut r = windows_record();
+    r.boot_id = Some("36c39237-f06e-4e88-a74d-ea99d42b817c".into());
+    r.pid_ns = Some(4_026_531_836);
+    assert_eq!(
+        validate(&r, &Platform::Windows, &Scope::none()),
+        Ok((4242, 134_301_578_477_907_396))
+    );
+}
+
+#[test]
+fn platform_tags_round_trip_through_their_wire_strings() {
+    for p in [Platform::Linux, Platform::MacOs, Platform::Windows] {
+        assert_eq!(Platform::from_wire(p.as_str()), p);
+    }
+    assert_eq!(Platform::from_wire("freebsd"), Platform::Other("freebsd".into()));
+    assert_eq!(Platform::Other("freebsd".into()).as_str(), "freebsd");
+}
+
+#[test]
+fn the_wire_strings_are_the_documented_ones() {
+    // Pinned literals: these strings are the persisted format and may never drift.
+    assert_eq!(Platform::Linux.as_str(), "linux");
+    assert_eq!(Platform::MacOs.as_str(), "macos");
+    assert_eq!(Platform::Windows.as_str(), "windows");
+}
+
+#[test]
+fn platform_current_names_this_host() {
+    // Expected value from `std::env::consts::OS`, an independent fact about the build
+    // target — NOT a second copy of `Platform::current`'s own cfg branching, which would
+    // only prove the two agree with each other. The three wire strings were chosen to
+    // match `consts::OS` exactly, so this is a straight comparison.
+    assert_eq!(Platform::current().as_str(), std::env::consts::OS);
+}
+
+// A pid is data from a file like everything else in the record, and the crate's Unix code
+// treats "not a single-process target" as impossible: `src/wait/linux.rs` does
+// `Pid::from_raw(id.pid() as i32).expect("a resolvable ProcessId is never pid 0")`, which
+// PANICS on 0, and `src/identity/probe.rs` documents that a value above `i32::MAX` wraps
+// negative, where `kill(-N, sig)` hits a whole process group. Restoring such a pid must be
+// a typed rejection, never a panic — and never a signal to the wrong target.
+
+#[test]
+fn a_unix_record_with_pid_zero_is_rejected() {
+    let mut r = linux_record();
+    r.pid = 0;
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::InvalidPid)
+    );
+}
+
+#[test]
+fn a_macos_record_with_pid_zero_is_rejected() {
+    // macOS is the platform where pid 0 actually RESOLVES (`kernel_task`), so the check
+    // cannot be left to the later existence probe.
+    let r = ProcessIdRecord {
+        version: RECORD_VERSION,
+        platform: Platform::MacOs,
+        pid: 0,
+        token: 1,
+        boot_id: None,
+        pid_ns: None,
+    };
+    assert_eq!(
+        validate(&r, &Platform::MacOs, &Scope::none()),
+        Err(RecordErrorKind::InvalidPid)
+    );
+}
+
+#[test]
+fn a_unix_record_with_a_pid_above_i32_max_is_rejected() {
+    let mut r = linux_record();
+    r.pid = u32::MAX;
+    assert_eq!(
+        validate(&r, &Platform::Linux, &linux_scope()),
+        Err(RecordErrorKind::InvalidPid)
+    );
+}
+
+#[test]
+fn a_windows_record_with_pid_zero_is_rejected() {
+    let mut r = windows_record();
+    r.pid = 0;
+    assert_eq!(
+        validate(&r, &Platform::Windows, &Scope::none()),
+        Err(RecordErrorKind::InvalidPid)
+    );
+}
+
+#[test]
+fn a_windows_record_with_a_pid_above_i32_max_is_accepted() {
+    // Deliberate asymmetry: a Windows pid is a full `DWORD` and is never a `kill(2)`
+    // target, so the `i32` ceiling that protects the Unix backends does not apply here.
+    let mut r = windows_record();
+    r.pid = u32::MAX;
+    assert_eq!(
+        validate(&r, &Platform::Windows, &Scope::none()),
+        Ok((u32::MAX, 134_301_578_477_907_396))
+    );
+}
+
+#[test]
+fn the_pid_check_runs_after_the_platform_check() {
+    // A pid-0 record from the wrong platform is ForeignPlatform: the pid rule is chosen by
+    // platform, so it may not be applied before the platform is known to match.
+    let mut r = linux_record();
+    r.pid = 0;
+    assert_eq!(
+        validate(&r, &Platform::Windows, &Scope::none()),
+        Err(RecordErrorKind::ForeignPlatform)
+    );
+}
+
+#[test]
+fn a_scope_mismatch_names_the_values_that_diverged() {
+    // `kind` alone tells an operator the category; the detail has to say WHICH value
+    // failed to match, the way the ScopeUnreadable path names its path and OS error.
+    //
+    // The live scope deliberately differs from the record in BOTH fields. With matching
+    // fixtures a single rendered occurrence would satisfy every assertion below, so a
+    // regression that dropped the `scope` side from the format string — or rendered the
+    // record's value twice — would still pass.
+    let live = Scope {
+        boot_id: Some("11111111-2222-3333-4444-555555555555".into()),
+        pid_ns: Some(4_026_539_999),
+    };
+    let e = reject(&linux_record(), &live, RecordErrorKind::ForeignBootSession);
+    let rendered = e.to_string();
+    assert!(
+        rendered.contains("36c39237-f06e-4e88-a74d-ea99d42b817c"),
+        "the record's boot id must appear: {rendered}"
+    );
+    assert!(
+        rendered.contains("11111111-2222-3333-4444-555555555555"),
+        "and the LIVE boot id it failed to match: {rendered}"
+    );
+    assert!(
+        rendered.contains("4026531836"),
+        "the record's pid namespace: {rendered}"
+    );
+    assert!(rendered.contains("4026539999"), "and the live one: {rendered}");
+    assert!(rendered.contains("4242"), "and the pid: {rendered}");
+}
+
+#[test]
+fn a_scope_read_failure_keeps_the_path_and_the_cause() {
+    // The one failure to_record/try_from can have. The mapping is pure, so it is checked
+    // on every host even though only Linux can trigger it for real.
+    let e = scope_error(ScopeReadError {
+        path: "/proc/sys/kernel/random/boot_id".to_owned(),
+        source: std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory"),
+    });
+    let Error::IdentityRecord { kind, detail, source } = &e else {
+        panic!("expected Error::IdentityRecord, got {e:?}");
+    };
+    assert_eq!(*kind, RecordErrorKind::ScopeUnreadable);
+    assert!(
+        detail.contains("/proc/sys/kernel/random/boot_id"),
+        "the failing path must be in the detail, got {detail:?}"
+    );
+    let source = source.as_ref().expect("the io error must be preserved as the source");
+    assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+    // And the rendered message must not just repeat the variant's own text.
+    let rendered = e.to_string();
+    assert!(rendered.contains("/proc/sys/kernel/random/boot_id"), "{rendered}");
+}
+
+// Live round trip ======================================================================
+
+use super::{record_from, restore};
+use crate::identity::{Existence, Liveness, ProcessId};
+
+/// A scope read that failed, for driving the failure wiring of `record_from` / `restore`.
+fn a_failed_scope_read() -> Result<Scope, ScopeReadError> {
+    Err(ScopeReadError {
+        path: "/proc/sys/kernel/random/boot_id".to_owned(),
+        source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Permission denied"),
+    })
+}
+
+#[test]
+fn a_failed_scope_read_aborts_writing_a_record() {
+    // Drives the `?` inside `record_from` — the wiring `to_record` is one line of. Runs on
+    // every host, including the two whose real `session_scope` cannot fail.
+    let e = record_from(&ProcessId::current(), a_failed_scope_read()).expect_err("must not produce a record");
+    let Error::IdentityRecord { kind, source, .. } = &e else {
+        panic!("expected Error::IdentityRecord, got {e:?}");
+    };
+    assert_eq!(*kind, RecordErrorKind::ScopeUnreadable);
+    assert_eq!(
+        source.as_ref().expect("cause preserved").kind(),
+        std::io::ErrorKind::PermissionDenied
+    );
+}
+
+#[test]
+fn a_failed_scope_read_aborts_restoring_a_record() {
+    // The same for `restore`. The record itself is perfectly valid — only the host's own
+    // scope read failed — so anything other than ScopeUnreadable means the `?` is misplaced
+    // and a record was validated against a scope nobody managed to read.
+    let record = ProcessIdRecord {
+        version: RECORD_VERSION,
+        platform: Platform::current(),
+        pid: 4242,
+        token: 1,
+        boot_id: None,
+        pid_ns: None,
+    };
+    let e = restore(&record, &Platform::current(), a_failed_scope_read()).expect_err("must not restore");
+    let Error::IdentityRecord { kind, .. } = &e else {
+        panic!("expected Error::IdentityRecord, got {e:?}");
+    };
+    assert_eq!(*kind, RecordErrorKind::ScopeUnreadable);
+}
+
+#[test]
+fn the_current_identity_round_trips_through_a_record() {
+    let me = ProcessId::current();
+    let record = me.to_record().expect("this host can describe its own boot session");
+    assert_eq!(record.version, RECORD_VERSION);
+    assert_eq!(record.platform, Platform::current());
+    assert_eq!(record.pid, me.pid());
+    let back = ProcessId::try_from(&record).expect("a record just written here must restore");
+    assert_eq!(back, me, "the restored identity must equal the original");
+    // And the restored identity is still a working identity, not just equal bits.
+    assert_eq!(back.exists(), Existence::Present);
+    assert_eq!(back.is_alive(), Liveness::Alive);
+}
+
+#[test]
+fn restoring_is_not_a_liveness_check() {
+    // A record for a process that has exited still RESTORES — validation is about whether
+    // the token can be compared here at all, not about whether the process is there.
+    let mut child = crate::test_child::spawn_a_process_that_exits();
+    let id = ProcessId::of(child.id())
+        .found()
+        .expect("a just-spawned child resolves");
+    let record = id.to_record().expect("to_record");
+    child.wait().expect("wait");
+    let back = ProcessId::try_from(&record).expect("a record for a dead process still restores");
+    assert_eq!(back, id);
+    // `is_alive`, not `exists`: `child` still holds the process handle, and on Windows
+    // that pins the kernel object so `exists()` stays Present. `is_alive` reads the
+    // signaled state and is correct the instant the process exits.
+    assert_eq!(
+        back.is_alive(),
+        Liveness::Dead,
+        "…and only then does it report the process is not running"
+    );
+}
+
+#[test]
+fn a_record_from_this_host_carries_exactly_this_hosts_scope() {
+    let record = ProcessId::current().to_record().expect("to_record");
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+        // Expected values read INDEPENDENTLY from /proc, not from the new code.
+        let boot_id =
+            std::fs::read_to_string("/proc/sys/kernel/random/boot_id").expect("/proc/sys/kernel/random/boot_id");
+        assert_eq!(record.boot_id.as_deref(), Some(boot_id.trim()));
+        let ino = std::fs::metadata("/proc/self/ns/pid").expect("ns/pid").ino();
+        assert_eq!(record.pid_ns, Some(ino));
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(record.boot_id, None, "an absolute token needs no boot session");
+        assert_eq!(record.pid_ns, None, "no pid namespaces on this platform");
+    }
+}
+
+/// Assert `TryFrom` on `record` fails with `kind`.
+fn assert_refused(record: &ProcessIdRecord, kind: RecordErrorKind) {
+    match ProcessId::try_from(record) {
+        Err(Error::IdentityRecord { kind: got, .. }) => assert_eq!(got, kind),
+        Err(other) => panic!("expected Error::IdentityRecord({kind:?}), got {other:?}"),
+        Ok(id) => panic!("expected {kind:?}, but the record restored to {id:?}"),
+    }
+}
+
+#[test]
+fn a_foreign_platform_record_is_refused_with_a_typed_error() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.platform = Platform::Other("freebsd".into());
+    assert_refused(&record, RecordErrorKind::ForeignPlatform);
+}
+
+#[test]
+fn a_pid_zero_record_is_refused_through_the_live_path() {
+    // The path that matters: a corrupt or hand-edited file reaching `Process::kill` with
+    // pid 0 would panic in `src/wait/linux.rs` rather than return an error.
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.pid = 0;
+    assert_refused(&record, RecordErrorKind::InvalidPid);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_pid_above_i32_max_is_refused_through_the_live_path() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.pid = u32::MAX;
+    assert_refused(&record, RecordErrorKind::InvalidPid);
+}
+
+// These four run only on Linux because only Linux has a non-empty scope. They are what
+// pins `session_scope()` to the shape `validate` compares against: without them a scope
+// left empty, or a boot_id read with a trailing newline, would pass every other test while
+// silently disabling the boot check (or rejecting every real restore).
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_record_from_a_different_boot_is_refused_through_the_live_path() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.boot_id = Some("00000000-0000-0000-0000-000000000000".into());
+    assert_refused(&record, RecordErrorKind::ForeignBootSession);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_record_without_a_boot_id_is_refused_through_the_live_path() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.boot_id = None;
+    assert_refused(&record, RecordErrorKind::MissingBootSession);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_record_from_a_different_pid_namespace_is_refused_through_the_live_path() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.pid_ns = Some(record.pid_ns.expect("linux records carry a pid namespace") + 1);
+    assert_refused(&record, RecordErrorKind::ForeignPidNamespace);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_record_without_a_pid_namespace_is_refused_through_the_live_path() {
+    let mut record = ProcessId::current().to_record().expect("to_record");
+    record.pid_ns = None;
+    assert_refused(&record, RecordErrorKind::MissingPidNamespace);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn an_unreadable_boot_session_is_reported_with_its_path_and_cause() {
+    // A real failed read of real paths that do not exist — no mocking. This is the only
+    // way ScopeUnreadable is reachable in a test; on Windows and macOS the scope read
+    // cannot fail at all, and the pure mapping is covered by
+    // `a_scope_read_failure_keeps_the_path_and_the_cause`.
+    let missing = std::path::Path::new("/proc/cosca-no-such-boot-id");
+    let err = crate::identity::backend::session_scope_at(missing, std::path::Path::new("/proc/self/ns/pid"))
+        .map_err(scope_error)
+        .expect_err("a nonexistent path must fail");
+    let Error::IdentityRecord { kind, detail, source } = &err else {
+        panic!("expected Error::IdentityRecord, got {err:?}");
+    };
+    assert_eq!(*kind, RecordErrorKind::ScopeUnreadable);
+    assert!(detail.contains("/proc/cosca-no-such-boot-id"), "{detail}");
+    assert_eq!(
+        source.as_ref().expect("cause preserved").kind(),
+        std::io::ErrorKind::NotFound
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_blank_boot_id_is_refused_rather_than_stored() {
+    // A container runtime that masks the boot_id file (bind-mounting /dev/null over it)
+    // makes the read SUCCEED and return "". Storing that as Some("") would compare equal to
+    // the next boot's Some(""), silently disabling the boot-session check. A real file, a
+    // real read — the emptiness is genuine, not mocked.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let blank = dir.path().join("boot_id");
+    std::fs::write(&blank, "\n").expect("write");
+    let err = crate::identity::backend::session_scope_at(&blank, std::path::Path::new("/proc/self/ns/pid"))
+        .map_err(scope_error)
+        .expect_err("a blank boot_id must be refused");
+    let Error::IdentityRecord { kind, .. } = &err else {
+        panic!("expected Error::IdentityRecord, got {err:?}");
+    };
+    assert_eq!(*kind, RecordErrorKind::ScopeUnreadable);
+}

--- a/src/identity/windows.rs
+++ b/src/identity/windows.rs
@@ -214,3 +214,9 @@ fn liveness_without_synchronize(pid: RawPid, start: StartToken) -> Liveness {
 #[cfg(test)]
 #[path = "windows_tests.rs"]
 mod windows_tests;
+
+/// Windows creation `FILETIME` is an absolute count of 100 ns ticks since 1601-01-01 UTC:
+/// recorded once, at creation, and unchanged by a reboot. There is nothing to scope it by.
+pub(super) fn session_scope() -> Result<super::persist::Scope, super::persist::ScopeReadError> {
+    Ok(super::persist::Scope::none())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ mod wait;
 #[cfg(test)]
 mod log_capture;
 
+#[cfg(test)]
+mod test_child;
+
 pub mod process;
 pub use process::{Process, Recursive};
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,26 +29,25 @@ pub struct Process {
 }
 
 impl Process {
-    /// Resolve a foreign process by a saved identity. [`Resolved::Gone`] if that exact
-    /// identity is gone or the pid was recycled; [`Resolved::Unknown`] if the OS refused the
-    /// query — the process may well be running.
-    pub fn from_id(id: ProcessId) -> Resolved<Process> {
-        match ProcessId::of(id.pid()) {
-            Resolved::Found(live) if live == id => Resolved::Found(Process { id }),
-            Resolved::Found(_) | Resolved::Gone => Resolved::Gone,
-            Resolved::Unknown => Resolved::Unknown,
-        }
+    /// A handle to the process with this identity. Infallible: the caller already holds the
+    /// identity, so there is nothing to resolve and nothing that can fail.
+    ///
+    /// This deliberately does NOT check that the process is still there. Existence is
+    /// ephemeral — it can change between this call and the next line — so a verdict bound to
+    /// construction is stale the instant it is returned, and gating construction on it would
+    /// discard a perfectly good identity whenever the OS merely declined to answer. Ask
+    /// [`exists`](Self::exists) or [`is_alive`](Self::is_alive) when you want the answer, as
+    /// late as you can.
+    pub fn from_id(id: ProcessId) -> Process {
+        Process { id }
     }
 
-    /// Resolve the process currently holding `pid`. [`Resolved::Gone`] if no process has it;
+    /// Resolve the process currently holding `pid`. Fallible, unlike
+    /// [`from_id`](Self::from_id): a bare pid is not an identity, so this has to obtain the
+    /// start token, and that query can fail. [`Resolved::Gone`] if no process has the pid;
     /// [`Resolved::Unknown`] if the OS refused the query.
     pub fn from_pid(pid: RawPid) -> Resolved<Process> {
         ProcessId::of(pid).map(|id| Process { id })
-    }
-
-    #[cfg(all(test, windows))]
-    pub(crate) fn from_parts_for_test(id: ProcessId) -> Process {
-        Process { id }
     }
 
     /// This process's own handle. Infallible.
@@ -61,6 +60,14 @@ impl Process {
     /// The stable identity (`(pid, start_token)`).
     pub fn id(&self) -> ProcessId {
         self.id
+    }
+
+    /// Whether this exact identity still resolves (zombie-*inclusive*; see
+    /// [`ProcessId::exists`]). [`Existence::Gone`] also covers a recycled pid — a different
+    /// process holding it now is not this one. [`Existence::Unknown`] when the OS refuses the
+    /// query; never `Gone` for a process we could not assess.
+    pub fn exists(&self) -> Existence {
+        self.id.exists()
     }
 
     /// Whether the process is still running (zombie-exclusive; see [`ProcessId::is_alive`]).

--- a/src/process_tests.rs
+++ b/src/process_tests.rs
@@ -5,22 +5,30 @@ use crate::identity::ProcessId;
 fn current_resolves_and_is_alive() {
     let me = Process::current();
     assert_eq!(me.is_alive(), crate::identity::Liveness::Alive);
-    assert_eq!(Process::from_id(me.id()), crate::identity::Resolved::Found(me));
+    assert_eq!(Process::from_id(me.id()), me);
+    assert_eq!(
+        Process::from_id(me.id()).exists(),
+        crate::identity::Existence::Present,
+        "the Present case of the method that replaced the constructor's check"
+    );
     assert_eq!(Process::from_pid(me.id().pid()), crate::identity::Resolved::Found(me));
 }
 
 #[test]
-fn from_id_rejects_a_recycled_pid() {
-    // A live pid bearing a DIFFERENT start token is the recycle case: the pid resolves,
-    // but its identity no longer matches the saved one, so resolution must fail. Built
-    // against our own (definitely-live) pid with a token that cannot be the real one.
+fn a_recycled_pid_is_reported_by_exists_not_by_the_constructor() {
+    // A live pid bearing a DIFFERENT start token is the recycle case: the pid resolves, but
+    // its identity does not match the saved one. Built against our own (definitely-live) pid
+    // with a token that cannot be the real one.
     let real = ProcessId::current();
     let stale = ProcessId::from_parts_for_test(real.pid(), real.start_token_raw().wrapping_add(1));
+    let p = Process::from_id(stale);
+    assert_eq!(p.id(), stale, "the identity is kept verbatim");
     assert_eq!(
-        Process::from_id(stale),
-        crate::identity::Resolved::Gone,
-        "a mismatched start token must not resolve"
+        p.exists(),
+        crate::identity::Existence::Gone,
+        "a mismatched start token is not this process"
     );
+    assert_eq!(p.is_alive(), crate::identity::Liveness::Dead);
 }
 
 #[test]
@@ -42,18 +50,31 @@ fn from_pid_is_unknown_for_an_access_denied_process() {
     );
 }
 
-/// `from_id` reaches Unknown through a different path than `from_pid` - it additionally
-/// compares the resolved identity against the caller-s, and that comparison is where an
-/// Unknown-into-Gone collapse would hide.
+/// A `Process` built from a saved identity reaches Unknown through a different path than
+/// `from_pid` - it additionally compares the resolved identity against the caller-s, and that
+/// comparison is where an Unknown-into-Gone collapse would hide.
 #[cfg(windows)]
 #[test]
-fn from_id_is_unknown_for_an_access_denied_process() {
+fn a_process_built_from_a_denied_identity_is_unknown_not_gone() {
     use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
     let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
     let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
         .expect("the owned handle always yields an identity");
     assert!(child.is_running(), "precondition: the subject must be live");
-    assert_eq!(Process::from_id(id), crate::identity::Resolved::Unknown);
+    // The identity survives construction - this is the whole point of an infallible
+    // `from_id`: an unelevated supervisor keeps the handle to a service it may not query.
+    let p = Process::from_id(id);
+    assert_eq!(
+        p.exists(),
+        crate::identity::Existence::Unknown,
+        "denied must not read as Gone"
+    );
+    assert_eq!(
+        p.is_alive(),
+        crate::identity::Liveness::Unknown,
+        "denied must not read as Dead"
+    );
+    assert!(child.is_running(), "and it must still have been live throughout");
 }
 
 /// Pinned default: an unassessable anchor yields the same empty answers as a gone one.
@@ -70,7 +91,7 @@ fn parent_and_children_of_an_unassessable_anchor_are_empty() {
         crate::identity::Existence::Unknown,
         "precondition: unassessable"
     );
-    let p = Process::from_parts_for_test(id);
+    let p = Process::from_id(id);
     assert!(p.parent().is_none());
     assert!(p.children(crate::Recursive::No).is_empty());
     assert!(p.children(crate::Recursive::Yes).is_empty());

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -1,0 +1,16 @@
+//! Test-only child processes shared across the crate's unit tests.
+
+/// A child that exits promptly and needs no external binary: this same test binary, run
+/// with a filter that matches nothing, so libtest runs zero tests and exits 0.
+///
+/// The libtest filter is mandatory, and is why this lives in exactly one place: re-execing
+/// the test binary with NO arguments runs the whole suite — including whichever test called
+/// this — which then re-execs again, unboundedly.
+pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
+    std::process::Command::new(std::env::current_exe().expect("current_exe"))
+        .args(["--exact", "__cosca_no_such_test__"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn")
+}

--- a/src/tokio/process.rs
+++ b/src/tokio/process.rs
@@ -25,13 +25,15 @@ impl From<crate::process::Process> for Process {
 }
 
 impl Process {
-    /// Resolve a foreign process by a saved identity. `None` if that exact identity is
-    /// gone or the pid was recycled.
-    pub fn from_id(id: ProcessId) -> crate::identity::Resolved<Process> {
-        crate::process::Process::from_id(id).map(Process::from)
+    /// A handle to the process with this identity. Infallible — see
+    /// [`Process::from_id`](crate::Process::from_id) for why construction does not check
+    /// that the process is still there.
+    pub fn from_id(id: ProcessId) -> Process {
+        Process::from(crate::process::Process::from_id(id))
     }
 
-    /// Resolve the process currently holding `pid`. `None` if no live process has it.
+    /// Resolve the process currently holding `pid`. Fallible, unlike
+    /// [`from_id`](Self::from_id): a bare pid has to be resolved into an identity first.
     pub fn from_pid(pid: RawPid) -> crate::identity::Resolved<Process> {
         crate::process::Process::from_pid(pid).map(Process::from)
     }
@@ -44,6 +46,12 @@ impl Process {
     /// The stable identity (`(pid, start_token)`).
     pub fn id(&self) -> ProcessId {
         self.inner.id()
+    }
+
+    /// Whether this exact identity still resolves (zombie-inclusive; see
+    /// [`ProcessId::exists`]).
+    pub fn exists(&self) -> crate::identity::Existence {
+        self.inner.exists()
     }
 
     /// Whether the process is still running (zombie-exclusive; see [`ProcessId::is_alive`]).
@@ -108,3 +116,7 @@ impl Process {
         self.inner.terminate_tree()
     }
 }
+
+#[cfg(test)]
+#[path = "process_tests.rs"]
+mod process_tests;

--- a/src/tokio/process_tests.rs
+++ b/src/tokio/process_tests.rs
@@ -1,0 +1,35 @@
+//! The async mirror's introspection delegates. `exists` and `is_alive` are one-line
+//! forwards, which is exactly the shape where a mis-wired delegate (forwarding to the other
+//! method, or answering from the wrong side) survives every happy-path test. Each of the
+//! three `Existence` variants is asserted through the async wrapper; `Present` is covered by
+//! `tests/tokio_foreign.rs`, and the two negative cases are here because they need
+//! crate-internal fixtures.
+//!
+//! Plain `#[test]`, not `#[tokio::test]`: these two methods are synchronous by design.
+
+use super::Process;
+use crate::identity::{Existence, Liveness, ProcessId};
+
+#[test]
+fn a_recycled_pid_reads_as_gone_through_the_async_wrapper() {
+    let real = ProcessId::current();
+    let stale = ProcessId::from_parts_for_test(real.pid(), real.start_token_raw().wrapping_add(1));
+    let p = Process::from_id(stale);
+    assert_eq!(p.id(), stale, "the identity is kept verbatim");
+    assert_eq!(p.exists(), Existence::Gone);
+    assert_eq!(p.is_alive(), Liveness::Dead);
+}
+
+#[cfg(windows)]
+#[test]
+fn a_denied_identity_reads_as_unknown_not_gone_through_the_async_wrapper() {
+    use windows::Win32::System::Threading::PROCESS_SYNCHRONIZE;
+    let child = crate::identity::windows_fixture::spawn_restricted(PROCESS_SYNCHRONIZE.0);
+    let id = crate::identity::windows_identity_from_handle(child.handle(), child.pid())
+        .expect("the owned handle always yields an identity");
+    assert!(child.is_running(), "precondition: the subject must be live");
+    let p = Process::from_id(id);
+    assert_eq!(p.exists(), Existence::Unknown, "denied must not read as Gone");
+    assert_eq!(p.is_alive(), Liveness::Unknown, "denied must not read as Dead");
+    assert!(child.is_running(), "and it must still have been live throughout");
+}

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -9,6 +9,14 @@ use std::time::{Duration, SystemTime};
 
 use cosca::identity::ProcessId;
 
+// All four are used only by the serde-gated tests at the end of this file; ungated they
+// would be unused imports with the feature off. The body above reaches `Liveness` through
+// fully-qualified paths, which does not count as a use of an import.
+#[cfg(feature = "serde")]
+use cosca::identity::{Liveness, ProcessIdRecord, Resolved};
+#[cfg(feature = "serde")]
+use std::io::BufRead;
+
 #[path = "common/mod.rs"]
 mod common;
 
@@ -147,4 +155,88 @@ fn identity_survives_the_alive_to_zombie_transition() {
         cosca::identity::Existence::Gone,
         "a reaped process is gone"
     );
+}
+
+// Persist / restore ====================================================================
+
+// Both consts are used only by the two serde-gated tests below; ungated they would be
+// dead with the feature off.
+#[cfg(feature = "serde")]
+const RECORD_VAR: &str = "COSCA_IDENTITY_TEST_RECORD_PATH";
+/// Printed by the helper on stdout once its record file is complete.
+#[cfg(feature = "serde")]
+const RECORD_READY: &str = "COSCA_RECORD_WRITTEN";
+
+/// Re-exec helper: when `RECORD_VAR` names a path, write this process's own identity
+/// record there, announce it on stdout, then block on stdin so the parent controls the
+/// exit. The record is produced by a genuinely different process — a real cross-process
+/// restart, not a round trip inside one test. Inert in a normal run, like
+/// `helper_block_on_stdin` above.
+#[test]
+#[cfg(feature = "serde")]
+fn helper_write_own_record() {
+    let Some(path) = std::env::var_os(RECORD_VAR) else {
+        return;
+    };
+    let path = std::path::PathBuf::from(path);
+    let record = ProcessId::current().to_record().expect("to_record");
+    let json = serde_json::to_string(&record).expect("serialize");
+    // Write-then-rename: the parent must never observe a half-written file. Rename over an
+    // existing name is atomic on all three platforms.
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, json).expect("write record");
+    std::fs::rename(&tmp, &path).expect("rename record into place");
+    // The handshake proper: a byte on the pipe, not an elapsed interval.
+    println!("{RECORD_READY}");
+    use std::io::Write;
+    std::io::stdout().flush().expect("flush");
+    let mut buf = Vec::new();
+    let _ = std::io::stdin().read_to_end(&mut buf);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn an_identity_written_by_another_process_restores_and_names_that_process() {
+    use cosca::Process;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("id.json");
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut child = Command::new(exe)
+        // The filter is mandatory: an unfiltered re-exec runs the whole suite recursively.
+        // `--nocapture` is what lets the helper's marker reach our pipe at all.
+        .args(["helper_write_own_record", "--exact", "--nocapture"])
+        .env(RECORD_VAR, &path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn helper");
+
+    // Synchronise on the pipe: read lines until the marker. libtest prints its own banner
+    // first, so scan rather than reading a single line. EOF without the marker means the
+    // helper died before writing — a real failure, reported as one.
+    let stdout = child.stdout.take().expect("piped stdout");
+    let ready = std::io::BufReader::new(stdout)
+        .lines()
+        .map_while(Result::ok)
+        .any(|l| l.trim() == RECORD_READY);
+    assert!(ready, "the helper exited without writing its record");
+
+    let json = std::fs::read_to_string(&path).expect("the record file is complete by now");
+    let record: ProcessIdRecord = serde_json::from_str(&json).expect("deserialize");
+    let restored = ProcessId::try_from(&record).expect("a record from this boot must restore");
+
+    // Derived independently of the record: the parent's own view of the child's identity.
+    let live = ProcessId::of(child.id()).found().expect("the live child resolves");
+    assert_eq!(restored, live, "the restored identity must be the child's identity");
+    assert_eq!(restored.pid(), child.id());
+    assert!(matches!(Process::from_id(restored), Resolved::Found(_)));
+
+    // End it, and the same restored identity now reports the process is not running.
+    // `is_alive`, not `exists`: `child` still holds the handle, which on Windows keeps the
+    // process object resolvable after exit.
+    drop(child.stdin.take());
+    child.wait().expect("wait");
+    assert_eq!(restored.is_alive(), Liveness::Dead);
 }

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -13,7 +13,7 @@ use cosca::identity::ProcessId;
 // would be unused imports with the feature off. The body above reaches `Liveness` through
 // fully-qualified paths, which does not count as a use of an import.
 #[cfg(feature = "serde")]
-use cosca::identity::{Liveness, ProcessIdRecord, Resolved};
+use cosca::identity::{Existence, Liveness, ProcessIdRecord};
 #[cfg(feature = "serde")]
 use std::io::BufRead;
 
@@ -231,7 +231,11 @@ fn an_identity_written_by_another_process_restores_and_names_that_process() {
     let live = ProcessId::of(child.id()).found().expect("the live child resolves");
     assert_eq!(restored, live, "the restored identity must be the child's identity");
     assert_eq!(restored.pid(), child.id());
-    assert!(matches!(Process::from_id(restored), Resolved::Found(_)));
+    // The restored identity is usable as a handle, and querying through that handle finds
+    // the live child — the whole point of persisting it.
+    let restored_handle = Process::from_id(restored);
+    assert_eq!(restored_handle.exists(), Existence::Present);
+    assert_eq!(restored_handle.is_alive(), Liveness::Alive);
 
     // End it, and the same restored identity now reports the process is not running.
     // `is_alive`, not `exists`: `child` still holds the handle, which on Windows keeps the

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -76,7 +76,11 @@ fn foreign_wait_timeout_huge_duration_does_not_panic() {
 fn current_and_from_id_round_trip() {
     let me = cosca::Process::current();
     assert_eq!(me.is_alive(), cosca::identity::Liveness::Alive);
-    assert_eq!(cosca::Process::from_id(me.id()).found().map(|p| p.id()), Some(me.id()));
+    assert_eq!(cosca::Process::from_id(me.id()).id(), me.id());
+    assert_eq!(
+        cosca::Process::from_id(me.id()).exists(),
+        cosca::identity::Existence::Present
+    );
 }
 
 #[test]
@@ -259,8 +263,9 @@ fn is_alive_is_false_for_a_real_zombie() {
     );
     // exists() is zombie-inclusive on ALL Unixes: Linux `/proc` persists, and macOS
     // resolves zombies via `sysctl KERN_PROC` (identity.rs).
-    assert!(
-        matches!(cosca::Process::from_id(p.id()), cosca::identity::Resolved::Found(_)),
+    assert_eq!(
+        cosca::Process::from_id(p.id()).exists(),
+        cosca::identity::Existence::Present,
         "a zombie identity still resolves"
     );
     raw.wait().expect("reap the zombie");

--- a/tests/tokio_foreign.rs
+++ b/tests/tokio_foreign.rs
@@ -64,7 +64,8 @@ async fn async_foreign_introspection_delegates() {
     let p = Process::from_pid(child.id().pid()).found().expect("resolves");
     assert_eq!(p.id(), child.id());
     assert_eq!(p.is_alive(), cosca::identity::Liveness::Alive);
-    assert_eq!(Process::from_id(p.id()).found().expect("round-trip").id(), p.id());
+    assert_eq!(Process::from_id(p.id()).id(), p.id());
+    assert_eq!(Process::from_id(p.id()).exists(), cosca::identity::Existence::Present);
     child.kill().expect("cleanup");
     child.wait().expect("reap");
 }

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -18,9 +18,11 @@ async fn async_id_is_a_real_stable_identity() {
     use std::io::Write as _;
     let (mut child, mut sock) = common::spawn_blocker_async();
     let id = child.id();
+    let p = cosca::Process::from_id(id);
+    assert_eq!(p.id(), id);
     assert_eq!(
-        cosca::Process::from_id(id).found().map(|p| p.id()),
-        Some(id),
+        p.exists(),
+        cosca::identity::Existence::Present,
         "id() is a resolvable identity"
     );
     sock.write_all(b"x").expect("release");


### PR DESCRIPTION
Closes #48.

`ProcessId` pairs a pid with a kernel start token so a recycled pid never compares equal to the original process. The canonical use of that property is surviving a restart — write the identity, read it back, confirm you are still supervising the same thing — and that round trip was impossible: `StartToken` was private, the only from-parts constructor was `#[cfg(test)]`, and there was no serde anywhere.

## The hard part was token portability, not serde

The three backends' tokens are not equally persistable, and this was measured rather than assumed:

| Platform | Token | Survives a reboot? |
|---|---|---|
| Windows | creation `FILETIME` | yes — absolute |
| macOS | `kinfo_proc` start µs | yes — absolute |
| Linux | `/proc` `starttime` jiffies | **no** — counted from boot |

Measured on WSL2 Ubuntu-24.04: a freshly spawned child's field-22 `starttime` was `162431157` jiffies at `HZ=100`, against a `/proc/uptime` of `1624311.57` s at the same instant — an exact match, and pid 1 carries a token of `228`. A naively serialized Linux token therefore aliases onto whichever process holds that pid after a reboot, reintroducing the exact hazard `ProcessId` exists to remove, in a form that is harder to notice because the holder believes they have a strong identity.

Measured on Windows: 200 processes spawned from 8 threads produced 200 distinct creation `FILETIME`s whose offsets from the minimum have a **GCD of 1** (100 ns unit), and separately, **0 of 120** creation tokens was a value `GetSystemTimeAsFileTime` ever took while they were being spawned — all 120 land strictly between consecutive ticks. The kernel stamps creation from the fine-grained interrupt-time source, not the tick clock, so the system timer resolution (0.5 ms on the measuring host, 15.625 ms by default elsewhere) does not enter into it.

## What landed

A versioned, self-describing `ProcessIdRecord` — pid, raw token, platform tag, format version, and on Linux the boot identifiers the token is relative to — plus a validating `TryFrom<&ProcessIdRecord> for ProcessId` that is the only way back. There is deliberately no infallible from-parts constructor. `RecordErrorKind` names each refusal: unknown version, foreign platform, invalid pid, foreign/missing boot session, foreign/missing pid namespace, unreadable scope.

Beyond the ticket's proposal, the record also carries the `/proc/self/ns/pid` inode. `boot_id` alone does not scope a pid: a Docker container was measured sharing the host's `boot_id` exactly (`36c39237-…`) while having its own pid namespace (`4026532369` vs `4026532417`). The inode is documented as an additional filter, never a guarantee — the kernel reuses namespace inode numbers, and with a recycled one the record falls back to exactly the `(pid, boot_id, token)` protection it would have had without the field, never less.

Restoring is not a liveness check. A record for an exited process restores fine and then reports `Gone` — which is what a supervisor iterating a state file wants.

Notes on the shape:

- Validation, the pid rule and error mapping are **pure and compiled on every target**, so the Linux-only rejection branches execute on Windows and macOS CI too.
- The pid is validated, reusing `identity::probe::signal_target` rather than restating it. Without this, a corrupt record with pid 0 reaches `Pid::from_raw(..).expect("a resolvable ProcessId is never pid 0")` in `src/wait/linux.rs` and panics the library; above `i32::MAX` it would wrap negative, where `kill(-N, sig)` addresses a whole process group.
- `token` is a **decimal string** on the wire. A real measured Windows token is `134301578477907396`, about 15× past 2^53, so a JSON number would silently round for any double-precision consumer — the precise corruption this type exists to prevent.
- Unknown platform tags decode to `Platform::Other` instead of failing, so a record from a newer `cosca` reaches validation and is refused with a stated reason rather than dying in the decoder. That leniency is what makes "reject an unknown format version" reachable at all.
- `serde` is a new optional feature. The record type and all its validation exist **without** it; only the `Serialize`/`Deserialize` impls are gated. A `--features serde` CI lane is added — without it the feature would ship untested.
## `Process::from_id` is now infallible (second commit)

Restoring an identity is only half the workflow; using it is the other half, and `from_id` was standing in the way. It returned `Resolved<Process>`, probing the OS and handing back **nothing** when the OS merely declined to answer - discarding a perfectly good identity in exactly the case this ticket exists to support: an unelevated supervisor re-attaching to a service it may not query.

`Process` is `struct Process { id: ProcessId }`. It holds no handle, so nothing is pinned by construction, and `from_id`'s `ProcessId::of(..) == id` was a pure probe duplicating a question the type already answers as a method. Existence is *ephemeral*: a verdict bound to construction is stale the instant it returns. So the check is gone, and the question moved to where it can be asked as late as the caller likes.

```rust
pub fn from_id(id: ProcessId) -> Process          // infallible - you already hold the identity
pub fn from_pid(pid: RawPid) -> Resolved<Process> // unchanged - a bare pid must be resolved first
```

The asymmetry is principled: `from_pid` receives something that is *not* an identity and must obtain the start token, which genuinely can come back `Gone` or `Unknown`.

`Process::exists()` is added - mirroring `is_alive()`, which already delegated to `ProcessId` - so the existence question has a home on the type. Both changes are mirrored on `cosca::tokio::Process`.

Two existing tests encoded #45's contract *through* `from_id`'s return: recycled-pid rejection, and access-denied reading as `Unknown` rather than `Gone`. They were **re-homed, not deleted** - the identity comparison where an Unknown-into-Gone collapse could hide now lives in `ProcessId::exists`/`is_alive`, so the assertions moved with it. Assertions that only matched `Resolved::Found(_)` after construction would have become vacuous and were rewritten to assert `exists() == Present` / `is_alive() == Alive`. `Process::from_parts_for_test` is deleted: the now-public infallible `from_id` replaces its only caller exactly.

## Testing

Executed on **Windows 11** (511 tests, all feature combinations) and on **Linux** (WSL2 Ubuntu-24.04 — real kernel, not the CI runner), including the eight Linux-gated tests Windows compiles out: live-path rejection of a foreign boot session, a foreign pid namespace, and both missing-scope cases; a real failed `/proc` read reported with its path and cause; a blank `boot_id` refused rather than stored; and a record's scope checked against `/proc` read independently by the test. `cargo clippy --all-targets --locked -- -D warnings` — the lint job's exact command — was run on Linux too.

**macOS is unverified locally** and rests on CI, which is green on both darwin lanes. Its `session_scope` is the same empty-scope constant as Windows.

The wire-format tests assert hand-written JSON literals derived from the documented format, never captured from the encoder. The cross-process test in `tests/identity_lifecycle.rs` has a helper write its own record, rename it into place atomically, and announce it on stdout; the parent synchronises on that pipe marker — no polling, no timeout. `Process::exists()` and its tokio mirror are asserted across all three `Existence` variants.

Two claims remain unmeasured and are documented as such: that `boot_id` changes across a reboot (testing it needs `wsl --shutdown`, which would disrupt other work on this machine), and anything macOS.
