### PR TITLE
fix(windows): report a typed NoConsole error when the caller has no console

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -156,6 +156,19 @@ impl Child {
     /// `Unsupported` otherwise). Cooperative best-effort: on the `TreeWalk` mechanism a
     /// descendant whose identity transiently fails to resolve is intentionally left
     /// unsignaled; `kill_tree` is the guaranteed hard teardown.
+    ///
+    /// **Windows: what this actually signals.** `CTRL_BREAK` is delivered to the root's
+    /// **process group**, not to the tree. A nested contained descendant leads its own
+    /// group and never receives it; only [`kill_tree`](Child::kill_tree) reaches every
+    /// member.
+    ///
+    /// **And it needs the caller to have a console.** The event is deliverable only within
+    /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything
+    /// spawned detached cannot deliver it. The failure is classified best-effort: usually
+    /// [`Error::NoConsole`](crate::error::Error::NoConsole), but a raw `Error::Io` when the
+    /// crate cannot confirm the cause. Treat **any** error here as "no signal was sent, the
+    /// tree is still running" rather than keying a fallback on the variant alone. Attach a
+    /// console before spawning the tree, or use `kill_tree`, which needs none.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
         self.attached.terminate(self.proc.id())

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -53,6 +53,22 @@ impl Child {
     /// `Unsupported` otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone
     /// child). Works on all platforms.
     ///
+    /// **Windows: what this actually signals, and what the grace costs.** `CTRL_BREAK` goes
+    /// to the root's **process group** only. A nested contained descendant leads its own
+    /// group and never receives it — so it does not exit during the grace, idles through the
+    /// whole window, and is then killed by the sweep. The call reports no error either way:
+    /// on Windows the grace is spent regardless of how much of the tree the signal reached.
+    /// Size it accordingly, and treat [`kill_tree`](Child::kill_tree) as the only op that
+    /// reaches every member.
+    ///
+    /// **The caller must also have a console.** The event is deliverable only within the
+    /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned
+    /// detached fails up front: no signal is sent, no grace is waited, and the tree is left
+    /// running for the caller to `kill_tree` (which needs no console). The cause is
+    /// classified best-effort — usually [`Error::NoConsole`](crate::error::Error::NoConsole),
+    /// but a raw `Error::Io` when the crate cannot confirm it — so treat **any** error here
+    /// as "not delivered, tree still running".
+    ///
     /// The grace-wait is **non-reaping** (watches the root's exit without collecting it), so the
     /// subsequent hard sweep runs while the root's pid — and thus the `killpg` group id — is
     /// still valid; reaping first could let `killpg` hit a recycled group. The sweep is

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -93,7 +93,7 @@ impl Attached {
             #[cfg(target_os = "linux")]
             Attached::Cgroup(leaf) => leaf.terminate().map_err(Error::Io),
             #[cfg(windows)]
-            Attached::JobObject(_) => crate::containment::windows::terminate(_child_pid).map_err(Error::Io),
+            Attached::JobObject(_) => crate::containment::windows::terminate(_child_pid),
             Attached::TreeWalk(root) => crate::containment::treewalk::terminate(*root),
         }
     }

--- a/src/containment/treewalk.rs
+++ b/src/containment/treewalk.rs
@@ -388,7 +388,7 @@ pub(crate) fn terminate(root: ProcessId) -> Result<(), crate::error::Error> {
     }
     #[cfg(windows)]
     {
-        crate::containment::windows::terminate(root.pid()).map_err(crate::error::Error::Io)
+        crate::containment::windows::terminate(root.pid())
     }
     #[cfg(not(any(unix, windows)))]
     {

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -178,14 +178,142 @@ pub(crate) fn clear_std_handle_inheritance() {
     }
 }
 
+/// Whether THIS process is attached to a console: `Ok(true)` attached, `Ok(false)` genuinely
+/// none, `Err` the probe itself failed.
+///
+/// `GetConsoleProcessList` returns 0 both for "no console" and for an API-level failure, so
+/// the two are told apart by the last OS error: a console-less caller gets 0 with
+/// `ERROR_INVALID_HANDLE`. Unlike `GetConsoleWindow` this is correct for a *windowless*
+/// console (`CREATE_NO_WINDOW`, ConPTY), which can signal fine.
+///
+/// Used only to CONFIRM a failure that already happened, never to gate one before it. Both
+/// orderings race a concurrent `AttachConsole`/`FreeConsole`; a confirmation at worst
+/// withholds the typed error, while a guard decides the outcome from state that may already
+/// be gone.
+pub(crate) fn caller_has_console() -> io::Result<bool> {
+    use windows::Win32::Foundation::{SetLastError, ERROR_INVALID_HANDLE, WIN32_ERROR};
+    use windows::Win32::System::Console::GetConsoleProcessList;
+    #[cfg(test)]
+    if fault::take_force_console_probe_error() {
+        return Err(io::Error::from_raw_os_error(
+            windows::Win32::Foundation::ERROR_INVALID_PARAMETER.0 as i32,
+        ));
+    }
+    let mut list = [0u32; 1];
+    // SAFETY: both calls are standard Win32; `list` is a valid writable slice. A buffer
+    // smaller than the attached-process count is fine — the return is then the required
+    // count, and only "is it zero" is read here. The last error is cleared first: a zero
+    // return is only meaningful together with the code THIS call set, and the live caller
+    // reaches here right after a `GenerateConsoleCtrlEvent` that itself failed with
+    // `ERROR_INVALID_HANDLE` — reading that stale value would let the probe "confirm" an
+    // absence it never measured.
+    let n = unsafe {
+        SetLastError(WIN32_ERROR(0));
+        GetConsoleProcessList(&mut list)
+    };
+    if n != 0 {
+        return Ok(true);
+    }
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(ERROR_INVALID_HANDLE.0 as i32) {
+        Ok(false)
+    } else {
+        Err(err)
+    }
+}
+
+/// Classify a `GenerateConsoleCtrlEvent` failure. Pure — the Win32 result and the console
+/// probe are both parameters — so every arm is unit-testable without hooking the OS calls the
+/// live path depends on (the same injection idiom as `treewalk::descendants_with`).
+///
+/// `err` is the `io::Error` converted from `windows::core::Error`, so its `raw_os_error` is
+/// the **HRESULT**, not the bare Win32 code.
+///
+/// `Error::NoConsole` is returned ONLY when the failure code matches AND the probe confirms
+/// there is no console. A contradicted probe, a failed probe, or any other failure code keeps
+/// the raw `Error::Io`: the typed variant must never assert a cause the process just measured
+/// to be false.
+pub(crate) fn classify_ctrl_event_failure(pid: u32, err: io::Error, console: io::Result<bool>) -> crate::error::Error {
+    use windows::Win32::Foundation::ERROR_INVALID_HANDLE;
+    let no_console = windows::core::HRESULT::from_win32(ERROR_INVALID_HANDLE.0).0;
+    if err.raw_os_error() == Some(no_console) && matches!(console, Ok(true)) {
+        // warn, not debug: the crate's core mapping (this code <=> no console) was just
+        // contradicted. Either another thread attached a console in the confirmation gap, or
+        // the mapping does not hold on this host — both deserve to be visible, and neither
+        // may be reported as an ordinary Io passthrough without a trace.
+        log::warn!(
+            "CTRL_BREAK to group {pid} failed with ERROR_INVALID_HANDLE, but a console is \
+             attached; surfacing the raw error rather than claiming NoConsole"
+        );
+        return crate::error::Error::Io(err);
+    }
+    if err.raw_os_error() == Some(no_console) {
+        if let Err(probe) = &console {
+            log::warn!("CTRL_BREAK to group {pid}: the console probe failed ({probe}); cannot classify");
+            return crate::error::Error::Io(err);
+        }
+        return crate::error::Error::NoConsole {
+            detail: format!(
+                "cannot send CTRL_BREAK to process group {pid}: this process has no attached \
+                 console. A GUI-subsystem binary, a service, or a detached spawn cannot deliver \
+                 console control events — Windows delivers them only within the caller's \
+                 console. Attach a console before spawning the tree, or use kill_tree() for a \
+                 hard teardown."
+            ),
+        };
+    }
+    // The probe cannot change this classification, but if it ALSO failed that is a second,
+    // independent OS failure and the arms above log theirs — say so here too rather than
+    // dropping it silently.
+    if let Err(probe) = &console {
+        log::warn!("CTRL_BREAK to group {pid} failed, and the console probe also failed ({probe})");
+    }
+    crate::error::Error::Io(err)
+}
+
 /// Send `CTRL_BREAK_EVENT` to the process group rooted at `pid`.
 /// The child was spawned with `CREATE_NEW_PROCESS_GROUP`, making it the leader;
 /// targeting its `pid` reaches the whole group without affecting the parent's console.
-/// Note: `CTRL_C` cannot be group-targeted; `CTRL_BREAK` is the only option here.
-pub(crate) fn terminate(pid: u32) -> io::Result<()> {
+/// `CTRL_C` cannot be group-targeted; `CTRL_BREAK` is the only option here.
+///
+/// **Requires the CALLER to have a console.** That is the failure this classifies; Windows
+/// can also report `ERROR_INVALID_PARAMETER` for a pid that names no process at all, which
+/// stays a raw `Error::Io`. A group that merely *drained* is not a failure — measured, a dead
+/// group leader still returns success. The failure code is authoritative; the console probe that follows only *confirms* it, so a
+/// console state change in the gap degrades the result to a raw `Error::Io` rather than to a
+/// false `NoConsole`. Targeting a group that is in a *different* console is NOT reported by
+/// Windows at all — it returns success and delivers nothing.
+pub(crate) fn terminate(pid: u32) -> Result<(), crate::error::Error> {
     use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
     // SAFETY: standard Win32 call targeting the child's own console group.
-    unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) }.map_err(io::Error::from)
+    match unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) } {
+        Ok(()) => Ok(()),
+        Err(e) => Err(classify_ctrl_event_failure(
+            pid,
+            io::Error::from(e),
+            caller_has_console(),
+        )),
+    }
+}
+
+/// Test-only: force the NEXT `caller_has_console` on THIS thread to report a probe failure,
+/// so that arm's production is covered — a live `GetConsoleProcessList` cannot be made to
+/// fail. Take semantics, mirroring `treewalk::fault`.
+#[cfg(test)]
+pub(crate) mod fault {
+    use std::cell::Cell;
+    thread_local! {
+        static FORCE_CONSOLE_PROBE_ERROR: Cell<bool> = const { Cell::new(false) };
+    }
+    pub(crate) fn set_force_console_probe_error(on: bool) {
+        FORCE_CONSOLE_PROBE_ERROR.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_console_probe_error() -> bool {
+        FORCE_CONSOLE_PROBE_ERROR.with(|f| f.replace(false))
+    }
+    pub(crate) fn armed() -> bool {
+        FORCE_CONSOLE_PROBE_ERROR.with(|f| f.get())
+    }
 }
 
 /// Create a `KILL_ON_JOB_CLOSE` job and assign the process at `proc_handle` to it.

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -14,3 +14,90 @@ fn job_handle_debug_does_not_panic() {
     let s = format!("{h:?}");
     assert!(s.contains("JobHandle"), "debug output: {s}");
 }
+
+/// Live coverage of the `Ok(true)` arm against a real console. `Ok(false)` needs the DETACHED
+/// helper in the integration suite (a different process); `Err` is not provokable live, hence
+/// the fault seam exercised below. This test does NOT guard the integration test against
+/// vacuity — that binary carries its own `console=0` / `console=1` assertions, measured inside
+/// the helper itself.
+#[test]
+fn caller_has_console_is_true_under_cargo_test() {
+    assert!(
+        matches!(super::caller_has_console(), Ok(true)),
+        "cargo test is expected to run with a console attached"
+    );
+}
+
+/// The `Err` arm's production, via the fault seam — a live `GetConsoleProcessList` cannot be
+/// made to fail. This exercises the fault-injection scaffolding, not a real API failure; the
+/// consumption side is covered by `invalid_handle_with_a_failed_probe_stays_io`.
+#[test]
+fn console_probe_error_surfaces() {
+    super::fault::set_force_console_probe_error(true);
+    assert!(super::caller_has_console().is_err());
+    assert!(!super::fault::armed(), "the seam must be consumed by one call");
+    // The very next call is a real probe again.
+    assert!(matches!(super::caller_has_console(), Ok(true)));
+}
+
+/// `HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE)`. Derived from the documented Win32 macro
+/// (`0x8007_0000 | (x & 0xFFFF)` for positive `x`, with `ERROR_INVALID_HANDLE` == 6), not from
+/// this crate's own output.
+const E_INVALID_HANDLE: i32 = 0x8007_0006u32 as i32;
+/// `HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED)` — a different failure, which must NOT be
+/// classified as a missing console.
+const E_ACCESS_DENIED: i32 = 0x8007_0005u32 as i32;
+
+fn io_err(hresult: i32) -> std::io::Error {
+    std::io::Error::from_raw_os_error(hresult)
+}
+
+#[test]
+fn invalid_handle_with_no_console_is_typed_no_console() {
+    let e = super::classify_ctrl_event_failure(4242, io_err(E_INVALID_HANDLE), Ok(false));
+    let crate::error::Error::NoConsole { detail } = e else {
+        panic!("expected NoConsole, got {e:?}");
+    };
+    assert!(detail.contains("4242"), "the detail must name the group: {detail}");
+    assert!(
+        detail.contains("kill_tree()"),
+        "the detail must name the way out: {detail}"
+    );
+}
+
+#[test]
+fn invalid_handle_with_a_console_attached_stays_io() {
+    // The probe contradicts the code: never claim a cause we just measured to be false.
+    let e = super::classify_ctrl_event_failure(1, io_err(E_INVALID_HANDLE), Ok(true));
+    assert!(matches!(e, crate::error::Error::Io(_)), "got {e:?}");
+}
+
+#[test]
+fn invalid_handle_with_a_failed_probe_stays_io() {
+    let probe = Err(std::io::Error::from_raw_os_error(87)); // ERROR_INVALID_PARAMETER
+    let e = super::classify_ctrl_event_failure(1, io_err(E_INVALID_HANDLE), probe);
+    assert!(matches!(e, crate::error::Error::Io(_)), "got {e:?}");
+}
+
+#[test]
+fn a_different_failure_code_stays_io_whatever_the_probe_says() {
+    for console in [Ok(true), Ok(false)] {
+        let e = super::classify_ctrl_event_failure(1, io_err(E_ACCESS_DENIED), console);
+        assert!(matches!(e, crate::error::Error::Io(_)), "got {e:?}");
+    }
+    let e = super::classify_ctrl_event_failure(1, io_err(E_ACCESS_DENIED), Err(io_err(87)));
+    assert!(matches!(e, crate::error::Error::Io(_)), "got {e:?}");
+}
+
+#[test]
+fn the_no_console_signature_matches_the_real_win32_mapping() {
+    // Pins the HRESULT the live path will see against the constant above, so a windows-rs
+    // change to the io::Error conversion cannot silently un-classify the error.
+    use windows::Win32::Foundation::ERROR_INVALID_HANDLE;
+    let hr = windows::core::HRESULT::from_win32(ERROR_INVALID_HANDLE.0);
+    assert_eq!(hr.0, E_INVALID_HANDLE);
+    assert_eq!(
+        std::io::Error::from(windows::core::Error::from_hresult(hr)).raw_os_error(),
+        Some(E_INVALID_HANDLE)
+    );
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,12 @@ pub enum Error {
     /// A containment mechanism could not be established or torn down.
     #[error("process containment failed: {detail}")]
     Containment { detail: String },
+    /// The calling process has no attached console, so Windows' console-group graceful
+    /// signal (`CTRL_BREAK`) cannot be delivered — the caller is a GUI-subsystem binary,
+    /// a service, or was spawned detached. Only the *graceful* tree ops are affected;
+    /// `kill_tree` needs no console.
+    #[error("no attached console for the graceful console-group signal: {detail}")]
+    NoConsole { detail: String },
     /// Privilege elevation could not be completed at runtime.
     #[error("elevation failed ({kind}): {detail}")]
     Elevation { kind: ElevationErrorKind, detail: String },

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -9,6 +9,17 @@ fn containment_error_displays_detail() {
 }
 
 #[test]
+fn no_console_error_names_the_cause() {
+    let e = Error::NoConsole {
+        detail: "CTRL_BREAK to group 1234".into(),
+    };
+    let s = e.to_string();
+    assert!(s.contains("no attached console"), "{s}");
+    assert!(s.contains("CTRL_BREAK to group 1234"), "{s}");
+    assert!(matches!(e, Error::NoConsole { .. }));
+}
+
+#[test]
 fn quote_error_displays_kind_and_offset() {
     let e = QuoteError::new(7, QuoteErrorKind::UnterminatedSingleQuote);
     assert_eq!(e.to_string(), "unterminated single quote at offset 7");

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -387,6 +387,19 @@ impl Child {
     /// `Unsupported` otherwise). Cooperative best-effort: on the `TreeWalk` mechanism a
     /// descendant whose identity transiently fails to resolve is intentionally left
     /// unsignaled; [`kill_tree`](Child::kill_tree) is the guaranteed hard teardown.
+    ///
+    /// **Windows: what this actually signals.** `CTRL_BREAK` is delivered to the root's
+    /// **process group**, not to the tree. A nested contained descendant leads its own
+    /// group and never receives it; only [`kill_tree`](Child::kill_tree) reaches every
+    /// member.
+    ///
+    /// **And it needs the caller to have a console.** The event is deliverable only within
+    /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything
+    /// spawned detached cannot deliver it. The failure is classified best-effort: usually
+    /// [`Error::NoConsole`](crate::error::Error::NoConsole), but a raw `Error::Io` when the
+    /// crate cannot confirm the cause. Treat **any** error here as "no signal was sent, the
+    /// tree is still running" rather than keying a fallback on the variant alone. Attach a
+    /// console before spawning the tree, or use `kill_tree`, which needs none.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
         self.attached.terminate(self.id.pid())

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -65,6 +65,22 @@ impl Child {
     /// `Unsupported` otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone
     /// child). Works on all platforms.
     ///
+    /// **Windows: what this actually signals, and what the grace costs.** `CTRL_BREAK` goes
+    /// to the root's **process group** only. A nested contained descendant leads its own
+    /// group and never receives it — so it does not exit during the grace, idles through the
+    /// whole window, and is then killed by the sweep. The call reports no error either way:
+    /// on Windows the grace is spent regardless of how much of the tree the signal reached.
+    /// Size it accordingly, and treat [`kill_tree`](Child::kill_tree) as the only op that
+    /// reaches every member.
+    ///
+    /// **The caller must also have a console.** The event is deliverable only within the
+    /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned
+    /// detached fails up front: no signal is sent, no grace is waited, and the tree is left
+    /// running for the caller to `kill_tree` (which needs no console). The cause is
+    /// classified best-effort — usually [`Error::NoConsole`](crate::error::Error::NoConsole),
+    /// but a raw `Error::Io` when the crate cannot confirm it — so treat **any** error here
+    /// as "not delivered, tree still running".
+    ///
     /// The grace-wait is **non-reaping** (watches the root's exit without collecting it), so the
     /// subsequent hard sweep runs while the root's pid — and thus the `killpg` group id — is
     /// still valid; reaping first could let `killpg` hit a recycled group. The sweep is

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -339,6 +339,215 @@ fn main() {
             let mut buf = [0u8; 1];
             let _ = sock.read(&mut buf);
         }
+        #[cfg(windows)]
+        "control-block-ack-break" => {
+            // Ack a CTRL_BREAK by writing "B" to the control socket and STAY ALIVE (the handler
+            // returns "handled"). Receipt is then an observed event that cannot race a later
+            // teardown, unlike a child that dies on the break.
+            use std::sync::Mutex;
+            use windows::core::BOOL;
+            use windows::Win32::System::Console::SetConsoleCtrlHandler;
+
+            // A console ctrl handler runs on an OS-spawned thread, not in signal context, so
+            // ordinary allocating I/O is fine here. It writes through its OWN clone of the
+            // socket, so it never contends with the main thread's blocking read. Only
+            // CTRL_BREAK is acked: acking any event would let a stray CTRL_C or CTRL_CLOSE
+            // satisfy a "the child received CTRL_BREAK" assertion.
+            static ACK: std::sync::OnceLock<Mutex<std::net::TcpStream>> = std::sync::OnceLock::new();
+            unsafe extern "system" fn ack(event: u32) -> BOOL {
+                if event != windows::Win32::System::Console::CTRL_BREAK_EVENT {
+                    return BOOL(0); // not handled — default disposition applies
+                }
+                // Every failure below traces and returns NOT-handled instead of fabricating a
+                // success — including a poisoned lock, same disposition as the unset-ACK case.
+                // Nothing panics: unwinding out of an `extern "system"` fn aborts.
+                let Some(m) = ACK.get() else {
+                    eprintln!("cosca_testbin: ctrl handler fired before ACK was set");
+                    return BOOL(0);
+                };
+                let Ok(mut s) = m.lock() else {
+                    eprintln!("cosca_testbin: ack socket mutex poisoned");
+                    return BOOL(0);
+                };
+                if let Err(e) = s.write_all(b"B").and_then(|()| s.flush()) {
+                    eprintln!("cosca_testbin: ack write failed: {e}");
+                }
+                BOOL(1) // handled — do not die
+            }
+
+            let addr = &args[2];
+            let tag = args.get(3).map(String::as_str).unwrap_or("?");
+            let mut sock = std::net::TcpStream::connect(addr).unwrap();
+            ACK.set(Mutex::new(sock.try_clone().unwrap()))
+                .expect("this arm runs exactly once per process");
+            // SAFETY: installing a console ctrl handler has no preconditions.
+            unsafe { SetConsoleCtrlHandler(Some(ack), true) }.expect("install ctrl handler");
+            sock.write_all(tag.as_bytes()).unwrap();
+            sock.flush().unwrap();
+            let mut buf = [0u8; 1];
+            let _ = sock.read(&mut buf); // blocks until the socket closes (our death)
+        }
+        #[cfg(windows)]
+        "report-console-terminate" => {
+            use std::fmt::Write as _;
+            use std::time::Duration;
+
+            // Connect FIRST. The test blocks on accept(), so a panic anywhere below must still
+            // reach it as socket EOF instead of hanging the suite.
+            let mut report_sock = std::net::TcpStream::connect(&args[2]).unwrap();
+
+            // Three-way: a zero return is also how this API reports failure, so "?" must never
+            // be able to satisfy the test's `console=0` vacuity guard. The last error is
+            // cleared first so the code read below is provably the one this call set.
+            let mut list = [0u32; 1];
+            // SAFETY: both calls are standard Win32; `list` is a valid writable slice.
+            let n = unsafe {
+                windows::Win32::Foundation::SetLastError(windows::Win32::Foundation::WIN32_ERROR(0));
+                windows::Win32::System::Console::GetConsoleProcessList(&mut list)
+            };
+            let console = if n != 0 {
+                "1"
+            } else if std::io::Error::last_os_error().raw_os_error()
+                == Some(windows::Win32::Foundation::ERROR_INVALID_HANDLE.0 as i32)
+            {
+                "0" // genuinely no console
+            } else {
+                "?" // the probe itself failed
+            };
+
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let ack_addr = listener.local_addr().unwrap().to_string();
+            let exe = std::env::current_exe().unwrap();
+
+            // A contained root that acks CTRL_BREAK over its own socket and keeps running.
+            let spawn_acker = |tag: &str| {
+                let mut cmd = cosca::Command::new();
+                cmd.executable(&exe)
+                    .args(["cosca_testbin", "control-block-ack-break", &ack_addr, tag])
+                    .contain();
+                let child = cmd.spawn().expect("spawn contained root");
+                let (mut sock, _) = listener.accept().expect("accept ack socket");
+                let mut t = [0u8; 1];
+                sock.read_exact(&mut t).expect("read ack tag");
+                assert_eq!(&t, tag.as_bytes(), "wrong ack tag");
+                (child, sock)
+            };
+            // Is a given pid attached to OUR console? Measured, not assumed: `console=1` alone
+            // only says WE have a console, not that the root is in it, and a blocking read
+            // gated on that weaker fact could hang forever. The acker has already handshaked
+            // its tag by the time this runs, so it has completed console registration.
+            let in_our_console = |pid: u32| {
+                // Grow to whatever count the API reports rather than capping: a too-small
+                // buffer makes it return the REQUIRED count without filling, which a fixed cap
+                // would silently read as "absent".
+                let mut buf = vec![0u32; 16];
+                loop {
+                    // SAFETY: standard Win32; `buf` is a valid writable slice.
+                    let n = unsafe { windows::Win32::System::Console::GetConsoleProcessList(&mut buf) } as usize;
+                    if n == 0 {
+                        return false; // no console at all
+                    }
+                    if n <= buf.len() {
+                        return buf[..n].contains(&pid);
+                    }
+                    buf.resize(n, 0);
+                }
+            };
+            // "1" delivered, "0" EOF (died without acking), "?" unexpected byte, "E" socket
+            // failure, "K" not read because the teardown that should have ended the child
+            // failed. A transport error must not masquerade as "no delivery".
+            let saw_break = |sock: &mut std::net::TcpStream| -> &'static str {
+                let mut b = [0u8; 1];
+                match sock.read(&mut b) {
+                    Ok(1) if &b == b"B" => "1",
+                    Ok(1) => "?",
+                    Ok(_) => "0",
+                    Err(_) => "E",
+                }
+            };
+            // Every field must stay ONE whitespace-free token: the report is parsed by
+            // splitting on whitespace, and an Error's Display is full of spaces.
+            let describe = |e: &cosca::error::Error| match e {
+                cosca::error::Error::NoConsole { .. } => "NoConsole".to_string(),
+                other => format!("Other({})", other.to_string().replace(char::is_whitespace, "_")),
+            };
+            let classify = |r: Result<(), cosca::error::Error>| match r {
+                Ok(()) => "Ok".to_string(),
+                Err(e) => describe(&e),
+            };
+
+            // (1) terminate_tree — signal-only, so delivery is observable without escalation.
+            let (c1, mut ack1) = spawn_acker("R");
+            // One whitespace-free token per field, so the report parses unambiguously; the
+            // Display form ("job object") would split across two fields.
+            let containment_tag = match c1.containment() {
+                cosca::Containment::JobObject => "job",
+                _ => "other", // anything else fails the assertion, which is the point
+            };
+            // One unambiguous token per liveness state. Never fold `Unknown` in with
+            // `Dead`: "couldn't tell" is not evidence that the tree went away, and each
+            // assertion below is proving something concrete about survival.
+            let liveness = |l: cosca::identity::Liveness| match l {
+                cosca::identity::Liveness::Alive => "alive",
+                cosca::identity::Liveness::Dead => "dead",
+                cosca::identity::Liveness::Unknown => "unknown",
+            };
+            let c1_in_console = in_our_console(c1.id().pid());
+            let terminate = classify(c1.terminate_tree());
+            let alive_after_terminate = liveness(c1.is_alive());
+            // The blocking wait for delivery happens ONLY where delivery is guaranteed: the
+            // root was MEASURED to be in our console AND terminate reported success. Every
+            // other combination kills first and collects EOF, so it always reaches the report
+            // and fails as an assertion rather than as a suite hang. The post-kill read/reap
+            // only runs when the kill itself succeeded — on a failed kill the child is still
+            // alive and blocked, so both would block forever and discard the kill error.
+            let (terminate_break, kill_tree) = if c1_in_console && terminate == "Ok" {
+                let seen = saw_break(&mut ack1);
+                (seen, classify(c1.kill_tree()))
+            } else {
+                let killed = classify(c1.kill_tree());
+                let seen = if killed == "Ok" { saw_break(&mut ack1) } else { "K" };
+                (seen, killed)
+            };
+            if kill_tree == "Ok" {
+                c1.wait().expect("reap probe root 1");
+            }
+
+            // (2) graceful_shutdown_tree — the escalation trio, ZERO grace. Delivery is proved
+            // by (1); this leg proves the trio's own classification and that a failure leaves
+            // the tree untouched.
+            let (c2, _ack2) = spawn_acker("S");
+            let graceful = match c2.graceful_shutdown_tree(Duration::ZERO) {
+                Ok(_) => "Ok".to_string(),
+                Err(e) => describe(&e),
+            };
+            let alive_after_graceful = liveness(c2.is_alive());
+            // "Skipped" — NOT "Ok": nothing was called on this path, so reporting a success
+            // would be a tautology. Whether the tree really went away is carried by the
+            // measured `alive_after_graceful`.
+            let graceful_cleanup = if graceful == "Ok" {
+                "Skipped".to_string()
+            } else {
+                let killed = classify(c2.kill_tree());
+                if killed == "Ok" {
+                    c2.wait().expect("reap probe root 2"); // a failed sweep leaves it alive
+                }
+                killed
+            };
+
+            let mut line = String::new();
+            write!(
+                line,
+                "console={console} c1_in_console={} containment={containment_tag} \
+                 terminate_tree={terminate} alive_after_terminate={alive_after_terminate} \
+                 terminate_break={terminate_break} kill_tree={kill_tree} graceful={graceful} \
+                 alive_after_graceful={alive_after_graceful} graceful_cleanup={graceful_cleanup}",
+                u8::from(c1_in_console),
+            )
+            .unwrap();
+            report_sock.write_all(line.as_bytes()).unwrap();
+            report_sock.flush().unwrap();
+        }
         #[cfg(unix)]
         "sid-report" => {
             // Print our session id (getsid(0)) to stdout so the test can verify

--- a/tests/windows_console.rs
+++ b/tests/windows_console.rs
@@ -1,0 +1,129 @@
+//! Windows: the console-group graceful signal (`CTRL_BREAK`) is delivered only within the
+//! CALLING process's console. Everything under `cargo test` has a console, so the
+//! console-less caller is reached by re-launching the testbin with `DETACHED_PROCESS`.
+//! Both tests drive the SAME helper mode; they must disagree.
+#![cfg(windows)]
+
+use std::io::Read;
+use std::net::TcpListener;
+use std::os::windows::process::CommandExt;
+use std::process::Command;
+
+/// `DETACHED_PROCESS`: the new process gets NO console and does not inherit ours — the
+/// GUI-app / service / detached-spawn caller these tests run against.
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+/// Run the `report-console-terminate` helper and return its one-line report.
+///
+/// The helper is launched DIRECTLY, never through a shell or launcher: a wrapper would be the
+/// detached process, and would then re-spawn the testbin as an ordinary child — which, coming
+/// from a console-less parent, gets a fresh private console. The console-less scenario would
+/// silently stop reproducing while these tests still passed.
+///
+/// The helper connects before doing any work, so the read returns on socket EOF whether it
+/// reported or crashed — a real event, never a timer. `wait()` then supplies the real status.
+fn run_probe(detached: bool) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cosca_testbin"));
+    cmd.args(["report-console-terminate", &addr]);
+    if detached {
+        cmd.creation_flags(DETACHED_PROCESS);
+    }
+    let mut helper = cmd.spawn().expect("spawn probe helper");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut report = String::new();
+    sock.read_to_string(&mut report).expect("read report");
+    let status = helper.wait().expect("reap probe helper");
+    assert!(
+        status.success(),
+        "probe helper failed: {status:?} — report so far: {report:?}"
+    );
+    report
+}
+
+/// Exact value of one `key=value` field. Substring matching is not safe here: `console=0` is a
+/// substring of `c1_in_console=0`, so a `contains` guard could be satisfied by the wrong field
+/// entirely.
+fn field<'a>(report: &'a str, key: &str) -> &'a str {
+    report
+        .split_ascii_whitespace()
+        .find_map(|kv| kv.strip_prefix(key)?.strip_prefix('='))
+        .unwrap_or_else(|| panic!("no field {key} in report: {report}"))
+}
+
+#[test]
+fn tree_graceful_ops_report_no_console_from_a_console_less_caller() {
+    let r = run_probe(true);
+    // A MEASURED absence — the helper reports `?` if its own probe failed — so this guard
+    // cannot be satisfied by a broken probe.
+    assert_eq!(
+        field(&r, "console"),
+        "0",
+        "helper must have NO console, else vacuous: {r}"
+    );
+    assert_eq!(
+        field(&r, "c1_in_console"),
+        "0",
+        "a console-less caller shares no console: {r}"
+    );
+    assert_eq!(
+        field(&r, "containment"),
+        "job",
+        "the root must be contained — the bug is about a contained root: {r}"
+    );
+    assert_eq!(field(&r, "terminate_tree"), "NoConsole", "{r}");
+    assert_eq!(
+        field(&r, "alive_after_terminate"),
+        "alive",
+        "a fail-fast terminate must leave the tree untouched: {r}"
+    );
+    // The acker is hard-killed on this path, and a killed peer resets its socket rather than
+    // closing it, so the read errors (`E`) about as often as it sees EOF (`0`) — both mean
+    // "died without acking". `?` (an unexpected byte) and `K` (the teardown failed, so
+    // delivery was never observable) stay distinct and neither may pass here.
+    let seen = field(&r, "terminate_break");
+    assert!(
+        matches!(seen, "0" | "E"),
+        "no signal can have been delivered, got {seen}: {r}"
+    );
+    assert_eq!(field(&r, "graceful"), "NoConsole", "{r}");
+    assert_eq!(
+        field(&r, "alive_after_graceful"),
+        "alive",
+        "graceful_shutdown_tree must fail before signalling, not after hard-killing: {r}"
+    );
+    assert_eq!(field(&r, "kill_tree"), "Ok", "hard teardown needs no console: {r}");
+    assert_eq!(field(&r, "graceful_cleanup"), "Ok", "{r}");
+}
+
+#[test]
+fn tree_graceful_ops_work_from_a_caller_that_has_a_console() {
+    // Positive control. `terminate_break=1` is load-bearing: the child acknowledges the
+    // CTRL_BREAK over its own socket, so this cannot pass on a return code alone —
+    // `GenerateConsoleCtrlEvent` reports success even when it delivers nothing.
+    let r = run_probe(false);
+    assert_eq!(field(&r, "console"), "1", "{r}");
+    assert_eq!(field(&r, "c1_in_console"), "1", "the root must share our console: {r}");
+    assert_eq!(field(&r, "containment"), "job", "{r}");
+    assert_eq!(field(&r, "terminate_tree"), "Ok", "{r}");
+    assert_eq!(
+        field(&r, "terminate_break"),
+        "1",
+        "the child must receive CTRL_BREAK: {r}"
+    );
+    assert_eq!(field(&r, "graceful"), "Ok", "{r}");
+    assert_eq!(field(&r, "kill_tree"), "Ok", "{r}");
+    assert_eq!(
+        field(&r, "graceful_cleanup"),
+        "Skipped",
+        "a successful graceful needs no sweep: {r}"
+    );
+    // Independent of the function's own word for it: the tree is actually gone. The acker
+    // ignores CTRL_BREAK, so only the escalation can have killed it.
+    assert_eq!(
+        field(&r, "alive_after_graceful"),
+        "dead",
+        "a successful graceful_shutdown_tree must leave nothing alive: {r}"
+    );
+}


### PR DESCRIPTION
Closes #46.

`GenerateConsoleCtrlEvent` fails with `ERROR_INVALID_HANDLE` when the **calling** process has
no console — a GUI-subsystem binary, a service, or anything spawned detached. Both Windows
dispositions bottom out in `containment::windows::terminate`, so `Child::terminate_tree` and
`Child::graceful_shutdown_tree` both failed for a correctly contained root, surfacing a bare
`io::Error` that named nothing.

## What changed

- **`Error::NoConsole { detail }`** — a typed error naming the cause and the way out.
- **Classification happens *after* the call**, from its own return code. A pre-call guard would
  be check-then-act: another thread's `FreeConsole` between probe and call would hand back the
  very `io::Error` this replaces. The `GetConsoleProcessList` probe only *confirms*; when it
  disagrees or fails, the raw `Error::Io` is kept rather than asserting a cause just measured
  to be false.
- `classify_ctrl_event_failure` is a **pure function**, so all four arms are unit-tested
  without faking the OS call the scenario rests on.
- Rustdoc on the four public `_tree` graceful ops, reframed: what `CTRL_BREAK` actually
  reaches (the root's **process group**, not the tree), that the grace is spent regardless,
  and the console requirement on top.

`terminate`'s signature changes from `io::Result<()>` to `Result<(), Error>`; both call sites
lose a now-wrong `.map_err(Error::Io)`.

## Coverage

`cargo test` always has a console — which is why this went uncaught. `tests/windows_console.rs`
re-launches the testbin with `DETACHED_PROCESS` so the crate runs under a genuinely
console-less caller, paired with a positive control running the identical helper *with* a
console. Delivery is proven by an acknowledgement from a `CTRL_BREAK` handler that stays
alive — never by a return code, because `GenerateConsoleCtrlEvent` returns `TRUE` even when it
delivers nothing.

## Measured on Windows 11 10.0.26100 x64

| situation | call returns | delivered |
|---|---|---|
| caller has a console, child in it | `TRUE` | **yes** |
| caller has **no** console | `FALSE`, err 6 | no |
| no console, then `AllocConsole()` | `TRUE` | **no** |
| child `CREATE_NO_WINDOW` / `DETACHED_PROCESS` / `CREATE_NEW_CONSOLE` | `TRUE` | **no** |
| group already drained | `TRUE` | n/a (success) |

Two of these overturned assumptions:

- The `AllocConsole` fallback the issue proposes **cannot work** — the new console holds only
  the caller, so the signal succeeds and delivers nothing, converting a loud failure into a
  full-grace-then-hard-kill with no error. Ruled out on evidence.
- A reachability precheck was designed and then **dropped**: console registration is done by
  the child's own startup (~0.9 ms after `ResumeThread`, absent at `CreateProcessW` return),
  so a membership test would false-positive against a freshly spawned root and break a path
  that works today. The sound form keys on the creation flags cosca chose, and belongs with
  the ticket that owns those flags (#50). #51's `CREATE_NO_WINDOW` is in the same table.

Per-descendant graceful signalling is tracked separately (#72) and is out of scope here.

## Verified

`cargo test`, `--features pty`, `--features tokio` all green on Windows 11 x64; clippy
`-D warnings`, `cargo fmt --check`, and rustdoc `-D warnings` clean. macOS and Linux are
CI-only — the change is entirely `cfg(windows)` apart from the new `Error` variant.
