### PR TITLE
fix!: report a refused process-group teardown instead of success (closes #61)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,3 +163,31 @@ jobs:
             export COSCA_TEST_CGROUP=1
             exec "$0" cgroup --nocapture --test-threads=1
           ' "$BIN"
+
+      # Live setuid-root process-group teardown test (issue #61) is gated behind
+      # COSCA_TEST_SETUID_HELPER (a no-op without it, same precedent as COSCA_TEST_CGROUP
+      # above). It needs a COPY of cosca_testbin that is genuinely setuid-root (owned by
+      # root, mode u+s) so the spawned helper process can call setuid(0) itself and become
+      # truly unsignalable by this job's ordinary unprivileged user — proving #61's fix
+      # against a REAL mixed process group (one signalable member, one genuinely not),
+      # not a synthetic one. Only preparing the helper copy needs root; the test itself
+      # runs as the normal unprivileged runner user, no sudo. With the marker set the
+      # test FAILS LOUDLY if the helper does not actually reach real uid 0 (wrong
+      # owner/mode, or a nosuid mount) — never a silent skip.
+      - name: Set up setuid-root helper (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          set -euxo pipefail
+          BIN=$(cargo build --locked --target ${{ matrix.target }} --bin cosca_testbin --message-format=json \
+            | jq -r 'select(.reason == "compiler-artifact" and .target.name == "cosca_testbin") | .executable' \
+            | grep -v '^null$' | grep . | head -n1)
+          test -x "$BIN"
+          HELPER="${RUNNER_TEMP}/cosca_testbin_setuid"
+          cp "$BIN" "$HELPER"
+          sudo chown root:root "$HELPER"
+          sudo chmod 4755 "$HELPER"
+          echo "COSCA_TEST_SETUID_HELPER=$HELPER" >> "$GITHUB_ENV"
+
+      - name: Run setuid-root process-group teardown test (Linux)
+        if: matrix.os == 'linux'
+        run: cargo test --locked --target ${{ matrix.target }} --test group_teardown_setuid

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,16 +164,17 @@ jobs:
             exec "$0" cgroup --nocapture --test-threads=1
           ' "$BIN"
 
-      # Live setuid-root process-group teardown test (issue #61) is gated behind
-      # COSCA_TEST_SETUID_HELPER (a no-op without it, same precedent as COSCA_TEST_CGROUP
-      # above). It needs a COPY of cosca_testbin that is genuinely setuid-root (owned by
-      # root, mode u+s) so the spawned helper process can call setuid(0) itself and become
-      # truly unsignalable by this job's ordinary unprivileged user — proving #61's fix
-      # against a REAL mixed process group (one signalable member, one genuinely not),
-      # not a synthetic one. Only preparing the helper copy needs root; the test itself
-      # runs as the normal unprivileged runner user, no sudo. With the marker set the
-      # test FAILS LOUDLY if the helper does not actually reach real uid 0 (wrong
-      # owner/mode, or a nosuid mount) — never a silent skip.
+      # Live setuid-root process-group teardown test (issue #61) is `#[ignore]`d by default
+      # (see tests/group_teardown_setuid.rs's module docs) — an ordinary `cargo test`
+      # anywhere, including the steps above, reports it as `ignored`, never a vacuous `ok`.
+      # This is the one step that opts in, via `-- --ignored`, after provisioning a COPY of
+      # cosca_testbin that is genuinely setuid-root (owned by root, mode u+s) so the spawned
+      # helper process can call setuid(0) itself and become truly unsignalable by this job's
+      # ordinary unprivileged user — proving #61's fix against a REAL mixed process group
+      # (one signalable member, one genuinely not), not a synthetic one. Only preparing the
+      # helper copy needs root; the test itself runs as the normal unprivileged runner user,
+      # no sudo. Once opted in, an unset/unusable helper FAILS LOUDLY (wrong owner/mode, or a
+      # nosuid mount) — never a silent skip.
       - name: Set up setuid-root helper (Linux)
         if: matrix.os == 'linux'
         run: |
@@ -190,4 +191,4 @@ jobs:
 
       - name: Run setuid-root process-group teardown test (Linux)
         if: matrix.os == 'linux'
-        run: cargo test --locked --target ${{ matrix.target }} --test group_teardown_setuid
+        run: cargo test --locked --target ${{ matrix.target }} --test group_teardown_setuid -- --ignored

--- a/src/child.rs
+++ b/src/child.rs
@@ -25,11 +25,45 @@ mod lifecycle;
 #[path = "child/graceful.rs"]
 mod graceful;
 
+#[cfg(test)]
+#[path = "child_tests.rs"]
+mod child_tests;
+
 /// A parent-side pipe end retained for a configured descriptor.
 #[derive(Debug)]
 pub(crate) enum ParentEnd {
     Reader(PipeReader),
     Writer(PipeWriter),
+}
+
+/// True only when there is POSITIVE evidence that a contained root's pid was reaped **and**
+/// recycled: it now resolves to a DIFFERENT identity than `original`, and that different
+/// identity is confirmed [`Liveness::Alive`](crate::identity::Liveness::Alive) — not merely
+/// resolvable, since a not-yet-reaped zombie also resolves. Reaping alone, without a
+/// subsequent recycle, is harmless to a pgid-based mechanism: `killpg` on an absent pgid
+/// returns `ESRCH`, which `signal_group`/`verify` in `containment::unix` already treat as
+/// `Cleared`. [`Existence`](crate::identity::Existence) cannot distinguish these two cases — it
+/// collapses "reaped, nothing there yet" and "reaped, a different live process now holds the
+/// pid" into the same `Gone` — which is why `kill_tree`/`terminate_tree`'s precondition assert
+/// needs this finer, two-value read (a fresh [`Resolved`](crate::identity::Resolved) plus a
+/// [`Liveness`](crate::identity::Liveness) reading of whatever it found) instead.
+///
+/// A pure function of already-resolved values, deliberately: it is unit-tested (`child_tests.rs`)
+/// with synthetic `ProcessId`s rather than by racing the kernel's own pid allocator to construct
+/// a genuine recycle — that would be synchronizing on luck, not a real test.
+#[cfg_attr(not(unix), allow(dead_code))] // only called from the `#[cfg(unix)]` debug_assert!s below
+                                         // and in `tokio/child.rs`; still unit-tested everywhere.
+pub(crate) fn root_pid_was_recycled(
+    original: ProcessId,
+    current: crate::identity::Resolved<ProcessId>,
+    current_liveness: crate::identity::Liveness,
+) -> bool {
+    match current {
+        crate::identity::Resolved::Found(now) => {
+            now != original && current_liveness == crate::identity::Liveness::Alive
+        }
+        crate::identity::Resolved::Gone | crate::identity::Resolved::Unknown => false,
+    }
 }
 
 /// A spawned child process the crate owns.
@@ -141,18 +175,25 @@ impl Child {
     /// tree is still running and this process cannot bring it down.
     pub fn kill_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
-        // Precondition (sibling #54's territory — asserted, not fixed, here): the contained
-        // root must not already be reaped when the mechanism is pgid-based (Attached::
-        // ProcessGroup — covers both Containment::ProcessGroup and Containment::Session, which
-        // also lands in this variant at spawn time), or the kernel may have recycled the pgid
-        // onto an unrelated process group. This crate's own `Drop` always kills before it
-        // reaps, so the common path never violates this; an explicit `wait()` then
-        // `kill_tree()`/`terminate_tree()` does — exactly the footgun #54 is about. Gated to
-        // this ONE mechanism: a recycled pgid is meaningless for Cgroup (keyed by an fd),
-        // JobObject (no pgid), Delegated (no mechanism), or TreeWalk (re-resolves identity per
-        // member, immune to this by construction) — asserting it there would be a false alarm
-        // unrelated to what this precondition is about. `Existence::Unknown` (the OS refused
-        // the query) is permitted through: this asserts against POSITIVE evidence of a
+        // Precondition (sibling #54's territory — asserted, not fixed, here): if the pgid-based
+        // mechanism's (Attached::ProcessGroup — covers both Containment::ProcessGroup and
+        // Containment::Session, which also lands in this variant at spawn time) leader pid has
+        // been reaped AND RECYCLED onto a DIFFERENT, LIVE process group, `killpg` would signal
+        // that unrelated group instead. Reaping alone is harmless — `killpg` on an absent pgid
+        // returns `ESRCH`, which `containment::unix::signal_group`/`verify` already treat as
+        // `Cleared` — so this only asserts on POSITIVE evidence of an actual recycle (see
+        // `root_pid_was_recycled`), never on a mere reap. That positive-evidence case is
+        // reachable on the ORDINARY spawn-then-teardown path for any fast-exiting child, not
+        // only via an explicit `wait()` before `kill_tree()`/`terminate_tree()`: `std`'s
+        // `SharedChild::new` (inside `Command::spawn`, see `child/spawn.rs`'s own comment on
+        // this) can reap a fast-exiting leader itself, before the caller ever gets a `Child`
+        // handle back — this assert can therefore fire on the very first call the caller makes,
+        // whatever ordering they use. Gated to this ONE mechanism: a recycled pgid is
+        // meaningless for Cgroup (keyed by an fd), JobObject (no pgid), Delegated (no
+        // mechanism), or TreeWalk (re-resolves identity per member, immune to this by
+        // construction) — asserting it there would be a false alarm unrelated to what this
+        // precondition is about. An OS refusal to answer either resolve (`Resolved::Unknown` /
+        // `Liveness::Unknown`) is permitted through: this asserts against POSITIVE evidence of a
         // violation, not against every case we merely couldn't rule out.
         //
         // `#[cfg(unix)]`: `Attached::ProcessGroup` is itself a Unix-only variant (see
@@ -162,11 +203,19 @@ impl Child {
         // assert there.
         #[cfg(unix)]
         debug_assert!(
-            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
-                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
-            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
-             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
-             (see #54)",
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_)) || {
+                let now = ProcessId::of(self.id.pid());
+                let now_liveness = match now {
+                    crate::identity::Resolved::Found(id) => id.is_alive(),
+                    crate::identity::Resolved::Gone | crate::identity::Resolved::Unknown => {
+                        crate::identity::Liveness::Unknown
+                    }
+                };
+                !root_pid_was_recycled(self.id, now, now_liveness)
+            },
+            "kill_tree/terminate_tree called after the contained root's pid ({}) was reaped and \
+             recycled onto a different, live process; a pgid-based mechanism would now signal an \
+             unrelated process group (see #54)",
             self.id.pid()
         );
         let group_result = self.attached.hard_kill();
@@ -213,11 +262,19 @@ impl Child {
         // `#[cfg(unix)]` gate (Attached::ProcessGroup does not exist on Windows).
         #[cfg(unix)]
         debug_assert!(
-            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
-                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
-            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
-             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
-             (see #54)",
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_)) || {
+                let now = ProcessId::of(self.id.pid());
+                let now_liveness = match now {
+                    crate::identity::Resolved::Found(id) => id.is_alive(),
+                    crate::identity::Resolved::Gone | crate::identity::Resolved::Unknown => {
+                        crate::identity::Liveness::Unknown
+                    }
+                };
+                !root_pid_was_recycled(self.id, now, now_liveness)
+            },
+            "kill_tree/terminate_tree called after the contained root's pid ({}) was reaped and \
+             recycled onto a different, live process; a pgid-based mechanism would now signal an \
+             unrelated process group (see #54)",
             self.id.pid()
         );
         self.attached.terminate(self.proc.id())

--- a/src/child.rs
+++ b/src/child.rs
@@ -134,8 +134,41 @@ impl Child {
     /// Hard-kill the contained tree. Requires an actionable containment mechanism
     /// (errors `Unsupported` otherwise — use `kill()` for a lone process).
     /// If both the group teardown and the handle backstop fail, the group error is returned.
+    ///
+    /// On the Unix process-group and session mechanisms this returns
+    /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
+    /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
+    /// tree is still running and this process cannot bring it down.
     pub fn kill_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
+        // Precondition (sibling #54's territory — asserted, not fixed, here): the contained
+        // root must not already be reaped when the mechanism is pgid-based (Attached::
+        // ProcessGroup — covers both Containment::ProcessGroup and Containment::Session, which
+        // also lands in this variant at spawn time), or the kernel may have recycled the pgid
+        // onto an unrelated process group. This crate's own `Drop` always kills before it
+        // reaps, so the common path never violates this; an explicit `wait()` then
+        // `kill_tree()`/`terminate_tree()` does — exactly the footgun #54 is about. Gated to
+        // this ONE mechanism: a recycled pgid is meaningless for Cgroup (keyed by an fd),
+        // JobObject (no pgid), Delegated (no mechanism), or TreeWalk (re-resolves identity per
+        // member, immune to this by construction) — asserting it there would be a false alarm
+        // unrelated to what this precondition is about. `Existence::Unknown` (the OS refused
+        // the query) is permitted through: this asserts against POSITIVE evidence of a
+        // violation, not against every case we merely couldn't rule out.
+        //
+        // `#[cfg(unix)]`: `Attached::ProcessGroup` is itself a Unix-only variant (see
+        // `containment/dispatch.rs`) — referencing it unconditionally does not compile on
+        // Windows (`cargo check --target x86_64-pc-windows-msvc` confirmed E0599 without this
+        // gate). Windows has no pgid to recycle, so there is nothing for this precondition to
+        // assert there.
+        #[cfg(unix)]
+        debug_assert!(
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
+                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
+            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
+             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
+             (see #54)",
+            self.id.pid()
+        );
         let group_result = self.attached.hard_kill();
         // Backstop for the TreeWalk mechanism: its hard_kill kills the root by identity,
         // which no-ops if `ProcessId::of` transiently fails to resolve the root — this
@@ -169,8 +202,24 @@ impl Child {
     /// crate cannot confirm the cause. Treat **any** error here as "no signal was sent, the
     /// tree is still running" rather than keying a fallback on the variant alone. Attach a
     /// console before spawning the tree, or use `kill_tree`, which needs none.
+    ///
+    /// On the Unix process-group and session mechanisms this returns
+    /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
+    /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
+    /// tree is still running and this process cannot bring it down.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
+        // See kill_tree's identical precondition assert for the full rationale, including the
+        // `#[cfg(unix)]` gate (Attached::ProcessGroup does not exist on Windows).
+        #[cfg(unix)]
+        debug_assert!(
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
+                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
+            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
+             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
+             (see #54)",
+            self.id.pid()
+        );
         self.attached.terminate(self.proc.id())
     }
 
@@ -243,6 +292,34 @@ impl Child {
     }
 }
 
+/// Whether a `hard_kill`/`terminate` result is still a genuine teardown MECHANISM failure —
+/// as opposed to `Error::Containment` (a live member refused the signal), both ORDINARY,
+/// expected outcomes after #61's fix and specifically the scenario it exists to report
+/// honestly, not bugs. Shared by both `Child::drop` impls (sync here, async in
+/// `src/tokio/child.rs`) so the classification has exactly one implementation instead of two
+/// hand-copied ones drifting apart.
+///
+/// **`Error::Unassessable` is NOT uniformly one or the other — it splits on `source`.**
+/// `group::decide` produces `source: None` when the group WAS listed successfully but one or
+/// more of its individual members could not be confirmed cleared (`check_or_signal` /
+/// `check_or_signal_linux_sigkill` returning `Reached::Unknown` for a live-or-unknown member)
+/// — an ordinary, expected outcome of the feature this issue adds, not a bug. `signal_group`'s
+/// `pgid <= 0` guard ALSO produces `source: None`, for a different but equally ORDINARY
+/// reason: a directly and deliberately TESTED input-validation refusal
+/// (`kill_group_and_term_group_reject_non_positive_pgid`, Task 5), not a "should never
+/// happen" internal contract violation — this function never got as far as attempting
+/// anything, the same way `group::decide`'s per-member case never got a confirmable answer.
+/// Neither provenance indicates the teardown MECHANISM'S OWN plumbing broke, which is the
+/// actual line this classifier draws. `group::state` produces `source: Some(io_error)` when
+/// `converge` itself returned `Err` — the listing syscall (`members()`'s `sysctl`/`/proc`
+/// scan) failed outright, before any member was even examined. THAT is a failure of the
+/// mechanism's own plumbing, the same class as `Error::Io`/`Error::Unsupported`, not a
+/// statement about any member or any input — so it, alone, is treated as a mechanism failure
+/// here.
+pub(crate) fn is_teardown_mechanism_failure(e: &Error) -> bool {
+    matches!(e, Error::Io(_) | Error::Unsupported { .. }) || matches!(e, Error::Unassessable { source: Some(_), .. })
+}
+
 impl Drop for Child {
     fn drop(&mut self) {
         if !self.kill_on_drop {
@@ -251,7 +328,18 @@ impl Drop for Child {
         // Hard-kill the contained tree (if any) — on Linux cgroup.kill reaches an elevated
         // subtree — then tear the direct child down. The dispatcher preserves the Unix
         // kill-before-wait order and NEVER blocks on an unkillable elevated child.
-        let _ = self.attached.hard_kill();
+        let tree = self.attached.hard_kill();
+        if let Err(e) = &tree {
+            // A live member refused, or couldn't be confirmed — visible, not silently
+            // discarded, on the RAII teardown path most callers actually hit. A genuine
+            // mechanism failure (is_teardown_mechanism_failure) is a debug_assert instead,
+            // matching the async twin's disposition for the identical condition.
+            debug_assert!(
+                !is_teardown_mechanism_failure(e),
+                "contained-tree teardown failed on sync Drop: {e:?}"
+            );
+            log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
+        }
         self.proc.teardown_on_drop();
     }
 }

--- a/src/child.rs
+++ b/src/child.rs
@@ -173,6 +173,18 @@ impl Child {
     /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
     /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
     /// tree is still running and this process cannot bring it down.
+    ///
+    /// **This guarantee, and its converse — that `Ok` is positive proof the group cleared —
+    /// hold only for the `ProcessGroup`/`Session` mechanisms**, not `TreeWalk`: `TreeWalk`
+    /// does not yet propagate a live refuser's outcome into this call's result (#63).
+    ///
+    /// **A `hidepid`-restricted Linux host can still return `Ok` with a live refuser left
+    /// running.** `/proc` is this mechanism's only way to confirm the group cleared, and
+    /// `hidepid=invisible`/`hidepid=2` hides a foreign-uid process from it entirely — the
+    /// ordinary setuid-in-a-container case. That member is then never listed, never
+    /// classified, never signaled, and the group can report cleared regardless. No fix
+    /// exists within this mechanism: the pid is never learned, and `killpg`'s own return
+    /// value is not trustworthy evidence either.
     pub fn kill_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
         // Precondition (sibling #54's territory — asserted, not fixed, here): if the pgid-based
@@ -256,6 +268,10 @@ impl Child {
     /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
     /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
     /// tree is still running and this process cannot bring it down.
+    ///
+    /// See [`kill_tree`](Child::kill_tree)'s doc for two things that also apply here: the
+    /// `ProcessGroup`/`Session`-only scope of this guarantee (`TreeWalk` is #63's territory),
+    /// and the residual `hidepid` gap on Linux.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
         // See kill_tree's identical precondition assert for the full rationale, including the

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -78,19 +78,68 @@ impl Child {
     /// A watch failure never skips the sweep and reap; a sweep error wins over it — and over
     /// a graceful root exit (survivors may remain; the root is still reaped first when its
     /// exit was observed, otherwise the child stays owned for `Drop`).
+    ///
+    /// **A refused or unconfirmed graceful signal never skips the grace wait and hard sweep
+    /// either.** If the initial group signal reaches a live member that refuses it, or a
+    /// member's post-signal state cannot be confirmed
+    /// ([`Error::Containment`](crate::error::Error::Containment) or
+    /// [`Error::Unassessable`](crate::error::Error::Unassessable) with no I/O `source` — see
+    /// [`terminate_tree`](Child::terminate_tree)), the grace is still waited and the sweep
+    /// still runs; the held error resurfaces only after a successful sweep and reap (mirroring
+    /// how a watch failure is held above), so a member that only needed the follow-up `SIGKILL`
+    /// does not strand the rest of the tree. A genuine listing-mechanism failure (an
+    /// `Unassessable` with an I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`,
+    /// it returns immediately: no signal is confirmed sent, so there is nothing for a grace
+    /// wait or sweep to act on yet.
     pub fn graceful_shutdown_tree(&self, grace: Duration) -> Result<ExitStatus, Error> {
         // Fail fast before sending any signal. terminate_tree/kill_tree re-check this guard
         // internally; the redundancy is intentional so an uncontained child errors up front.
         self.require_contained()?;
-        self.terminate_tree()?; // group SIGTERM / CTRL_BREAK (signal-only)
+
+        #[cfg(test)]
+        let term_result = match fault::take_force_terminate() {
+            fault::Forced::None => self.terminate_tree(),
+            kind => Err(fault::forced_terminate_error(kind)),
+        };
+        #[cfg(not(test))]
+        let term_result = self.terminate_tree();
+
+        // Hold-and-continue ONLY for the error shapes #61's fix can produce as ORDINARY
+        // outcomes — a confirmed refusal (`Error::Containment`) or a per-member-unconfirmed
+        // state (`Error::Unassessable { source: None, .. }`, `group::decide`'s shape). Both mean
+        // a signal WAS attempted and reachable members WERE reached (`converge` delivers to
+        // everyone it can, refusers or not), so the grace wait is still meaningful and the sweep
+        // can still reach the rest. `Error::Unassessable { source: Some(_), .. }` — `group::
+        // state`'s OWN listing failed, before any member was even examined — is deliberately
+        // EXCLUDED from this arm and falls through to fail-fast below: `crate::child::
+        // is_teardown_mechanism_failure` classifies that identical shape as a genuine
+        // teardown-mechanism failure, not an ordinary #61 outcome, for the same reason (no
+        // delivery was even attempted) — holding for a grace wait and sweep that reflect nothing
+        // real would silently disagree with that classifier for the same error shape reaching a
+        // different call site. Every OTHER error (`NoConsole`, `Unsupported`, `Io`, ...) keeps the
+        // ORIGINAL fail-fast `?` — those mean no signal was sent at all (the documented contract
+        // on this exact function, unchanged by this issue), so waiting a grace period and
+        // hard-sweeping afterward would be new, undocumented behavior on a path #61 has nothing to
+        // do with.
+        let term = match term_result {
+            Ok(()) => Ok(()),
+            Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
+                log::debug!(
+                    "graceful_shutdown_tree({id}): terminate_tree refused (subsumed if the sweep also fails): {e}",
+                    id = self.id.pid()
+                );
+                Err(e)
+            }
+            Err(e) => return Err(e), // unchanged pre-existing behavior: no signal sent, no grace, no sweep
+        };
 
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
         let watch = crate::wait::block_until_exit(self.id, Some(grace)); // NON-reaping grace-wait on root
 
         // The sweep is unconditional — a gracefully-exited root does NOT mean the descendants
-        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch Err; it must
-        // propagate before the reap on a LIVE root (waiting unswept would hang), but once the
-        // root's exit was observed, the reap runs first so no zombie is stranded.
+        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch or terminate Err;
+        // it must propagate before the reap on a LIVE root (waiting unswept would hang), but once
+        // the root's exit was observed, the reap runs first so no zombie is stranded.
         if let Err(e) = &watch {
             log::debug!(
                 "graceful_shutdown_tree({id}): watch error before escalation (subsumed if it also fails): {e}",
@@ -99,17 +148,89 @@ impl Child {
         }
         if let Err(sweep) = self.kill_tree() {
             if matches!(watch, Ok(true)) {
-                // The root is a zombie — this reap cannot hang (which is why it is gated on the
-                // observed exit). The sweep Err stays the verdict: the status, and even a distinct
-                // reap Err (a wait failure on the zombie), are subsumed — live survivors are the
-                // actionable failure, and the child stays owned for Drop's teardown.
-                let _ = self.wait();
+                // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
+                // (below) is already the error this call reports, so a failure here is
+                // secondary — but every other discarded error in this module is still logged,
+                // and a silent one here would obscure a second, independent failure mode.
+                if let Err(e) = self.wait() {
+                    log::debug!(
+                        "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
+                        id = self.id.pid()
+                    );
+                }
             }
             return Err(sweep);
         }
         let status = self.wait()?;
         watch?;
+        term?;
         Ok(status)
+    }
+}
+
+/// Test-only fault-injection seam for a forced `terminate_tree` failure inside
+/// `graceful_shutdown_tree`, mirroring `crate::wait::fault`'s shape. Duplicated (not shared)
+/// with `crate::tokio::child::graceful::fault` — see this crate's `#61` implementation plan,
+/// Task 7, "Structural note", for why: `mod graceful;` is private in both `src/child.rs` and
+/// `src/tokio/child.rs`, so a seam here is not nameable from the tokio tree without widening
+/// that visibility, which is out of scope here.
+#[cfg(test)]
+pub(crate) mod fault {
+    use std::cell::Cell;
+
+    /// Which `terminate_tree` failure to fabricate on the next call, on this thread.
+    /// `Containment` and `UnassessablePerMember` exercise the hold-and-continue path this
+    /// task adds — both ORDINARY #61 outcomes, a signal was attempted. `Unsupported` and
+    /// `UnassessableMechanism` exercise fail-fast paths: `Unsupported` models the
+    /// PRE-EXISTING console-less-caller shape (`NoConsole`/`Unsupported`) this task must not
+    /// touch; `UnassessableMechanism` models `Error::Unassessable { source: Some(_), .. }` —
+    /// `group::state`'s own listing failure, `crate::child::is_teardown_mechanism_failure`'s
+    /// classification for the identical shape reaching `Child::drop` — which this task's
+    /// `graceful_shutdown_tree` match must treat the SAME way (fail-fast), not fold into the
+    /// per-member `Unassessable{source: None}` hold-and-continue case.
+    #[derive(Clone, Copy, PartialEq, Eq, Default)]
+    pub(crate) enum Forced {
+        #[default]
+        None,
+        Containment,
+        UnassessablePerMember,
+        UnassessableMechanism,
+        Unsupported,
+    }
+    thread_local! {
+        static FORCE_TERMINATE: Cell<Forced> = const { Cell::new(Forced::None) };
+    }
+    pub(crate) fn set_force_terminate(kind: Forced) {
+        FORCE_TERMINATE.with(|f| f.set(kind));
+    }
+    pub(crate) fn take_force_terminate() -> Forced {
+        FORCE_TERMINATE.with(|f| f.replace(Forced::None))
+    }
+    // No `armed()` here, unlike `crate::wait::fault`'s seam: `take_force_terminate` runs
+    // unconditionally at the very top of `graceful_shutdown_tree`, so by the time any test
+    // assertion runs the seam is ALWAYS already consumed — an `armed()` check would be
+    // tautologically true and, worse, an unused `pub(crate)` item once nothing calls it,
+    // which `cargo clippy -D warnings` (Task 7 Step 4) would hard-fail on.
+    pub(crate) fn forced_terminate_error(kind: Forced) -> crate::error::Error {
+        match kind {
+            Forced::None => unreachable!("forced_terminate_error called with Forced::None"),
+            Forced::Containment => crate::error::Error::Containment {
+                detail: "forced term_group refusal (test seam)".into(),
+            },
+            Forced::UnassessablePerMember => crate::error::Error::Unassessable {
+                detail: "forced per-member unconfirmed state (test seam) — group::decide's shape".into(),
+                source: None,
+            },
+            Forced::UnassessableMechanism => crate::error::Error::Unassessable {
+                detail: "forced listing-mechanism failure (test seam) — group::state's shape".into(),
+                source: Some(std::io::Error::other("forced (test seam)")),
+            },
+            Forced::Unsupported => crate::error::Error::Unsupported {
+                op: "terminate_tree".into(),
+                platform: "test",
+                detail: "forced (test seam) — models NoConsole/Unsupported, NOT a #61 refusal".into(),
+            },
+        }
     }
 }
 

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -85,12 +85,14 @@ impl Child {
     /// ([`Error::Containment`](crate::error::Error::Containment) or
     /// [`Error::Unassessable`](crate::error::Error::Unassessable) with no I/O `source` — see
     /// [`terminate_tree`](Child::terminate_tree)), the grace is still waited and the sweep
-    /// still runs; the held error resurfaces only after a successful sweep and reap (mirroring
-    /// how a watch failure is held above), so a member that only needed the follow-up `SIGKILL`
-    /// does not strand the rest of the tree. A genuine listing-mechanism failure (an
-    /// `Unassessable` with an I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`,
-    /// it returns immediately: no signal is confirmed sent, so there is nothing for a grace
-    /// wait or sweep to act on yet.
+    /// still runs, so a member that only needed the follow-up `SIGKILL` does not strand the
+    /// rest of the tree. A subsequent successful sweep is fresher, positive proof the group
+    /// cleared, which supersedes the earlier refusal: it is logged and discarded, and this
+    /// call reports `Ok`. It resurfaces only indirectly, as the sweep's own error, if the
+    /// sweep then fails too. A genuine listing-mechanism failure (an `Unassessable` with an
+    /// I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`, it returns
+    /// immediately: no signal is confirmed sent, so there is nothing for a grace wait or
+    /// sweep to act on yet.
     pub fn graceful_shutdown_tree(&self, grace: Duration) -> Result<ExitStatus, Error> {
         // Fail fast before sending any signal. terminate_tree/kill_tree re-check this guard
         // internally; the redundancy is intentional so an uncontained child errors up front.
@@ -125,7 +127,7 @@ impl Child {
             Ok(()) => Ok(()),
             Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
                 log::debug!(
-                    "graceful_shutdown_tree({id}): terminate_tree refused (subsumed if the sweep also fails): {e}",
+                    "graceful_shutdown_tree({id}): terminate_tree refused; the sweep's own outcome decides what surfaces: {e}",
                     id = self.id.pid()
                 );
                 Err(e)
@@ -163,7 +165,15 @@ impl Child {
         }
         let status = self.wait()?;
         watch?;
-        term?;
+        // The sweep just returned `Ok`: positive, freshly-measured proof the group cleared,
+        // superseding whatever `term` held. Discard it here rather than returning it — an
+        // already-disproved refusal must never outrank the evidence that disproved it.
+        if let Err(e) = &term {
+            log::debug!(
+                "graceful_shutdown_tree({id}): sweep succeeded; discarding the superseded terminate_tree refusal: {e}",
+                id = self.id.pid()
+            );
+        }
         Ok(status)
     }
 }
@@ -210,7 +220,7 @@ pub(crate) mod fault {
     // unconditionally at the very top of `graceful_shutdown_tree`, so by the time any test
     // assertion runs the seam is ALWAYS already consumed — an `armed()` check would be
     // tautologically true and, worse, an unused `pub(crate)` item once nothing calls it,
-    // which `cargo clippy -D warnings` (Task 7 Step 4) would hard-fail on.
+    // which `cargo clippy -D warnings` would hard-fail on.
     pub(crate) fn forced_terminate_error(kind: Forced) -> crate::error::Error {
         match kind {
             Forced::None => unreachable!("forced_terminate_error called with Forced::None"),

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -109,10 +109,12 @@ fn graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
     crate::log_capture::install();
     let mark = crate::log_capture::mark();
     term_fault::set_force_terminate(term_fault::Forced::Containment);
-    let err = child
+    // A successful sweep is fresher, positive proof the group cleared, superseding the held
+    // refusal — the call must report `Ok`, not resurface the disproved `Containment` error.
+    let status = child
         .graceful_shutdown_tree(std::time::Duration::ZERO)
-        .expect_err("the forced terminate refusal must surface");
-    assert!(matches!(err, crate::error::Error::Containment { .. }), "got {err:?}");
+        .expect("a successful sweep must supersede the forced terminate refusal");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
     // Matches the TERMINATE trace specifically, not the pre-existing watch-error trace (both
     // share the same "graceful_shutdown_tree({pid})" prefix, so a bare prefix match would
     // pass even if the wrong log line fired). No `armed()` check here: `take_force_terminate`
@@ -126,6 +128,16 @@ fn graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
         ),
         "the terminate-refusal trace specifically must fire"
     );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!(
+                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                pid = id.pid()
+            )
+        ),
+        "the refusal must be logged as discarded, not silently dropped"
+    );
     #[cfg(unix)]
     assert_eq!(
         id.exists(),
@@ -134,8 +146,6 @@ fn graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
     );
     #[cfg(windows)]
     let _ = id;
-    let status = child.wait().expect("cached status — already reaped by the graceful op");
-    assert!(!status.success(), "swept root cannot report success, got {status:?}");
 }
 
 // Same hold-and-continue contract as the `Containment` test above, but for the OTHER
@@ -156,19 +166,28 @@ fn graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
     crate::log_capture::install();
     let mark = crate::log_capture::mark();
     term_fault::set_force_terminate(term_fault::Forced::UnassessablePerMember);
-    let err = child
+    // Same supersession as the `Containment` test above: the sweep's success disproves the
+    // held per-member-unconfirmed state, so the call must report `Ok`.
+    let status = child
         .graceful_shutdown_tree(std::time::Duration::ZERO)
-        .expect_err("the forced per-member-unassessable state must surface");
-    assert!(
-        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
-        "got {err:?}"
-    );
+        .expect("a successful sweep must supersede the forced unassessable state");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
     assert!(
         crate::log_capture::contains_since(
             mark,
             &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
         ),
         "the terminate-refusal trace specifically must fire"
+    );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!(
+                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                pid = id.pid()
+            )
+        ),
+        "the refusal must be logged as discarded, not silently dropped"
     );
     #[cfg(unix)]
     assert_eq!(
@@ -178,16 +197,14 @@ fn graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
     );
     #[cfg(windows)]
     let _ = id;
-    let status = child.wait().expect("cached status — already reaped by the graceful op");
-    assert!(!status.success(), "swept root cannot report success, got {status:?}");
 }
 
 // `Error::Unassessable { source: Some(_), .. }` — group::state's OWN listing failed, no
 // signal was ever attempted — must fail fast, the SAME disposition
 // `crate::child::is_teardown_mechanism_failure` gives the identical error shape reaching
-// `Child::drop`. This is finding 116ceaf7's regression test: an earlier round of this task
-// folded this shape into the same hold-and-continue arm as the ordinary per-member case,
-// silently disagreeing with the classifier for the same underlying error.
+// `Child::drop`. Regression test: folding this shape into the same hold-and-continue arm as
+// the ordinary per-member case would silently disagree with the classifier for the same
+// underlying error.
 #[test]
 fn graceful_tree_unassessable_mechanism_failure_fails_fast() {
     let mut cmd = crate::Command::new();

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use super::fault as term_fault;
 use crate::wait::fault;
 
 // A watch failure must not strand the tree between the soft signal and the hard sweep: the
@@ -83,4 +84,168 @@ fn graceful_lone_watch_error_still_escalates_and_reaps() {
         !status.success(),
         "escalated child cannot report success, got {status:?}"
     );
+}
+
+// A term_group refusal must not strand the tree between the soft signal and the hard sweep:
+// the sweep and reap still run, then the refusal surfaces. Mirrors
+// `graceful_tree_watch_error_still_sweeps_and_reaps` above, for the terminate seam instead
+// of the watch seam. Uses `Duration::ZERO`, not a nonzero grace: the watch-error test's
+// `from_secs(30)` was safe there because that seam fires BEFORE the watch ever runs, so the
+// grace is never actually waited. This seam replaces `terminate_tree` itself, so with a
+// nonzero grace the watch WOULD really block for the full window — racing the "sleep 30"
+// fixture's own natural exit and violating the no-timed-synchronization rule. `ZERO` is
+// documented (`graceful_shutdown`'s own rustdoc) as "signals, polls once, then escalates",
+// which is exactly the ordering this test needs and nothing more.
+#[test]
+fn graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    term_fault::set_force_terminate(term_fault::Forced::Containment);
+    let err = child
+        .graceful_shutdown_tree(std::time::Duration::ZERO)
+        .expect_err("the forced terminate refusal must surface");
+    assert!(matches!(err, crate::error::Error::Containment { .. }), "got {err:?}");
+    // Matches the TERMINATE trace specifically, not the pre-existing watch-error trace (both
+    // share the same "graceful_shutdown_tree({pid})" prefix, so a bare prefix match would
+    // pass even if the wrong log line fired). No `armed()` check here: `take_force_terminate`
+    // runs unconditionally at the very top of `graceful_shutdown_tree`, so by the time any
+    // assertion after calling it runs, the seam is ALWAYS already consumed — asserting that
+    // would be tautologically true and catch nothing.
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "the terminate-refusal trace specifically must fire"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "root must be swept AND reaped despite the forced terminate refusal"
+    );
+    #[cfg(windows)]
+    let _ = id;
+    let status = child.wait().expect("cached status — already reaped by the graceful op");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
+}
+
+// Same hold-and-continue contract as the `Containment` test above, but for the OTHER
+// ordinary #61 outcome: `Error::Unassessable { source: None, .. }` (group::decide's
+// per-member-unconfirmed shape). Mirrors the test above almost exactly; kept as a fully
+// separate test (not parameterized) matching this file's existing convention of one test
+// per forced-error shape.
+#[test]
+fn graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    term_fault::set_force_terminate(term_fault::Forced::UnassessablePerMember);
+    let err = child
+        .graceful_shutdown_tree(std::time::Duration::ZERO)
+        .expect_err("the forced per-member-unassessable state must surface");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
+        "got {err:?}"
+    );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "the terminate-refusal trace specifically must fire"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "root must be swept AND reaped despite the forced unassessable state"
+    );
+    #[cfg(windows)]
+    let _ = id;
+    let status = child.wait().expect("cached status — already reaped by the graceful op");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
+}
+
+// `Error::Unassessable { source: Some(_), .. }` — group::state's OWN listing failed, no
+// signal was ever attempted — must fail fast, the SAME disposition
+// `crate::child::is_teardown_mechanism_failure` gives the identical error shape reaching
+// `Child::drop`. This is finding 116ceaf7's regression test: an earlier round of this task
+// folded this shape into the same hold-and-continue arm as the ordinary per-member case,
+// silently disagreeing with the classifier for the same underlying error.
+#[test]
+fn graceful_tree_unassessable_mechanism_failure_fails_fast() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    term_fault::set_force_terminate(term_fault::Forced::UnassessableMechanism);
+    let err = child
+        .graceful_shutdown_tree(std::time::Duration::ZERO)
+        .expect_err("the forced listing-mechanism failure must surface immediately");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: Some(_), .. }),
+        "got {err:?}"
+    );
+    // Fails fast: no grace was waited, no sweep ran, so the child is STILL ALIVE — same
+    // assertion shape as the pre-existing NoConsole/Unsupported fail-fast test below.
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Present,
+        "a listing-mechanism failure must return before any grace wait or sweep"
+    );
+    // Clean up: the child is still running by design (no sweep happened above).
+    let _ = child.kill_tree();
+    let _ = child.wait();
+}
+
+// A NON-containment terminate_tree error (modelling NoConsole/Unsupported) must NOT be held
+// -- this is the pre-existing, still-documented "no signal sent, no grace waited, tree left
+// running" contract from #46, unrelated to #61, and this task's scoping must not silently
+// rewrite it (see this task's "Scope correction" note above). `Duration::ZERO` here too: the
+// point is that the function returns before ever reaching the watch, at all, regardless of
+// the requested grace, so there is nothing to synchronize on.
+#[test]
+fn graceful_tree_non_containment_terminate_error_fails_fast() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    term_fault::set_force_terminate(term_fault::Forced::Unsupported);
+    let err = child
+        .graceful_shutdown_tree(std::time::Duration::ZERO)
+        .expect_err("the forced Unsupported error must surface immediately");
+    assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    // Fails fast: no grace was waited, no sweep ran, so the child is STILL ALIVE.
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Present,
+        "a non-containment terminate error must return before any grace wait or sweep"
+    );
+    // Clean up: the child is still running by design (no sweep happened above).
+    let _ = child.kill_tree();
+    let _ = child.wait();
 }

--- a/src/child_tests.rs
+++ b/src/child_tests.rs
@@ -1,0 +1,70 @@
+//! Unit tests for `child.rs`'s pure, synthetic-value-friendly helpers — see
+//! `root_pid_was_recycled`'s own doc comment for why this must stay a pure function rather
+//! than a live-syscall check: constructing a genuinely recycled pid in a test is a race against
+//! the kernel's own allocator, not something to synchronize on.
+
+use crate::identity::{Liveness, ProcessId, Resolved};
+
+use super::root_pid_was_recycled;
+
+fn id(pid: u32, token: u64) -> ProcessId {
+    ProcessId::from_parts_for_test(pid, token)
+}
+
+#[test]
+fn recycled_root_pid_resolving_gone_is_not_recycled() {
+    let original = id(100, 1);
+    // Regardless of the liveness reading passed in (there is nothing to read a liveness OF
+    // when nothing resolved) — `Resolved::Gone` alone must never trip this.
+    assert!(!root_pid_was_recycled(original, Resolved::Gone, Liveness::Unknown));
+    assert!(!root_pid_was_recycled(original, Resolved::Gone, Liveness::Alive));
+}
+
+#[test]
+fn recycled_root_pid_unknown_resolution_is_not_recycled() {
+    let original = id(100, 1);
+    // The OS refused the query — positive evidence, not absence of counter-evidence, is what
+    // this predicate requires.
+    assert!(!root_pid_was_recycled(original, Resolved::Unknown, Liveness::Unknown));
+}
+
+#[test]
+fn recycled_root_pid_resolving_back_to_the_same_identity_is_not_recycled() {
+    let original = id(100, 1);
+    // The pid resolves to itself again (an unreaped zombie the caller hasn't reaped yet, or a
+    // still-running process) — the ordinary, harmless case this predicate must not flag.
+    assert!(!root_pid_was_recycled(
+        original,
+        Resolved::Found(original),
+        Liveness::Alive
+    ));
+}
+
+#[test]
+fn recycled_root_pid_a_different_but_dead_identity_is_not_recycled() {
+    let original = id(100, 1);
+    let different = id(100, 2); // same pid, different start token — a zombie, not yet reaped
+                                // Resolved but not confirmed ALIVE (e.g. a zombie of the recycled process, itself unreaped)
+                                // is not the hazardous case: `killpg` on it is still harmless.
+    assert!(!root_pid_was_recycled(
+        original,
+        Resolved::Found(different),
+        Liveness::Dead
+    ));
+    assert!(!root_pid_was_recycled(
+        original,
+        Resolved::Found(different),
+        Liveness::Unknown
+    ));
+}
+
+#[test]
+fn recycled_root_pid_a_different_live_identity_is_recycled() {
+    let original = id(100, 1);
+    let different = id(100, 2); // same pid, different start token, confirmed running
+    assert!(root_pid_was_recycled(
+        original,
+        Resolved::Found(different),
+        Liveness::Alive
+    ));
+}

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -54,9 +54,7 @@ impl Attached {
         match self {
             Attached::None | Attached::Delegated => Ok(()),
             #[cfg(unix)]
-            Attached::ProcessGroup(pgid) => {
-                crate::containment::unix::kill_group(*pgid).map_err(crate::error::Error::Io)
-            }
+            Attached::ProcessGroup(pgid) => crate::containment::unix::kill_group(*pgid),
             #[cfg(target_os = "linux")]
             Attached::Cgroup(leaf) => {
                 leaf.hard_kill();
@@ -89,7 +87,7 @@ impl Attached {
                 })
             }
             #[cfg(unix)]
-            Attached::ProcessGroup(pgid) => crate::containment::unix::term_group(*pgid).map_err(Error::Io),
+            Attached::ProcessGroup(pgid) => crate::containment::unix::term_group(*pgid),
             #[cfg(target_os = "linux")]
             Attached::Cgroup(leaf) => leaf.terminate().map_err(Error::Io),
             #[cfg(windows)]

--- a/src/containment/unix.rs
+++ b/src/containment/unix.rs
@@ -35,12 +35,18 @@
 //! the group's actual membership — see the `group` submodule.
 //!
 //! # PGID-reuse caveat
-//! `kill_tree` must run *before* the leader is reaped (`wait`): once reaped, the
-//! kernel may recycle the leader's PID/PGID, so `killpg` could signal an
-//! unrelated process group. The crate's `Drop` kills before it reaps, so the
-//! common path is safe; an explicit `wait()` then `kill_tree()` is the unsafe
-//! ordering. cgroup v2 and the identity-reverifying TreeWalk mechanism do not
-//! have this hole — prefer them when the guarantee matters.
+//! Reaping the leader (`wait`) alone is harmless: `killpg` on an absent pgid returns `ESRCH`,
+//! which `signal_group`/`verify` above already treat as `Cleared`. The actual hazard is
+//! narrower — the kernel recycling the leader's already-reaped PID/PGID onto a *different,
+//! live* process group before `kill_tree`/`term_group` next runs: only then does `killpg` risk
+//! signalling that unrelated group. This is reachable on the ORDINARY spawn-then-teardown path
+//! for any fast-exiting child, not only via an explicit `wait()` before `kill_tree()`: `std`'s
+//! `SharedChild::new` (inside `Command::spawn`) can reap a fast-exiting leader itself, before
+//! the caller ever gets a `Child` handle back — see `child/spawn.rs`'s own comment on this race,
+//! and `Child::kill_tree`'s precondition assert (`src/child.rs`), which fires on POSITIVE
+//! evidence of an actual recycle (a different, live identity at the same pid), not on a mere
+//! reap. cgroup v2 and the identity-reverifying TreeWalk mechanism do not have this hole at
+//! all — prefer them when the guarantee matters.
 
 use std::io;
 

--- a/src/containment/unix.rs
+++ b/src/containment/unix.rs
@@ -104,6 +104,9 @@ fn term_direct(pid: i32) -> io::Result<()> {
     }
 }
 
+#[path = "unix/group.rs"]
+mod group;
+
 #[cfg(test)]
 #[path = "unix_tests.rs"]
 mod unix_tests;

--- a/src/containment/unix.rs
+++ b/src/containment/unix.rs
@@ -21,6 +21,19 @@
 //!
 //! Parent-side signals use `nix` (not hand-rolled `libc`).
 //!
+//! # What `killpg` does and does not report
+//! Its return value says only whether *at least one* member took the signal. A
+//! group holding both a member we may signal and one we may not reports plain
+//! success while the second keeps running, on both Unixes. macOS additionally
+//! reports `EPERM` for a group whose survivors are all zombies, because xnu
+//! excludes zombies from the pgrp iteration before counting. And on Linux even
+//! `ESRCH` is not trustworthy as "definitely empty": `__kill_pgrp_info` keeps
+//! overwriting its return value with each member's error until one succeeds, so
+//! a departed member processed after a live refuser can leave the group's
+//! overall `ESRCH` hiding that refuser. None of `killpg`'s three outcomes can be
+//! trusted alone on either platform, so teardown always confirms itself against
+//! the group's actual membership — see the `group` submodule.
+//!
 //! # PGID-reuse caveat
 //! `kill_tree` must run *before* the leader is reaped (`wait`): once reaped, the
 //! kernel may recycle the leader's PID/PGID, so `killpg` could signal an
@@ -33,6 +46,8 @@ use std::io;
 
 use nix::sys::signal::{kill, killpg, Signal};
 use nix::unistd::Pid;
+
+use crate::error::Error;
 
 /// Apply pre-spawn group setup to `std_cmd` (root spawns only).
 /// Must not be combined with `set_session` on the same command.
@@ -68,39 +83,129 @@ pub(crate) fn set_session(std_cmd: &mut std::process::Command) {
     }
 }
 
-/// Hard-kill the whole process group. ESRCH (gone) is success; EPERM falls
-/// back to the leader directly (pgid == pid for a process-group root).
-pub(crate) fn kill_group(pgid: i32) -> io::Result<()> {
-    match killpg(Pid::from_raw(pgid), Signal::SIGKILL) {
-        Ok(()) => Ok(()),
-        Err(nix::errno::Errno::ESRCH) => Ok(()),
-        Err(nix::errno::Errno::EPERM) => kill_direct(pgid),
-        Err(e) => Err(io::Error::from(e)),
+/// Hard-kill the whole process group, then confirm the group actually came
+/// down. See [`signal_group`]. `Ok(())` means every member the ONE listing pass saw was
+/// either reached or already gone — not an atomic, ongoing guarantee: a member that forks a
+/// new process into the group after that listing (an ordinary respawning supervisor, not
+/// only an adversarial fork-bomb) is never seen, never signalled, and does not affect the
+/// verdict. `Attached::Cgroup` (Linux cgroup v2, `cgroup.kill`) is fork-proof where this
+/// mechanism structurally cannot be; prefer it when that atomicity matters.
+pub(crate) fn kill_group(pgid: i32) -> Result<(), Error> {
+    signal_group(pgid, Signal::SIGKILL)
+}
+
+/// Send the graceful signal to the whole process group, then confirm no live
+/// member refused it. See [`signal_group`].
+pub(crate) fn term_group(pgid: i32) -> Result<(), Error> {
+    signal_group(pgid, Signal::SIGTERM)
+}
+
+/// Signal the group and report what was actually achieved. `killpg`'s return value is a
+/// best-effort first delivery attempt, never the final verdict — see the module docs and
+/// `verify` for why none of `Ok`/`ESRCH`/`EPERM` can be trusted alone on either platform.
+///
+/// **The `pgid` guard lives HERE, before any signal is sent — not only in `group::state`.**
+/// An earlier draft of this fix placed the `pgid <= 0` rejection inside `group::state`,
+/// downstream of this function's own `killpg`/`signal_direct` calls — meaning a `pgid` of `0`
+/// (which signals the CALLER's own process group, per POSIX) or a negative one (the
+/// broadcast/double-negation hazard this file's Background measures) would already have been
+/// signalled for real before the "guard" ever ran. A check placed after the dangerous syscall
+/// it claims to guard is not a guard.
+fn signal_group(pgid: i32, signal: Signal) -> Result<(), Error> {
+    // NOT a debug_assert!: unlike the reaped-root precondition in `Child::kill_tree`/
+    // `terminate_tree` (Task 5, below), an invalid `pgid` reaching this function is a directly
+    // and deliberately TESTED, ordinary input-validation outcome, not a "should never happen"
+    // internal contract — `kill_group_and_term_group_reject_non_positive_pgid` (this file)
+    // calls this path with `0`/`-1`/`i32::MIN` on purpose and asserts a plain `Err`, not a
+    // panic. A `debug_assert!` here would turn that legitimate, always-possible defensive
+    // check into a test-build panic and break that test outright — the two are not the same
+    // kind of precondition, even though both guard "this input should not reach the syscall
+    // below."
+    if pgid <= 0 {
+        return Err(Error::Unassessable {
+            detail: format!(
+                "process group {pgid} is not a valid group id to signal (0 addresses this \
+                 process's own group; negative wraps to a broadcast or double-negation hazard)"
+            ),
+            source: None,
+        });
+    }
+    match killpg(Pid::from_raw(pgid), signal) {
+        Ok(()) => {}
+        // NOT trusted as "definitely empty": Linux's __kill_pgrp_info returns the LAST
+        // per-member error once none succeed, so ESRCH can mean "empty" or "a departed member
+        // processed after a live refuser" indistinguishably. `verify` below re-lists and
+        // settles it either way.
+        Err(nix::errno::Errno::ESRCH) => {}
+        // Preserved exactly as before this fix: the pgid == pid direct-to-leader fallback
+        // for the sudo-wrapper case (sibling #54 territory — do not remove or reshape).
+        Err(nix::errno::Errno::EPERM) => {
+            let _ = signal_direct(pgid, signal);
+        }
+        Err(e) => return Err(Error::Io(io::Error::from(e))),
+    }
+    verify(pgid, signal)
+}
+
+/// Turn the group's actual membership into a contract answer — the single source of truth
+/// regardless of what `killpg` reported. See `group`'s module docs for the listing and
+/// signal-delivery design (one pass; `SIGKILL` resends for real, `SIGTERM` only probes).
+fn verify(pgid: i32, signal: Signal) -> Result<(), Error> {
+    match group::state(pgid, signal) {
+        group::GroupState::Cleared => Ok(()),
+        group::GroupState::Refused { refused, unassessable } => {
+            let list = |pids: &[u32]| pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", ");
+            let mut detail = format!(
+                "{signal} did not clear {n} member(s) of process group {pgid} (pid {list}); the \
+                 tree is still up and this process cannot bring it down",
+                n = refused.len(),
+                list = list(&refused),
+            );
+            if !unassessable.is_empty() {
+                // The group's true state may be WORSE than `refused` alone says — these
+                // members were never confirmed either way, not confirmed clear.
+                detail.push_str(&format!(
+                    "; additionally, {n} member(s) could not be assessed at all (pid {list})",
+                    n = unassessable.len(),
+                    list = list(&unassessable),
+                ));
+            }
+            Err(Error::Containment { detail })
+        }
+        group::GroupState::Unlistable { detail, source } => Err(Error::Unassessable { detail, source }),
     }
 }
 
-/// SIGTERM the group; ESRCH (gone) is success; EPERM falls back to the leader
-/// directly (valid because pgid == pid — the sudo-wrapper case).
-pub(crate) fn term_group(pgid: i32) -> io::Result<()> {
-    match killpg(Pid::from_raw(pgid), Signal::SIGTERM) {
-        Ok(()) => Ok(()),
-        Err(nix::errno::Errno::ESRCH) => Ok(()),
-        Err(nix::errno::Errno::EPERM) => term_direct(pgid),
-        Err(e) => Err(io::Error::from(e)),
-    }
-}
-
-fn kill_direct(pid: i32) -> io::Result<()> {
-    match kill(Pid::from_raw(pid), Signal::SIGKILL) {
+/// Signal `pid` directly. Already-gone is success. Kept, unmodified, because sibling #54
+/// explicitly forbids touching this fallback — but the two signals it guards need opposite
+/// framing, worked out fully rather than left as one general "unclear":
+///
+/// - **`kill_group` (`SIGKILL`)**: redundant for a member `converge` actually reaches, NOT
+///   provably redundant overall. `converge` only resends to a member it has classified
+///   `Liveness::Alive` AND successfully re-verified (`classify_member`/`check_or_signal`);
+///   any member whose liveness or identity the OS refuses to confirm (`Liveness::Unknown` /
+///   `Resolved::Unknown`) is never signalled by `converge` at all — for THOSE, this direct
+///   call is the only delivery attempt, not a duplicate. It is also not the same check: this
+///   call signals a bare `pid` number with NO identity verification, while `converge` refuses
+///   to signal a pid whose token no longer matches — under the #54 pgid-recycle hazard the two
+///   calls can have different, divergent targets. Kept because #54 forbids removing it, not
+///   because it is proven safe or proven duplicative.
+/// - **`term_group` (`SIGTERM`)**: NOT redundant — the only real one. `converge`'s `SIGTERM`
+///   path deliberately never resends (Task 4's design: only probes, to avoid tripping a
+///   program's own double-signal escalation convention), so this is the ONLY actual `SIGTERM`
+///   delivery attempt to the leader after `killpg` reports `EPERM`. Do not remove or reframe
+///   this arm as optional for the graceful path.
+///
+/// Its failure is intentionally NOT propagated (best-effort; `verify`'s listing decides the
+/// contract answer either way), but is now logged rather than silently discarded, so a
+/// genuine `SIGTERM` delivery failure here — the one case that matters — leaves a trace.
+fn signal_direct(pid: i32, signal: Signal) -> io::Result<()> {
+    match kill(Pid::from_raw(pid), signal) {
         Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
-        Err(e) => Err(io::Error::from(e)),
-    }
-}
-
-fn term_direct(pid: i32) -> io::Result<()> {
-    match kill(Pid::from_raw(pid), Signal::SIGTERM) {
-        Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
-        Err(e) => Err(io::Error::from(e)),
+        Err(e) => {
+            log::debug!("containment::unix::signal_direct: kill({pid}, {signal}) failed: {e}");
+            Err(io::Error::from(e))
+        }
     }
 }
 

--- a/src/containment/unix.rs
+++ b/src/containment/unix.rs
@@ -111,15 +111,12 @@ pub(crate) fn term_group(pgid: i32) -> Result<(), Error> {
 /// `verify` for why none of `Ok`/`ESRCH`/`EPERM` can be trusted alone on either platform.
 ///
 /// **The `pgid` guard lives HERE, before any signal is sent — not only in `group::state`.**
-/// An earlier draft of this fix placed the `pgid <= 0` rejection inside `group::state`,
-/// downstream of this function's own `killpg`/`signal_direct` calls — meaning a `pgid` of `0`
-/// (which signals the CALLER's own process group, per POSIX) or a negative one (the
-/// broadcast/double-negation hazard this file's Background measures) would already have been
-/// signalled for real before the "guard" ever ran. A check placed after the dangerous syscall
-/// it claims to guard is not a guard.
+/// A `pgid` of `0` signals the CALLER's own process group (per POSIX); a negative one risks
+/// the broadcast/double-negation hazard this file's Background measures. A check placed after
+/// the dangerous syscall it claims to guard is not a guard.
 fn signal_group(pgid: i32, signal: Signal) -> Result<(), Error> {
     // NOT a debug_assert!: unlike the reaped-root precondition in `Child::kill_tree`/
-    // `terminate_tree` (Task 5, below), an invalid `pgid` reaching this function is a directly
+    // `terminate_tree`, an invalid `pgid` reaching this function is a directly
     // and deliberately TESTED, ordinary input-validation outcome, not a "should never happen"
     // internal contract — `kill_group_and_term_group_reject_non_positive_pgid` (this file)
     // calls this path with `0`/`-1`/`i32::MIN` on purpose and asserts a plain `Err`, not a
@@ -197,8 +194,8 @@ fn verify(pgid: i32, signal: Signal) -> Result<(), Error> {
 ///   calls can have different, divergent targets. Kept because #54 forbids removing it, not
 ///   because it is proven safe or proven duplicative.
 /// - **`term_group` (`SIGTERM`)**: NOT redundant — the only real one. `converge`'s `SIGTERM`
-///   path deliberately never resends (Task 4's design: only probes, to avoid tripping a
-///   program's own double-signal escalation convention), so this is the ONLY actual `SIGTERM`
+///   path deliberately never resends — only probes, to avoid tripping a program's own
+///   double-signal escalation convention — so this is the ONLY actual `SIGTERM`
 ///   delivery attempt to the leader after `killpg` reports `EPERM`. Do not remove or reframe
 ///   this arm as optional for the graceful path.
 ///

--- a/src/containment/unix/group.rs
+++ b/src/containment/unix/group.rs
@@ -13,6 +13,8 @@
 //! So the group's actual membership decides (see `converge` below), and this module owns the
 //! listing: sysctl `KERN_PROC_PGRP` on macOS, `/proc` on Linux.
 
+use nix::sys::signal::Signal;
+
 use crate::identity::RawPid;
 
 /// One process-group member as the listing found it, carrying the start token needed to
@@ -214,6 +216,457 @@ pub(crate) fn members(_pgid: i32) -> std::io::Result<Vec<Member>> {
         std::io::ErrorKind::Unsupported,
         "process-group membership is implemented only for Linux and macOS",
     ))
+}
+
+/// What a process group looked like after one signal-and-classify pass.
+#[derive(Debug)]
+pub(crate) enum GroupState {
+    /// Nothing listed is both running (under the identity the listing saw) and beyond our
+    /// reach.
+    Cleared,
+    /// These pids were listed, confirmed `Liveness::Alive` under the SAME identity the
+    /// listing saw, and were not reached — the tree is still up. `SIGKILL` delivered
+    /// successfully is not itself proof of death (a member wedged in uninterruptible sleep on
+    /// a hung mount can accept `SIGKILL` and still not have exited yet) — this is an inherent
+    /// limitation of any `kill(2)`-based mechanism, present before this fix and after it;
+    /// closing it needs a bounded wait with a caller-supplied timeout, a distinct API-shape
+    /// addition. `unassessable` carries any OTHER member whose state could not be determined
+    /// at all — never silently dropped just because a confirmed refuser already settles the
+    /// overall verdict; a caller reading the error should learn the group's true state may be
+    /// WORSE than `refused` alone says, not just that one member refused.
+    Refused {
+        refused: Vec<RawPid>,
+        unassessable: Vec<RawPid>,
+    },
+    /// The group's membership could not be listed (`source: Some`), or a listed member's
+    /// liveness could not be assessed at all (`source: None`) — either way nothing can be
+    /// said about whether the group is down. Mirrors `Error::Unassessable`'s own shape.
+    Unlistable {
+        detail: String,
+        source: Option<std::io::Error>,
+    },
+}
+
+/// Whether a live-confirmed member was actually reached by the signal/probe. A THIRD
+/// answer, `Unknown`, is threaded all the way from the deepest primitive up through
+/// `classify_member` — this round's review found the previous draft collapsing "could not
+/// assess" into a binary `bool` at exactly the boundary where the distinction mattered most
+/// (inside `converge`'s `reached` closure), silently re-narrowing the `Liveness::Unknown`
+/// handling `classify_member` otherwise protects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Reached {
+    Yes,
+    No,
+    Unknown,
+}
+
+/// One listed member's fate, decided from its already-read `Liveness` plus (whenever an
+/// attempt could still teach us something) whether the real check reached it. Pure — a unit
+/// test drives all `Liveness`/`Reached` combinations directly, without needing a real OS
+/// condition for `Unknown` (which normally needs a permission-denying host like `hidepid`).
+/// `reached` is called for `Liveness::Alive` OR `Liveness::Unknown` — NOT only `Alive` (an
+/// earlier round of this plan gated it on `Alive` alone; review correctly caught that this
+/// is guard-then-do backwards for an operation the plan itself calls idempotent and
+/// self-reporting: `SIGKILL`/a probe answers the permission question directly and
+/// authoritatively, so gating the ATTEMPT on a separate LIVENESS QUERY that can itself be
+/// denied — e.g. under App Sandbox / a hardened runtime, where `is_alive`'s own fallback can
+/// legitimately answer `Unknown` for a foreign-uid member — needlessly turns a recoverable
+/// teardown into `Error::Unassessable` without ever trying the one call that would have
+/// answered the real question). Only a POSITIVE `Liveness::Dead` skips the attempt entirely
+/// — there is nothing left to prove for a zombie, a departed pid, or a pid recycled onto an
+/// unrelated process, however a signal/probe of the raw pid might answer.
+enum MemberOutcome {
+    NotASurvivor,
+    Survivor(RawPid),
+    Unassessable(RawPid),
+}
+
+fn classify_member(
+    pid: RawPid,
+    liveness: crate::identity::Liveness,
+    reached: impl FnOnce() -> Reached,
+) -> MemberOutcome {
+    match liveness {
+        crate::identity::Liveness::Dead => MemberOutcome::NotASurvivor,
+        crate::identity::Liveness::Alive | crate::identity::Liveness::Unknown => match reached() {
+            Reached::Yes => MemberOutcome::NotASurvivor,
+            Reached::No => MemberOutcome::Survivor(pid),
+            Reached::Unknown => MemberOutcome::Unassessable(pid),
+        },
+    }
+}
+
+/// Re-verify `id` is still the SAME identity, deliver-or-probe it, and classify the answer —
+/// the ONE implementation both the `SIGKILL` and `SIGTERM` paths use, differing only in
+/// `signal` (`Some(SIGKILL)` resends for real; `None` probes with `kill(pid, 0)`).
+///
+/// **Why this replaced `treewalk::kill_by_identity` from an earlier round of this plan.**
+/// That primitive's `KillOutcome::NotAttempted` conflates TWO different causes — a denied
+/// identity re-verify, and a genuine `EPERM` from the real `kill(2)` call — into one variant
+/// (`src/containment/treewalk.rs:222-256`), with nothing in the return value to tell them
+/// apart. An earlier round tried to route around this by pre-checking identity here and
+/// *assuming* `kill_by_identity`'s own internal re-check, a moment later, would agree — a
+/// probability argument, not a proof, and review correctly rejected it: a transient
+/// disagreement in that gap still mislabels "unassessable" as a confirmed refusal. Reusing
+/// `kill_by_identity` here cannot be made precise without changing its return type (out of
+/// scope — it is a sibling module's primitive), so this performs the identity check AND the
+/// `kill(2)` call directly, observing the real errno first-hand. `EPERM` and only `EPERM`
+/// classifies as a confirmed refusal; every other unexpected errno is `Unknown`, not `No` —
+/// conservative, and consistent with every other "not EPERM/ESRCH" disposition in this
+/// module.
+///
+/// **The identity check and the act are still two separate syscalls on macOS — a narrowed,
+/// not eliminated, race.** Review correctly caught an earlier claim here that a pid recycled
+/// between the listing and this call is "never mistakenly signalled" — false: the re-verify
+/// and the `kill(2)` below are non-atomic, so a recycle in THAT gap (not the earlier,
+/// listing-to-here gap the re-verify closes) is still possible. On Linux this is closed for
+/// real, not just narrowed: `SIGKILL` delivery goes through `pidfd_open`+`pidfd_send_signal`
+/// (`check_or_signal_linux_sigkill`, below), reusing `crate::wait::backend::open_verified`
+/// verbatim rather than a second implementation — the fd itself pins the identity at the
+/// kernel level, so a pid reused after `pidfd_open` cannot be hit even in principle. macOS has
+/// no pidfd equivalent, so `kill(2)` here keeps the same irreducible, ALREADY-ACCEPTED window
+/// `src/wait/macos.rs::kill`'s own doc comment documents verbatim ("The window between this
+/// check and kill(2) is irreducible on macOS (no pidfd); a recycled pid in that window is a
+/// documented best-effort limitation, mirroring treewalk::kill_by_identity") — this function
+/// is that same, already-reviewed trade-off, not a new one.
+fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<Signal>) -> Reached {
+    // Contract (repo-wide policy, this round): this module's whole design rests on
+    // `SIGTERM` never being resent for real (the double-signal-escalation avoidance —
+    // `converge`'s design note above) — only `SIGKILL` may be `Some`, everything else must
+    // probe (`None`). A future caller passing e.g. `Some(Signal::SIGTERM)` through here would
+    // silently violate that without this assert ever making it visible.
+    debug_assert!(
+        matches!(signal, None | Some(Signal::SIGKILL)),
+        "check_or_signal called with {signal:?}; only None (probe) or Some(SIGKILL) (resend) \
+         are ever valid here — SIGTERM must never resend, see converge's design note"
+    );
+    match crate::identity::ProcessId::of(pid) {
+        crate::identity::Resolved::Found(live) if live == id => {}
+        // Gone — nothing to refuse.
+        crate::identity::Resolved::Found(_) => {
+            log::debug!(
+                "containment::unix::group: pid {pid} now names a different process (recycled \
+                 mid-teardown) — not the listed member, so not a survivor"
+            );
+            return Reached::Yes;
+        }
+        crate::identity::Resolved::Gone => return Reached::Yes,
+        // **Reverted this round — a prior round's "ask forgiveness" change here was itself a
+        // bug, caught by review.** An earlier version of this arm signalled the bare `pid`
+        // for real whenever `signal.is_some()`, reasoning that "a genuinely recycled pid still
+        // answers ESRCH/EPERM on its own terms, same as `Resolved::Found(_)`'s recycle case
+        // above." That reasoning does not hold: `Resolved::Found(_)` is safe BECAUSE identity
+        // was resolved and compared (we KNOW it's a different, and therefore not-our-business,
+        // process). `Resolved::Unknown` means the re-verify could not be performed AT ALL — if
+        // the pid was recycled onto a process the caller MAY signal, `kill(2)` returns
+        // `Ok(())` and a completely unrelated process gets killed, not `ESRCH`/`EPERM`. There
+        // is no analogy to lean on; the two cases are opposite, not equivalent. Conservative
+        // bail, for BOTH the resend and the probe: an unverifiable identity is never signalled
+        // on this platform (no atomic handle exists here — `check_or_signal_linux_sigkill`,
+        // below, is the platform where a genuinely atomic alternative exists and is used).
+        crate::identity::Resolved::Unknown => {
+            log::warn!(
+                "containment::unix::group: pid {pid} could not be re-verified (access denied?) \
+                 — treated as unassessable, not signalled (an unverified pid is never signalled \
+                 on this platform: a recycled pid onto an unrelated, signalable process would \
+                 be hit for real, not safely refused)"
+            );
+            return Reached::Unknown;
+        }
+    }
+    let Some(target) = crate::identity::probe::signal_target(pid) else {
+        // Defence in depth: a kernel-reported pid is never 0 or overflowing, so this should be
+        // unreachable. Logged loudly if it ever is, and treated as unassessable rather than
+        // (wrongly) cleared — the conservative direction, matching every other "should never
+        // happen" branch in this module.
+        log::warn!("containment::unix::group: pid {pid} is not a single-process signal target");
+        return Reached::Unknown;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(target), signal) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => Reached::Yes,
+        Err(nix::errno::Errno::EPERM) => {
+            // The expected, common case for a genuine refuser — logged at debug (not warn),
+            // but logged: every other "member did not clear" branch in this module records
+            // its cause, and this is the one that produces the primary, expected outcome of
+            // the whole feature (a confirmed refusal), so it should be no less traceable.
+            log::debug!("containment::unix::group: kill({pid}, {signal:?}) refused: EPERM");
+            Reached::No
+        }
+        Err(e) => {
+            // Neither EPERM nor ESRCH: genuinely anomalous. Not evidence of a refusal, and
+            // not evidence the tree came down either — the conservative "we don't know"
+            // answer, not a guess in either direction.
+            log::warn!("containment::unix::group: kill({pid}, {signal:?}) answered {e}, neither EPERM nor ESRCH");
+            Reached::Unknown
+        }
+    }
+}
+
+/// Linux-only, `SIGKILL`-only: the atomic version of `check_or_signal`'s resend, via the
+/// crate's own existing pidfd primitive (`src/wait/linux.rs::open_verified` — reused, not
+/// reimplemented, per this module's own stated preference; it already does exactly "open a
+/// pidfd for this identity, re-verifying, `Ok(None)` if already gone"). `pidfd_send_signal`
+/// on the returned fd is guaranteed to hit the SAME process `open_verified` just confirmed,
+/// even if the pid number is reused by something else in between — no gap remains, unlike
+/// `check_or_signal`'s plain-`kill(2)` path.
+///
+/// **Falls back to `check_or_signal`'s plain `kill(2)` on `Error::Unsupported` OR
+/// `Error::Io`, not `Reached::Unknown`.** `open_verified` returns `Unsupported` when
+/// `pidfd_open` answers `ENOSYS` — kernel < 5.3, or a seccomp/sandbox policy blocking the
+/// syscall entirely. It returns `Error::Io` for every OTHER `pidfd_open`/`poll` failure —
+/// which, in the same seccomp/sandbox case, is exactly what a policy that returns `EPERM`
+/// (rather than `ENOSYS`) on the blocked syscall produces instead (verified against
+/// `open_verified`'s own match arms in `src/wait/linux.rs`: only `Errno::NOSYS` maps to
+/// `Unsupported`; every other errno, including `EPERM`, falls into the generic `Error::Io`
+/// arm). A seccomp profile is free to pick either errno for a denied syscall, so treating only
+/// `Unsupported` as fallback-eligible silently reclassifies "we couldn't even ask" as
+/// `Reached::Unknown` on exactly the containers this fallback exists for (Task 6's setuid
+/// helper test runs under Docker's default seccomp profile). Both variants get the SAME
+/// treatment: fall back to `check_or_signal`'s plain `kill(2)`, which observes envelopes IT
+/// controls directly rather than trusting `open_verified`'s errno classification a second
+/// time. Only `Error::Unassessable` — identity genuinely denied by `id.exists()`, or the pid
+/// overflows the pidfd interface — stays `Reached::Unknown`: that is a statement about the
+/// PID's identity, not about whether the kernel can open a pidfd at all, and no fallback
+/// resolves it.
+///
+/// **Considered and rejected: signalling via the already-open pidfd anyway when `id.exists()`
+/// answers `Unknown` inside `open_verified`.** This looks tempting — `pidfd_open` already
+/// succeeded, so *something* is there — but it does not actually close the gap, for the same
+/// reason `check_or_signal`'s own `Resolved::Unknown` arm (above) must never signal a bare
+/// pid: `pidfd_open(pid)` binds to WHATEVER process holds that pid NUMBER at the moment it is
+/// called, exactly like a bare `kill(2)`. If the member `members()` listed at T0 exited and
+/// its pid was recycled onto an unrelated, signalable process before `pidfd_open` runs at T1,
+/// `pidfd_open` succeeds — for the WRONG process. `id.exists()`'s subsequent `Unknown` answer
+/// is precisely the case where this recycle cannot be ruled out (a permission-denied `/proc`
+/// read under `hidepid`, or the platform's equivalent, giving neither a clear "same identity"
+/// nor a clear "gone"). The pidfd's real safety property is narrower than "identity-pinned
+/// from the moment of listing": it guarantees the target does not change identity AFTER a
+/// successful open, not that the identity was already correct AT open time — exactly the gap
+/// `open_verified`'s own `id.exists()` step exists to close, and exactly the gap `Existence::
+/// Unknown` says was NOT closed this time. Signalling anyway would reintroduce, on Linux, the
+/// identical "unrelated-process-killed" failure mode `check_or_signal`'s reverted "ask
+/// forgiveness" arm had on macOS — not a smaller version of it. Left as a disclosed,
+/// asymmetric gap (see the report / Verification gaps) rather than closed with an unsound
+/// fix: on a genuinely `hidepid`-restricted host, a live member whose identity cannot be
+/// re-confirmed at delivery time is correctly left unsignalled and reported `Unassessable`,
+/// even though the earlier `Liveness::Unknown`-admitting gate (`classify_member`) let it
+/// through to the attempt.
+#[cfg(target_os = "linux")]
+fn check_or_signal_linux_sigkill(pid: RawPid, id: crate::identity::ProcessId) -> Reached {
+    match crate::wait::backend::open_verified(id, "process-group teardown verification") {
+        Ok(None) => Reached::Yes, // already gone
+        Ok(Some(pidfd)) => match rustix::process::pidfd_send_signal(&pidfd, rustix::process::Signal::KILL) {
+            Ok(()) => Reached::Yes,
+            Err(rustix::io::Errno::SRCH) => Reached::Yes, // exited between open and signal
+            Err(rustix::io::Errno::PERM) => {
+                log::debug!(
+                    "containment::unix::group: pidfd_send_signal({}, KILL) refused: EPERM",
+                    id.pid()
+                );
+                Reached::No
+            }
+            Err(e) => {
+                log::warn!(
+                    "containment::unix::group: pidfd_send_signal({}, KILL) answered {e}, neither EPERM nor ESRCH",
+                    id.pid()
+                );
+                Reached::Unknown
+            }
+        },
+        Err(e @ (crate::error::Error::Unsupported { .. } | crate::error::Error::Io(_))) => {
+            log::debug!(
+                "containment::unix::group: pidfd unavailable ({e}) for pid {}; falling back to \
+                 kill(2) — same residual race macOS already accepts",
+                id.pid()
+            );
+            check_or_signal(pid, id, Some(Signal::SIGKILL))
+        }
+        // Only `Error::Unassessable` reaches here: identity genuinely denied by `id.exists()`,
+        // or the pid overflows the pidfd interface — a statement about the PID itself, which
+        // no kill(2) fallback resolves. Conservative, not a guess.
+        Err(e) => {
+            log::warn!("containment::unix::group: open_verified for pid {}: {e}", id.pid());
+            Reached::Unknown
+        }
+    }
+}
+
+/// "Ask forgiveness, one more time": re-confirm a `Survivor` verdict with a SECOND liveness
+/// check before it is finalized. Pure and testable in isolation (unlike `converge`'s inline
+/// loop it replaced) — a unit test drives all three `recheck` answers directly. The FIRST
+/// `Liveness` check (fed into `classify_member`, before the signal/probe ran at all) can go
+/// stale in the gap before the signal/probe actually ran: a foreign-uid member that was alive
+/// at that check and exits to a zombie microseconds later still answers `EPERM` (measured,
+/// this file's Background — a foreign-uid zombie answers identically to a foreign-uid live
+/// refuser), so without this re-check a member that finished dying mid-teardown would be
+/// misreported as a survivor. Only `Survivor` is re-checked — `NotASurvivor`/`Unassessable`
+/// need no second look, since neither claims a definite, still-running refuser. A downgrade
+/// is logged: it overturns an `EPERM` already logged once inside `check_or_signal`, and a
+/// debug session starting from "why did teardown report Cleared/Unassessable despite the
+/// EPERM in the logs" needs this decision to be visible too, not just the original refusal.
+///
+/// **Downgrades on `Liveness::Dead` only — `Liveness::Unknown` keeps `Survivor`, fixed this
+/// round.** An earlier version of this match also downgraded on `Unknown`, reasoning that a
+/// denied liveness re-check should not be trusted either way. Review correctly caught that
+/// this throws away STRONGER evidence for WEAKER: the `Survivor` this function receives
+/// already carries a REAL, directly-observed `EPERM` from `check_or_signal`'s own `kill(2)`/
+/// `pidfd_send_signal` call — the kernel's authoritative, first-hand answer to "may this
+/// caller signal this process". `recheck`'s liveness query is a WEAKER, independently-deniable
+/// signal (the same class of query that can itself answer `Unknown` under `hidepid` or a
+/// sandboxed runtime); a denied liveness reconfirmation is not evidence the EPERM was wrong,
+/// only that this SECOND, unrelated query could not be answered. Combined with `classify_member`
+/// proceeding on `Liveness::Unknown` (a separate, correct fix from an earlier round), the
+/// prior `Unknown`-downgrades-too shape made that fix produce no benefit for the refusal
+/// verdict at all — `Unknown` at the first check could only ever end in `NotASurvivor` or
+/// `Unassessable`, never the `Refused` a genuine, already-observed `EPERM` earns. The member
+/// was already established not-`Dead` by the first liveness check (`classify_member`'s own
+/// gate) before the signal was ever attempted, so `Dead` is the only recheck answer that
+/// actually contradicts the `Survivor` verdict; `Unknown` contradicts nothing.
+fn reconfirm_survivor(outcome: MemberOutcome, recheck: impl FnOnce() -> crate::identity::Liveness) -> MemberOutcome {
+    let MemberOutcome::Survivor(pid) = outcome else {
+        return outcome;
+    };
+    match recheck() {
+        crate::identity::Liveness::Alive => MemberOutcome::Survivor(pid),
+        crate::identity::Liveness::Dead => {
+            log::debug!(
+                "containment::unix::group: pid {pid} answered EPERM but has since gone (exited \
+                 mid-teardown); downgraded from a confirmed refusal to not-a-survivor"
+            );
+            MemberOutcome::NotASurvivor
+        }
+        // A denied reconfirmation does NOT overturn an already-observed, authoritative EPERM
+        // — see the doc comment above for why this differs from the Dead arm.
+        crate::identity::Liveness::Unknown => MemberOutcome::Survivor(pid),
+    }
+}
+
+/// List `pgid` once, classify every member, and decide the group's verdict. See this task's
+/// design note above for why there is exactly one listing pass, and why `SIGKILL` resends the
+/// real signal while every other signal (in practice, only `SIGTERM`) only probes. Runs the
+/// loop to completion — a member classified `Unassessable` does NOT short-circuit the pass:
+/// on the `SIGKILL` path `converge` is the delivery mechanism itself, so cutting the loop
+/// short would silently skip signalling every member listed after it. `decide` (below) is
+/// what turns the fully-accumulated result into one verdict.
+///
+/// `pid == 1` is excluded from the `SIGKILL` resend specifically (not the `SIGTERM` probe,
+/// which never delivers anything). xnu's own `killpg1` (this file's Background) explicitly
+/// excludes `kernproc`, `initproc`, and any `P_SYSTEM` process from group signalling before
+/// it even counts `nfound` — a protection `killpg` gave for free that a per-member resend
+/// bypasses unless restated here. Only the `initproc`/pid-1 case is covered here (the
+/// practically reachable one: `kernproc` is pid 0 and never appears in a user-visible pgroup
+/// listing). The broader `P_SYSTEM` flag is NOT filtered — `p_flag` is not currently read
+/// from `kinfo_proc`, and guessing its bit value (`P_SYSTEM` is not exposed by the `libc`
+/// crate for macOS) rather than measuring it would break this plan's own rule of never
+/// resting on an unverified constant. Left as an explicit open question for Anna — see the
+/// report — rather than silently shipped as equivalent to xnu's full check. Excluded pid 1
+/// classifies `Unassessable`, NOT `Cleared`: it was never actually reached, so folding it
+/// into "not a survivor" would manufacture the same false-`Ok` #61 exists to eliminate, just
+/// for pid 1 specifically.
+///
+/// **Interaction with sibling #54 (pgid reuse), read before touching the resend below.** This
+/// function does not obtain, trust, or pin `pgid` itself — it is handed the same, still
+/// unpinned, group id `unix.rs::signal_group` already passed to `killpg`. #54 tracks that
+/// hazard and owns its eventual fix (pinning the pgid against reuse); nothing here changes
+/// how `pgid` is obtained or trusted, and the direct-to-leader fallback in `unix.rs` is left
+/// exactly as it was. What IS new, and worth stating plainly at the one place it bites
+/// hardest: unlike a plain probe, the loop below delivers a REAL `SIGKILL` to every member it
+/// classifies alive-and-reachable. If `pgid` was recycled onto an unrelated process group
+/// between `killpg`'s own call (in `signal_group`) and this function's `members(pgid)` listing
+/// a moment later — #54's race, reoccurring here in a strictly later, second window — this
+/// loop can deliver a real `SIGKILL` into that unrelated group, not merely misreport its
+/// state. This is a consequence of #54's still-open race showing up on this new code path; it
+/// is #54's fix to close (by pinning the pgid before either call), not something this function
+/// can safely work around on its own — see the report's sequencing question to Anna.
+pub(crate) fn converge(pgid: i32, signal: Signal) -> std::io::Result<GroupState> {
+    let listed = members(pgid)?;
+    let mut refused = Vec::new();
+    let mut unassessable = Vec::new();
+    for m in &listed {
+        let id = crate::identity::ProcessId::from_parts(m.pid, m.token);
+        let outcome = classify_member(m.pid, id.is_alive(), || {
+            if signal == Signal::SIGKILL && m.pid == 1 {
+                log::warn!(
+                    "containment::unix::group: pid 1 (init) listed in process group {pgid}; \
+                     excluded from the SIGKILL resend (mirrors xnu's own killpg1 exclusion) \
+                     and reported unassessable, not cleared, since it was never actually reached"
+                );
+                return Reached::Unknown;
+            }
+            if signal == Signal::SIGKILL {
+                // Linux: the atomic pidfd path (see its own doc comment). macOS/other Unix:
+                // no pidfd equivalent exists, so `check_or_signal` keeps the same
+                // already-accepted residual race `src/wait/macos.rs::kill` documents.
+                #[cfg(target_os = "linux")]
+                {
+                    check_or_signal_linux_sigkill(m.pid, id)
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    check_or_signal(m.pid, id, Some(signal))
+                }
+            } else {
+                check_or_signal(m.pid, id, None)
+            }
+        });
+        match reconfirm_survivor(outcome, || id.is_alive()) {
+            MemberOutcome::NotASurvivor => {}
+            MemberOutcome::Survivor(pid) => refused.push(pid),
+            MemberOutcome::Unassessable(pid) => unassessable.push(pid),
+        }
+    }
+    Ok(decide(pgid, signal, refused, unassessable))
+}
+
+/// Turn an accumulated pass into one verdict. Pure — a unit test drives all three shapes
+/// without a real listing. A known refusal always wins over unresolved members elsewhere in
+/// the same group (`Refused` is strictly more informative than a bare `Unlistable`), but the
+/// unassessable pids are carried in `Refused`'s own `unassessable` field rather than merely
+/// logged — an earlier round of this plan discarded them there with only a debug log line;
+/// review correctly called that an incomplete payload on the one issue whose entire point is
+/// not under-reporting teardown state.
+fn decide(pgid: i32, signal: Signal, refused: Vec<RawPid>, unassessable: Vec<RawPid>) -> GroupState {
+    if !refused.is_empty() {
+        return GroupState::Refused { refused, unassessable };
+    }
+    if !unassessable.is_empty() {
+        let list = unassessable
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return GroupState::Unlistable {
+            detail: format!(
+                "{n} member(s) of process group {pgid} could not be assessed after {signal} \
+                 (pid {list})",
+                n = unassessable.len(),
+            ),
+            source: None,
+        };
+    }
+    GroupState::Cleared
+}
+
+/// The friendly wrapper `unix.rs` calls: list `pgid`, converge on delivering `signal`, and
+/// turn a listing failure into the same `Unlistable` shape a per-member `Unknown` produces.
+///
+/// `pgid <= 0` is a `debug_assert!`, not a runtime guard, here: it documents this module's own
+/// contract (never called with an unaddressable group id) rather than pretending to be a
+/// safety net for a dangerous syscall — the REAL guard, which runs before `killpg` is ever
+/// called, is in `unix.rs`'s `signal_group` (this module's only production caller).
+pub(crate) fn state(pgid: i32, signal: Signal) -> GroupState {
+    debug_assert!(
+        pgid > 0,
+        "group::state called with a non-positive pgid ({pgid}); the real guard belongs in the \
+         caller, before any signal is sent — see unix.rs::signal_group"
+    );
+    match converge(pgid, signal) {
+        Ok(gs) => gs,
+        Err(e) => GroupState::Unlistable {
+            detail: format!("process group {pgid} could not be listed after {signal}"),
+            source: Some(e),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/src/containment/unix/group.rs
+++ b/src/containment/unix/group.rs
@@ -20,10 +20,17 @@ use crate::identity::RawPid;
 /// One process-group member as the listing found it, carrying the start token needed to
 /// re-verify later that a check still lands on the SAME process (`converge`, below) rather
 /// than a zombie or a pid recycled onto someone else.
+///
+/// `system`: xnu's own `P_SYSTEM` flag (see `identity::kinfo::P_SYSTEM`), read directly from
+/// the same `kinfo_proc` record the listing already fetched — no second syscall. Always
+/// `false` on Linux and other Unix: their listings carry no equivalent flag, and `killpg`'s
+/// own kernel-side exclusion this crate must mirror (see `excluded_from_sigkill_resend`) is
+/// specifically xnu's `killpg1` behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Member {
     pub(crate) pid: RawPid,
     pub(crate) token: u64,
+    pub(crate) system: bool,
 }
 
 /// Every process the kernel currently lists in process group `pgid`. An empty result means
@@ -41,17 +48,13 @@ pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
     let mut mib = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_PGRP, pgid];
     // Extra headroom beyond the (padded) sizing query's own answer, doubled on every genuine
     // ENOMEM retry below — NOT a retry cap (the loop itself stays uncapped; only the buffer
-    // grows). Flagged by review: a single fixed record of slack, re-derived fresh from a new
-    // sizing query on every retry, has no independent termination argument against a group
-    // that keeps growing faster than that one-record margin between the sizing and fetch
-    // calls — the same shape `converge`'s rejected repeat-until-stable loop was cut for. This
-    // is a real but much narrower version of that risk (the sizing-to-fetch gap here is two
-    // syscalls back to back, not a full signal-and-relist pass), so it was not promoted to a
-    // must-fix by review, but the fix is free and removes the gap rather than merely narrowing
-    // it: doubling `slack` on each ENOMEM guarantees it eventually exceeds any BOUNDED
+    // grows). A single fixed slack, re-derived fresh from a new sizing query on every retry,
+    // has no termination argument against a group that keeps growing faster than that
+    // one-record margin between the sizing and fetch calls (the sizing-to-fetch gap here is
+    // two syscalls back to back, narrower than a full signal-and-relist pass but still real).
+    // Doubling `slack` on each ENOMEM guarantees it eventually exceeds any BOUNDED
     // per-iteration growth rate (forking still takes non-zero wall-clock time even in a tight
-    // loop), giving a genuine, finite termination argument — not a probability one — matching
-    // what this plan's own Self-review section already claims for this loop.
+    // loop), giving a genuine, finite termination argument, not a probability one.
     let mut slack: usize = 1;
     loop {
         let mut len: libc::size_t = 0;
@@ -110,10 +113,10 @@ pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
         }
         // A partial trailing record means the kernel's `kinfo_proc` no longer matches this
         // crate's 648-byte definition — the same ENOMEM-is-the-only-runtime-detector situation
-        // `identity/macos/kinfo.rs`'s single-pid reader already guards (`kinfo.rs:126-137`,
-        // its own size-mismatch `contract_violation`). Reject rather than reinterpret at the
-        // wrong stride, which would silently produce garbage `p_pid` values that `converge`
-        // would then send a real signal to.
+        // `identity/macos/kinfo.rs`'s single-pid reader already guards, via its own
+        // size-mismatch `contract_violation`. Reject rather than reinterpret at the wrong
+        // stride, which would silently produce garbage `p_pid` values that `converge` would
+        // then send a real signal to.
         if !got.is_multiple_of(RECORD) {
             return Err(std::io::Error::other(format!(
                 "sysctl(KERN_PROC_PGRP, {pgid}) returned {got} bytes, not a whole multiple of \
@@ -131,6 +134,7 @@ pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
                 token: unsafe {
                     k.kp_proc.p_un.p_starttime.tv_sec as u64 * 1_000_000 + k.kp_proc.p_un.p_starttime.tv_usec as u64
                 },
+                system: k.kp_proc.p_flag & crate::identity::kinfo::P_SYSTEM != 0,
             })
             .collect());
     }
@@ -154,21 +158,18 @@ pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
         };
         let stat = match std::fs::read(format!("/proc/{pid}/stat")) {
             Ok(bytes) => bytes,
-            // Deliberately NOT propagated as a listing failure, and deliberately NOT trying to
-            // disambiguate the cause (an earlier version of this plan tried: probe with
-            // `kill(pid, 0)` and propagate unless it confirms ESRCH). That attempt made things
-            // WORSE, not better: this loop scans ALL of `/proc`, not just `pgid`'s members, and
-            // a `hidepid`-restricted `/proc` answers a foreign-uid signal probe with `EPERM`
-            // (permission and /proc-visibility are separate kernel subsystems; hidepid governs
-            // only the latter) — so on a `hidepid` host, the very FIRST foreign-uid process
-            // encountered anywhere on the host, however unrelated to `pgid`, would abort the
-            // entire listing and turn every `kill_group`/`term_group` call into `Unassessable`,
-            // including a fully-torn-down group of the caller's own same-uid children. A read
-            // failure on a pid we have not yet even determined belongs to `pgid` at all carries
-            // no information about `pgid` specifically — it is simply excluded, the same as any
-            // other non-matching entry. What THIS does leave open, honestly: on a `hidepid`
-            // host, a genuine FOREIGN-uid member of `pgid` itself is invisible to this scan and
-            // silently excluded, undercounting the group — see the report's open question.
+            // Deliberately NOT propagated as a listing failure, and deliberately NOT
+            // disambiguated by probing with `kill(pid, 0)`: this loop scans ALL of `/proc`, not
+            // just `pgid`'s members, and a `hidepid`-restricted `/proc` answers a foreign-uid
+            // probe with `EPERM` too — so the first foreign-uid process anywhere on the host,
+            // however unrelated to `pgid`, would abort the entire listing and turn every
+            // `kill_group`/`term_group` call into `Unassessable`, including a fully-torn-down
+            // group of the caller's own same-uid children. A read failure on a pid not yet
+            // determined to belong to `pgid` carries no information about `pgid` specifically,
+            // so it is simply excluded like any other non-matching entry. The residual this
+            // leaves — a genuine foreign-uid member of `pgid` itself, invisible to this scan and
+            // silently excluded — is documented on `Child::kill_tree`'s public rustdoc, the
+            // guarantee it actually weakens.
             Err(e) => {
                 log::debug!(
                     "containment::unix::group::members: /proc/{pid}/stat unreadable ({e}); \
@@ -201,7 +202,11 @@ pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
             );
             continue;
         };
-        out.push(Member { pid, token });
+        out.push(Member {
+            pid,
+            token,
+            system: false,
+        });
     }
     Ok(out)
 }
@@ -249,10 +254,9 @@ pub(crate) enum GroupState {
 
 /// Whether a live-confirmed member was actually reached by the signal/probe. A THIRD
 /// answer, `Unknown`, is threaded all the way from the deepest primitive up through
-/// `classify_member` — this round's review found the previous draft collapsing "could not
-/// assess" into a binary `bool` at exactly the boundary where the distinction mattered most
-/// (inside `converge`'s `reached` closure), silently re-narrowing the `Liveness::Unknown`
-/// handling `classify_member` otherwise protects.
+/// `classify_member`: collapsing "could not assess" into a binary `bool` at the boundary
+/// where the distinction matters most (inside `converge`'s `reached` closure) would silently
+/// re-narrow the `Liveness::Unknown` handling `classify_member` otherwise protects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Reached {
     Yes,
@@ -264,15 +268,14 @@ enum Reached {
 /// attempt could still teach us something) whether the real check reached it. Pure — a unit
 /// test drives all `Liveness`/`Reached` combinations directly, without needing a real OS
 /// condition for `Unknown` (which normally needs a permission-denying host like `hidepid`).
-/// `reached` is called for `Liveness::Alive` OR `Liveness::Unknown` — NOT only `Alive` (an
-/// earlier round of this plan gated it on `Alive` alone; review correctly caught that this
-/// is guard-then-do backwards for an operation the plan itself calls idempotent and
-/// self-reporting: `SIGKILL`/a probe answers the permission question directly and
-/// authoritatively, so gating the ATTEMPT on a separate LIVENESS QUERY that can itself be
+/// `reached` is called for `Liveness::Alive` OR `Liveness::Unknown` — NOT only `Alive`.
+/// Gating the attempt on `Alive` alone is guard-then-do backwards for an operation that is
+/// idempotent and self-reporting: `SIGKILL`/a probe answers the permission question directly
+/// and authoritatively, so gating the ATTEMPT on a separate LIVENESS QUERY that can itself be
 /// denied — e.g. under App Sandbox / a hardened runtime, where `is_alive`'s own fallback can
 /// legitimately answer `Unknown` for a foreign-uid member — needlessly turns a recoverable
 /// teardown into `Error::Unassessable` without ever trying the one call that would have
-/// answered the real question). Only a POSITIVE `Liveness::Dead` skips the attempt entirely
+/// answered the real question. Only a POSITIVE `Liveness::Dead` skips the attempt entirely
 /// — there is nothing left to prove for a zombie, a departed pid, or a pid recycled onto an
 /// unrelated process, however a signal/probe of the raw pid might answer.
 enum MemberOutcome {
@@ -300,37 +303,35 @@ fn classify_member(
 /// the ONE implementation both the `SIGKILL` and `SIGTERM` paths use, differing only in
 /// `signal` (`Some(SIGKILL)` resends for real; `None` probes with `kill(pid, 0)`).
 ///
-/// **Why this replaced `treewalk::kill_by_identity` from an earlier round of this plan.**
-/// That primitive's `KillOutcome::NotAttempted` conflates TWO different causes — a denied
-/// identity re-verify, and a genuine `EPERM` from the real `kill(2)` call — into one variant
-/// (`src/containment/treewalk.rs:222-256`), with nothing in the return value to tell them
-/// apart. An earlier round tried to route around this by pre-checking identity here and
-/// *assuming* `kill_by_identity`'s own internal re-check, a moment later, would agree — a
-/// probability argument, not a proof, and review correctly rejected it: a transient
-/// disagreement in that gap still mislabels "unassessable" as a confirmed refusal. Reusing
-/// `kill_by_identity` here cannot be made precise without changing its return type (out of
-/// scope — it is a sibling module's primitive), so this performs the identity check AND the
-/// `kill(2)` call directly, observing the real errno first-hand. `EPERM` and only `EPERM`
-/// classifies as a confirmed refusal; every other unexpected errno is `Unknown`, not `No` —
-/// conservative, and consistent with every other "not EPERM/ESRCH" disposition in this
+/// **Why this doesn't reuse `treewalk::kill_by_identity`.** That primitive's
+/// `KillOutcome::NotAttempted` conflates TWO different causes — a denied identity re-verify,
+/// and a genuine `EPERM` from the real `kill(2)` call — into one variant, with nothing in the
+/// return value to tell them apart. Pre-checking identity here and assuming
+/// `kill_by_identity`'s own internal re-check, a moment later, would agree is not reliable: a
+/// transient disagreement in that gap would mislabel "unassessable" as a confirmed refusal.
+/// Reusing `kill_by_identity` here cannot be made precise without changing its return type
+/// (out of scope — it is a sibling module's primitive), so this performs the identity check
+/// AND the `kill(2)` call directly, observing the real errno first-hand. `EPERM` and only
+/// `EPERM` classifies as a confirmed refusal; every other unexpected errno is `Unknown`, not
+/// `No` — conservative, and consistent with every other "not EPERM/ESRCH" disposition in this
 /// module.
 ///
 /// **The identity check and the act are still two separate syscalls on macOS — a narrowed,
-/// not eliminated, race.** Review correctly caught an earlier claim here that a pid recycled
-/// between the listing and this call is "never mistakenly signalled" — false: the re-verify
-/// and the `kill(2)` below are non-atomic, so a recycle in THAT gap (not the earlier,
-/// listing-to-here gap the re-verify closes) is still possible. On Linux this is closed for
-/// real, not just narrowed: `SIGKILL` delivery goes through `pidfd_open`+`pidfd_send_signal`
-/// (`check_or_signal_linux_sigkill`, below), reusing `crate::wait::backend::open_verified`
-/// verbatim rather than a second implementation — the fd itself pins the identity at the
-/// kernel level, so a pid reused after `pidfd_open` cannot be hit even in principle. macOS has
-/// no pidfd equivalent, so `kill(2)` here keeps the same irreducible, ALREADY-ACCEPTED window
-/// `src/wait/macos.rs::kill`'s own doc comment documents verbatim ("The window between this
-/// check and kill(2) is irreducible on macOS (no pidfd); a recycled pid in that window is a
-/// documented best-effort limitation, mirroring treewalk::kill_by_identity") — this function
-/// is that same, already-reviewed trade-off, not a new one.
+/// not eliminated, race.** A pid recycled between the listing and this call is not "never
+/// mistakenly signalled": the re-verify and the `kill(2)` below are non-atomic, so a recycle
+/// in THAT gap (not the earlier, listing-to-here gap the re-verify closes) is still possible.
+/// On Linux this is closed for real, not just narrowed: `SIGKILL` delivery goes through
+/// `pidfd_open`+`pidfd_send_signal` (`check_or_signal_linux_sigkill`, below), reusing
+/// `crate::wait::backend::open_verified` verbatim rather than a second implementation — the fd
+/// itself pins the identity at the kernel level, so a pid reused after `pidfd_open` cannot be
+/// hit even in principle. macOS has no pidfd equivalent, so `kill(2)` here keeps the same
+/// irreducible window `src/wait/macos.rs::kill`'s own doc comment documents verbatim ("The
+/// window between this check and kill(2) is irreducible on macOS (no pidfd); a recycled pid
+/// in that window is a documented best-effort limitation, mirroring
+/// treewalk::kill_by_identity") — this function is that same accepted trade-off, not a new
+/// one.
 fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<Signal>) -> Reached {
-    // Contract (repo-wide policy, this round): this module's whole design rests on
+    // Contract (repo-wide policy): this module's whole design rests on
     // `SIGTERM` never being resent for real (the double-signal-escalation avoidance —
     // `converge`'s design note above) — only `SIGKILL` may be `Some`, everything else must
     // probe (`None`). A future caller passing e.g. `Some(Signal::SIGTERM)` through here would
@@ -351,19 +352,17 @@ fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<S
             return Reached::Yes;
         }
         crate::identity::Resolved::Gone => return Reached::Yes,
-        // **Reverted this round — a prior round's "ask forgiveness" change here was itself a
-        // bug, caught by review.** An earlier version of this arm signalled the bare `pid`
-        // for real whenever `signal.is_some()`, reasoning that "a genuinely recycled pid still
-        // answers ESRCH/EPERM on its own terms, same as `Resolved::Found(_)`'s recycle case
-        // above." That reasoning does not hold: `Resolved::Found(_)` is safe BECAUSE identity
-        // was resolved and compared (we KNOW it's a different, and therefore not-our-business,
-        // process). `Resolved::Unknown` means the re-verify could not be performed AT ALL — if
-        // the pid was recycled onto a process the caller MAY signal, `kill(2)` returns
-        // `Ok(())` and a completely unrelated process gets killed, not `ESRCH`/`EPERM`. There
-        // is no analogy to lean on; the two cases are opposite, not equivalent. Conservative
-        // bail, for BOTH the resend and the probe: an unverifiable identity is never signalled
-        // on this platform (no atomic handle exists here — `check_or_signal_linux_sigkill`,
-        // below, is the platform where a genuinely atomic alternative exists and is used).
+        // `Resolved::Unknown` must NOT be treated like `Resolved::Found(_)`'s recycle case
+        // above, even though both look like "a pid that no longer names the expected
+        // process": `Resolved::Found(_)` is safe BECAUSE identity was resolved and compared
+        // (we KNOW it's a different, and therefore not-our-business, process).
+        // `Resolved::Unknown` means the re-verify could not be performed AT ALL — if the pid
+        // was recycled onto a process the caller MAY signal, `kill(2)` returns `Ok(())` and a
+        // completely unrelated process gets killed, not `ESRCH`/`EPERM`. There is no analogy
+        // to lean on; the two cases are opposite, not equivalent. Conservative bail, for BOTH
+        // the resend and the probe: an unverifiable identity is never signalled on this
+        // platform (no atomic handle exists here — `check_or_signal_linux_sigkill`, below, is
+        // the platform where a genuinely atomic alternative exists and is used).
         crate::identity::Resolved::Unknown => {
             log::warn!(
                 "containment::unix::group: pid {pid} could not be re-verified (access denied?) \
@@ -420,8 +419,8 @@ fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<S
 /// `Unsupported`; every other errno, including `EPERM`, falls into the generic `Error::Io`
 /// arm). A seccomp profile is free to pick either errno for a denied syscall, so treating only
 /// `Unsupported` as fallback-eligible silently reclassifies "we couldn't even ask" as
-/// `Reached::Unknown` on exactly the containers this fallback exists for (Task 6's setuid
-/// helper test runs under Docker's default seccomp profile). Both variants get the SAME
+/// `Reached::Unknown` on exactly the containers this fallback exists for (a seccomp-restricted
+/// container, e.g. Docker's default profile). Both variants get the SAME
 /// treatment: fall back to `check_or_signal`'s plain `kill(2)`, which observes envelopes IT
 /// controls directly rather than trusting `open_verified`'s errno classification a second
 /// time. Only `Error::Unassessable` — identity genuinely denied by `id.exists()`, or the pid
@@ -429,11 +428,11 @@ fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<S
 /// PID's identity, not about whether the kernel can open a pidfd at all, and no fallback
 /// resolves it.
 ///
-/// **Considered and rejected: signalling via the already-open pidfd anyway when `id.exists()`
-/// answers `Unknown` inside `open_verified`.** This looks tempting — `pidfd_open` already
-/// succeeded, so *something* is there — but it does not actually close the gap, for the same
-/// reason `check_or_signal`'s own `Resolved::Unknown` arm (above) must never signal a bare
-/// pid: `pidfd_open(pid)` binds to WHATEVER process holds that pid NUMBER at the moment it is
+/// **Why this never signals via the already-open pidfd when `id.exists()` answers `Unknown`
+/// inside `open_verified`.** This looks tempting — `pidfd_open` already succeeded, so
+/// *something* is there — but it does not actually close the gap, for the same reason
+/// `check_or_signal`'s own `Resolved::Unknown` arm (above) must never signal a bare pid:
+/// `pidfd_open(pid)` binds to WHATEVER process holds that pid NUMBER at the moment it is
 /// called, exactly like a bare `kill(2)`. If the member `members()` listed at T0 exited and
 /// its pid was recycled onto an unrelated, signalable process before `pidfd_open` runs at T1,
 /// `pidfd_open` succeeds — for the WRONG process. `id.exists()`'s subsequent `Unknown` answer
@@ -444,13 +443,12 @@ fn check_or_signal(pid: RawPid, id: crate::identity::ProcessId, signal: Option<S
 /// successful open, not that the identity was already correct AT open time — exactly the gap
 /// `open_verified`'s own `id.exists()` step exists to close, and exactly the gap `Existence::
 /// Unknown` says was NOT closed this time. Signalling anyway would reintroduce, on Linux, the
-/// identical "unrelated-process-killed" failure mode `check_or_signal`'s reverted "ask
-/// forgiveness" arm had on macOS — not a smaller version of it. Left as a disclosed,
-/// asymmetric gap (see the report / Verification gaps) rather than closed with an unsound
-/// fix: on a genuinely `hidepid`-restricted host, a live member whose identity cannot be
-/// re-confirmed at delivery time is correctly left unsignalled and reported `Unassessable`,
-/// even though the earlier `Liveness::Unknown`-admitting gate (`classify_member`) let it
-/// through to the attempt.
+/// identical "unrelated-process-killed" failure mode a bare-pid signal has on macOS's
+/// `Resolved::Unknown` arm — not a smaller version of it. Left as a disclosed, asymmetric gap
+/// rather than closed with an unsound fix: on a genuinely `hidepid`-restricted host, a live
+/// member whose identity cannot be re-confirmed at delivery time is correctly left unsignalled
+/// and reported `Unassessable`, even though the earlier `Liveness::Unknown`-admitting gate
+/// (`classify_member`) let it through to the attempt.
 #[cfg(target_os = "linux")]
 fn check_or_signal_linux_sigkill(pid: RawPid, id: crate::identity::ProcessId) -> Reached {
     match crate::wait::backend::open_verified(id, "process-group teardown verification") {
@@ -505,23 +503,22 @@ fn check_or_signal_linux_sigkill(pid: RawPid, id: crate::identity::ProcessId) ->
 /// debug session starting from "why did teardown report Cleared/Unassessable despite the
 /// EPERM in the logs" needs this decision to be visible too, not just the original refusal.
 ///
-/// **Downgrades on `Liveness::Dead` only — `Liveness::Unknown` keeps `Survivor`, fixed this
-/// round.** An earlier version of this match also downgraded on `Unknown`, reasoning that a
-/// denied liveness re-check should not be trusted either way. Review correctly caught that
-/// this throws away STRONGER evidence for WEAKER: the `Survivor` this function receives
-/// already carries a REAL, directly-observed `EPERM` from `check_or_signal`'s own `kill(2)`/
-/// `pidfd_send_signal` call — the kernel's authoritative, first-hand answer to "may this
-/// caller signal this process". `recheck`'s liveness query is a WEAKER, independently-deniable
-/// signal (the same class of query that can itself answer `Unknown` under `hidepid` or a
-/// sandboxed runtime); a denied liveness reconfirmation is not evidence the EPERM was wrong,
-/// only that this SECOND, unrelated query could not be answered. Combined with `classify_member`
-/// proceeding on `Liveness::Unknown` (a separate, correct fix from an earlier round), the
-/// prior `Unknown`-downgrades-too shape made that fix produce no benefit for the refusal
-/// verdict at all — `Unknown` at the first check could only ever end in `NotASurvivor` or
-/// `Unassessable`, never the `Refused` a genuine, already-observed `EPERM` earns. The member
-/// was already established not-`Dead` by the first liveness check (`classify_member`'s own
-/// gate) before the signal was ever attempted, so `Dead` is the only recheck answer that
-/// actually contradicts the `Survivor` verdict; `Unknown` contradicts nothing.
+/// **Downgrades on `Liveness::Dead` only — `Liveness::Unknown` keeps `Survivor`.** Downgrading
+/// on `Unknown` too would throw away STRONGER evidence for WEAKER: the `Survivor` this
+/// function receives already carries a REAL, directly-observed `EPERM` from
+/// `check_or_signal`'s own `kill(2)`/`pidfd_send_signal` call — the kernel's authoritative,
+/// first-hand answer to "may this caller signal this process". `recheck`'s liveness query is a
+/// WEAKER, independently-deniable signal (the same class of query that can itself answer
+/// `Unknown` under `hidepid` or a sandboxed runtime); a denied liveness reconfirmation is not
+/// evidence the EPERM was wrong, only that this SECOND, unrelated query could not be answered.
+/// `classify_member` already proceeds on `Liveness::Unknown` rather than stopping there, so an
+/// `Unknown`-downgrades-too shape here would make that upstream permissiveness produce no
+/// benefit for the refusal verdict at all — `Unknown` at the first check could only ever end in
+/// `NotASurvivor` or `Unassessable`, never the `Refused` a genuine, already-observed `EPERM`
+/// earns. The member was already established not-`Dead` by the first liveness check
+/// (`classify_member`'s own gate) before the signal was ever attempted, so `Dead` is the only
+/// recheck answer that actually contradicts the `Survivor` verdict; `Unknown` contradicts
+/// nothing.
 fn reconfirm_survivor(outcome: MemberOutcome, recheck: impl FnOnce() -> crate::identity::Liveness) -> MemberOutcome {
     let MemberOutcome::Survivor(pid) = outcome else {
         return outcome;
@@ -549,20 +546,10 @@ fn reconfirm_survivor(outcome: MemberOutcome, recheck: impl FnOnce() -> crate::i
 /// short would silently skip signalling every member listed after it. `decide` (below) is
 /// what turns the fully-accumulated result into one verdict.
 ///
-/// `pid == 1` is excluded from the `SIGKILL` resend specifically (not the `SIGTERM` probe,
-/// which never delivers anything). xnu's own `killpg1` (this file's Background) explicitly
-/// excludes `kernproc`, `initproc`, and any `P_SYSTEM` process from group signalling before
-/// it even counts `nfound` — a protection `killpg` gave for free that a per-member resend
-/// bypasses unless restated here. Only the `initproc`/pid-1 case is covered here (the
-/// practically reachable one: `kernproc` is pid 0 and never appears in a user-visible pgroup
-/// listing). The broader `P_SYSTEM` flag is NOT filtered — `p_flag` is not currently read
-/// from `kinfo_proc`, and guessing its bit value (`P_SYSTEM` is not exposed by the `libc`
-/// crate for macOS) rather than measuring it would break this plan's own rule of never
-/// resting on an unverified constant. Left as an explicit open question for Anna — see the
-/// report — rather than silently shipped as equivalent to xnu's full check. Excluded pid 1
-/// classifies `Unassessable`, NOT `Cleared`: it was never actually reached, so folding it
-/// into "not a survivor" would manufacture the same false-`Ok` #61 exists to eliminate, just
-/// for pid 1 specifically.
+/// A pid excluded from the `SIGKILL` resend (see `excluded_from_sigkill_resend`, just below)
+/// classifies `Unassessable`, NOT `Cleared`: it was never actually reached, so folding it into
+/// "not a survivor" would manufacture the same false-`Ok` #61 exists to eliminate, just for
+/// this pid specifically.
 ///
 /// **Interaction with sibling #54 (pgid reuse), read before touching the resend below.** This
 /// function does not obtain, trust, or pin `pgid` itself — it is handed the same, still
@@ -577,7 +564,7 @@ fn reconfirm_survivor(outcome: MemberOutcome, recheck: impl FnOnce() -> crate::i
 /// loop can deliver a real `SIGKILL` into that unrelated group, not merely misreport its
 /// state. This is a consequence of #54's still-open race showing up on this new code path; it
 /// is #54's fix to close (by pinning the pgid before either call), not something this function
-/// can safely work around on its own — see the report's sequencing question to Anna.
+/// can safely work around on its own.
 pub(crate) fn converge(pgid: i32, signal: Signal) -> std::io::Result<GroupState> {
     let listed = members(pgid)?;
     let mut refused = Vec::new();
@@ -585,11 +572,13 @@ pub(crate) fn converge(pgid: i32, signal: Signal) -> std::io::Result<GroupState>
     for m in &listed {
         let id = crate::identity::ProcessId::from_parts(m.pid, m.token);
         let outcome = classify_member(m.pid, id.is_alive(), || {
-            if signal == Signal::SIGKILL && m.pid == 1 {
+            if signal == Signal::SIGKILL && excluded_from_sigkill_resend(m.pid, m.system) {
                 log::warn!(
-                    "containment::unix::group: pid 1 (init) listed in process group {pgid}; \
-                     excluded from the SIGKILL resend (mirrors xnu's own killpg1 exclusion) \
-                     and reported unassessable, not cleared, since it was never actually reached"
+                    "containment::unix::group: pid {pid} in process group {pgid} is excluded \
+                     from the SIGKILL resend (mirrors xnu's own killpg1 exclusion for init/ \
+                     P_SYSTEM) and reported unassessable, not cleared, since it was never \
+                     actually reached",
+                    pid = m.pid
                 );
                 return Reached::Unknown;
             }
@@ -618,13 +607,27 @@ pub(crate) fn converge(pgid: i32, signal: Signal) -> std::io::Result<GroupState>
     Ok(decide(pgid, signal, refused, unassessable))
 }
 
+/// Mirrors xnu's own `killpg1` exclusion set for the `SIGKILL` resend above: `killpg1` skips
+/// `kernproc`, `initproc` (pid 1), and every `P_SYSTEM`-flagged process before it even counts a
+/// group as reachable. `kernproc` (pid 0) never appears in a listed group's membership, so only
+/// the other two need restating here — this crate's own per-member resend does not inherit
+/// `killpg`'s kernel-side exclusion for free, and without it a live `P_SYSTEM` process would
+/// receive a real `SIGKILL` that `killpg` itself would have refused to send. Pure, and tested
+/// directly against synthetic pid/`system` combinations (`group_tests.rs`) rather than only
+/// through `converge`'s live path.
+///
+/// `system` comes from the listing's own `Member::system` — real on macOS, always `false`
+/// elsewhere, where no equivalent kernel flag exists to restate.
+fn excluded_from_sigkill_resend(pid: RawPid, system: bool) -> bool {
+    pid == 1 || system
+}
+
 /// Turn an accumulated pass into one verdict. Pure — a unit test drives all three shapes
 /// without a real listing. A known refusal always wins over unresolved members elsewhere in
 /// the same group (`Refused` is strictly more informative than a bare `Unlistable`), but the
 /// unassessable pids are carried in `Refused`'s own `unassessable` field rather than merely
-/// logged — an earlier round of this plan discarded them there with only a debug log line;
-/// review correctly called that an incomplete payload on the one issue whose entire point is
-/// not under-reporting teardown state.
+/// logged: a debug log line alone would be an incomplete payload on the one issue whose entire
+/// point is not under-reporting teardown state.
 fn decide(pgid: i32, signal: Signal, refused: Vec<RawPid>, unassessable: Vec<RawPid>) -> GroupState {
     if !refused.is_empty() {
         return GroupState::Refused { refused, unassessable };

--- a/src/containment/unix/group.rs
+++ b/src/containment/unix/group.rs
@@ -1,0 +1,221 @@
+//! Process-group membership, and turning a signal-and-verify pass into a checkable list.
+//!
+//! `killpg` cannot answer "is the group down?" On both Unix platforms its return value
+//! reports only whether *at least one* member took the signal, never who it skipped: Linux
+//! returns 0 as soon as one `group_send_sig_info` succeeds (`kernel/signal.c`,
+//! `__kill_pgrp_info`), and xnu returns `nfound > 0 ? 0 : (posix ? EPERM : ESRCH)`
+//! (`bsd/kern/kern_sig.c`, `killpg1`). So a group holding one member we may signal and one we
+//! may not reports plain success while the second keeps running — measured on both
+//! (this file's Background in the plan). Darwin's undocumented third `kill` argument does not
+//! help: it only chooses which errno labels `nfound == 0`, returning `ESRCH` for a live
+//! unsignalable group exactly as it does for an all-zombie one (measured, macOS 26.5.2).
+//!
+//! So the group's actual membership decides (see `converge` below), and this module owns the
+//! listing: sysctl `KERN_PROC_PGRP` on macOS, `/proc` on Linux.
+
+use crate::identity::RawPid;
+
+/// One process-group member as the listing found it, carrying the start token needed to
+/// re-verify later that a check still lands on the SAME process (`converge`, below) rather
+/// than a zombie or a pid recycled onto someone else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Member {
+    pub(crate) pid: RawPid,
+    pub(crate) token: u64,
+}
+
+/// Every process the kernel currently lists in process group `pgid`. An empty result means
+/// the group holds nothing — not an error.
+///
+/// macOS: `sysctl(KERN_PROC_PGRP)`, which lists a group belonging to another user
+/// unprivileged (verified, this file's Background) and reports each member's start time in
+/// the same record as its pid. libproc's `proc_listpgrppids` is deliberately NOT used: it
+/// returns a COUNT where its siblings return bytes, and it carries no start time.
+#[cfg(target_os = "macos")]
+pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
+    use crate::identity::kinfo::kinfo_proc;
+
+    const RECORD: usize = std::mem::size_of::<kinfo_proc>();
+    let mut mib = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_PGRP, pgid];
+    // Extra headroom beyond the (padded) sizing query's own answer, doubled on every genuine
+    // ENOMEM retry below — NOT a retry cap (the loop itself stays uncapped; only the buffer
+    // grows). Flagged by review: a single fixed record of slack, re-derived fresh from a new
+    // sizing query on every retry, has no independent termination argument against a group
+    // that keeps growing faster than that one-record margin between the sizing and fetch
+    // calls — the same shape `converge`'s rejected repeat-until-stable loop was cut for. This
+    // is a real but much narrower version of that risk (the sizing-to-fetch gap here is two
+    // syscalls back to back, not a full signal-and-relist pass), so it was not promoted to a
+    // must-fix by review, but the fix is free and removes the gap rather than merely narrowing
+    // it: doubling `slack` on each ENOMEM guarantees it eventually exceeds any BOUNDED
+    // per-iteration growth rate (forking still takes non-zero wall-clock time even in a tight
+    // loop), giving a genuine, finite termination argument — not a probability one — matching
+    // what this plan's own Self-review section already claims for this loop.
+    let mut slack: usize = 1;
+    loop {
+        let mut len: libc::size_t = 0;
+        // SAFETY: a size query — null buffer, `len` receives the byte count.
+        let rc = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                std::ptr::null_mut(),
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if rc != 0 {
+            let e = std::io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(e);
+        }
+        // No `len == 0` early return here: measured directly (Background), the sizing query
+        // is always padded by xnu's `KERN_PROCSLOP` and so is never literally 0, even for a
+        // genuinely empty group — the real "empty" signal is `got == 0` from the FETCH call
+        // below, already handled correctly (an empty `buf` after `set_len(0)`, `Ok(vec![])`).
+        // A `len == 0` branch here would be dead code, not a safety net.
+        let mut buf: Vec<kinfo_proc> = Vec::with_capacity(len / RECORD + slack);
+        let mut got = buf.capacity() * RECORD;
+        // SAFETY: `buf` has room for `got` bytes of records; sysctl writes at
+        // most `got` and updates it to what it actually wrote.
+        let rc = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                buf.as_mut_ptr().cast(),
+                &mut got,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if rc != 0 {
+            let e = std::io::Error::last_os_error();
+            // ENOMEM: the group grew between sizing and fetching. Size it again, with the
+            // slack doubled (see this function's opening comment) so the margin outruns any
+            // bounded growth rate rather than staying fixed. EINTR: no growth implied, retry
+            // with the same slack. There is no retry CAP either way: the loop ends when
+            // sysctl succeeds, which the growing margin guarantees in finite iterations.
+            if e.raw_os_error() == Some(libc::ENOMEM) {
+                slack = slack.saturating_mul(2);
+                continue;
+            }
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(e);
+        }
+        // A partial trailing record means the kernel's `kinfo_proc` no longer matches this
+        // crate's 648-byte definition — the same ENOMEM-is-the-only-runtime-detector situation
+        // `identity/macos/kinfo.rs`'s single-pid reader already guards (`kinfo.rs:126-137`,
+        // its own size-mismatch `contract_violation`). Reject rather than reinterpret at the
+        // wrong stride, which would silently produce garbage `p_pid` values that `converge`
+        // would then send a real signal to.
+        if !got.is_multiple_of(RECORD) {
+            return Err(std::io::Error::other(format!(
+                "sysctl(KERN_PROC_PGRP, {pgid}) returned {got} bytes, not a whole multiple of \
+                 the {RECORD}-byte kinfo_proc record — kernel ABI drift, refusing to reinterpret"
+            )));
+        }
+        // SAFETY: sysctl initialised exactly `got / RECORD` whole records (checked above).
+        unsafe { buf.set_len(got / RECORD) };
+        return Ok(buf
+            .iter()
+            .map(|k| Member {
+                pid: k.kp_proc.p_pid as RawPid,
+                // SAFETY: the kernel's KERN_PROC copy always fills `p_starttime`
+                // (see `identity::macos::token_of_kinfo`, the same formula).
+                token: unsafe {
+                    k.kp_proc.p_un.p_starttime.tv_sec as u64 * 1_000_000 + k.kp_proc.p_un.p_starttime.tv_usec as u64
+                },
+            })
+            .collect());
+    }
+}
+
+/// Linux: scan `/proc` and keep the entries whose `stat` field 5 is `pgid`, carrying field 22
+/// (`starttime`) as the token. There is no narrower kernel interface for process-group
+/// membership.
+#[cfg(target_os = "linux")]
+pub(crate) fn members(pgid: i32) -> std::io::Result<Vec<Member>> {
+    use crate::identity::stat_parse::{parse_pgrp, parse_starttime_jiffies};
+
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir("/proc")? {
+        // A genuine read_dir iteration error means the listing itself is unreliable —
+        // propagate it rather than silently treating it as one absent entry among many.
+        let entry = entry?;
+        // /proc/<pid> directories are named by their decimal pid; skip the rest (self, net, ...).
+        let Some(pid) = entry.file_name().to_str().and_then(|n| n.parse::<RawPid>().ok()) else {
+            continue;
+        };
+        let stat = match std::fs::read(format!("/proc/{pid}/stat")) {
+            Ok(bytes) => bytes,
+            // Deliberately NOT propagated as a listing failure, and deliberately NOT trying to
+            // disambiguate the cause (an earlier version of this plan tried: probe with
+            // `kill(pid, 0)` and propagate unless it confirms ESRCH). That attempt made things
+            // WORSE, not better: this loop scans ALL of `/proc`, not just `pgid`'s members, and
+            // a `hidepid`-restricted `/proc` answers a foreign-uid signal probe with `EPERM`
+            // (permission and /proc-visibility are separate kernel subsystems; hidepid governs
+            // only the latter) — so on a `hidepid` host, the very FIRST foreign-uid process
+            // encountered anywhere on the host, however unrelated to `pgid`, would abort the
+            // entire listing and turn every `kill_group`/`term_group` call into `Unassessable`,
+            // including a fully-torn-down group of the caller's own same-uid children. A read
+            // failure on a pid we have not yet even determined belongs to `pgid` at all carries
+            // no information about `pgid` specifically — it is simply excluded, the same as any
+            // other non-matching entry. What THIS does leave open, honestly: on a `hidepid`
+            // host, a genuine FOREIGN-uid member of `pgid` itself is invisible to this scan and
+            // silently excluded, undercounting the group — see the report's open question.
+            Err(e) => {
+                log::debug!(
+                    "containment::unix::group::members: /proc/{pid}/stat unreadable ({e}); \
+                     excluding it (not evidence it belongs to pgid {pgid} either way)"
+                );
+                continue;
+            }
+        };
+        let Some(g) = parse_pgrp(&stat) else {
+            // The stat line read but its pgrp field did not parse — a malformed/unexpected
+            // record, not evidence this pid belongs to a different group. Visible, not
+            // silently folded into "not a member", mirroring the starttime-parse-failure
+            // handling three lines below.
+            log::debug!(
+                "containment::unix::group::members: /proc/{pid}/stat had no parseable pgrp \
+                 field; excluding it"
+            );
+            continue;
+        };
+        if g != pgid as u32 {
+            continue;
+        }
+        let Some(token) = parse_starttime_jiffies(&stat) else {
+            // No usable identity token — a later re-check could never confirm this pid is
+            // still the SAME process, so it cannot be counted as a member either; visible,
+            // not silent.
+            log::debug!(
+                "containment::unix::group::members: /proc/{pid}/stat matched pgid {pgid} but \
+                 had no parseable starttime; excluding it"
+            );
+            continue;
+        };
+        out.push(Member { pid, token });
+    }
+    Ok(out)
+}
+
+/// Other Unix: the crate supports Linux, macOS and Windows (see
+/// `containment::enumerate`), so there is no listing here. Reported as
+/// unlistable rather than silently empty — an empty group would read as
+/// "teardown succeeded".
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+pub(crate) fn members(_pgid: i32) -> std::io::Result<Vec<Member>> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "process-group membership is implemented only for Linux and macOS",
+    ))
+}
+
+#[cfg(test)]
+#[path = "group_tests.rs"]
+mod group_tests;

--- a/src/containment/unix/group_tests.rs
+++ b/src/containment/unix/group_tests.rs
@@ -1,7 +1,8 @@
 // Unit tests for process-group membership listing and the identity it carries.
 
-use super::{members, Member};
+use super::{members, state, GroupState, Member};
 use crate::identity::{Liveness, ProcessId};
+use nix::sys::signal::Signal;
 
 fn is_alive(m: &Member) -> bool {
     matches!(ProcessId::from_parts(m.pid, m.token).is_alive(), Liveness::Alive)
@@ -18,14 +19,7 @@ fn await_zombie(pid: u32) {
     loop {
         // SAFETY: a well-formed `waitid` call; `info` is a valid, owned, zeroed
         // `siginfo_t` the kernel fills in. WNOWAIT leaves the child reapable.
-        let rc = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                pid as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOWAIT,
-            )
-        };
+        let rc = unsafe { libc::waitid(libc::P_PID, pid as libc::id_t, &mut info, libc::WEXITED | libc::WNOWAIT) };
         if rc == 0 {
             return;
         }
@@ -77,7 +71,10 @@ fn members_marks_an_unreaped_leader_as_dead() {
         .iter()
         .find(|m| m.pid == pid)
         .unwrap_or_else(|| panic!("unreaped leader {pid} missing from {listed:?}"));
-    assert!(!is_alive(leader), "an exited, unreaped leader's token must resolve to Dead, not Alive");
+    assert!(
+        !is_alive(leader),
+        "an exited, unreaped leader's token must resolve to Dead, not Alive"
+    );
 
     let mut child = child;
     child.wait().expect("reap");
@@ -118,8 +115,203 @@ fn members_token_matches_a_live_read_of_the_same_pid() {
     let listed = members(pgid).expect("list the group");
     let leader = listed.iter().find(|m| m.pid == child.id()).expect("leader listed");
     let live = ProcessId::of(child.id()).found().expect("resolve the live leader");
-    assert_eq!(leader.token, live.start_token_raw(), "listing token must match a fresh live read");
+    assert_eq!(
+        leader.token,
+        live.start_token_raw(),
+        "listing token must match a fresh live read"
+    );
 
     let _ = child.kill();
     let _ = child.wait();
+}
+
+/// A group we own holds no refusers once SIGKILLed — and `state` really did deliver the
+/// signal, not just classify: the leader is dead afterward.
+#[test]
+fn state_of_an_owned_group_is_cleared_and_the_signal_was_real() {
+    use std::os::unix::process::CommandExt;
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .process_group(0)
+        .spawn()
+        .expect("spawn sleep");
+    let pgid = child.id() as i32;
+    assert!(
+        matches!(state(pgid, Signal::SIGKILL), GroupState::Cleared),
+        "a group we own must never report refusers"
+    );
+    let status = child.wait().expect("wait after state()'s own SIGKILL");
+    assert!(
+        !status.success(),
+        "state() must have actually delivered SIGKILL, not just probed, got {status:?}"
+    );
+}
+
+/// A group whose only member is our own unreaped zombie is cleared: there is nothing left
+/// running. This is the benign case macOS reports as EPERM.
+#[test]
+fn state_of_an_all_zombie_group_is_cleared() {
+    use std::os::unix::process::CommandExt;
+    let child = std::process::Command::new("true")
+        .process_group(0)
+        .spawn()
+        .expect("spawn true");
+    let pid = child.id();
+    await_zombie(pid);
+    assert!(
+        matches!(state(pid as i32, Signal::SIGKILL), GroupState::Cleared),
+        "a group holding only a zombie has nothing left to kill"
+    );
+    let mut child = child;
+    child.wait().expect("reap");
+}
+
+/// `classify_member`'s pure decision. Only `Liveness::Dead` skips the attempt (a panicking
+/// closure proves it); `Alive` AND `Unknown` both proceed to `reached()` and are classified
+/// identically from its answer — the fix for a guard-then-do inversion review caught
+/// (`classify_member`'s own doc comment has the full account). `Reached::Unknown` still needs
+/// a real permission-denying host (`hidepid`) to construct for real; exercised here directly.
+#[test]
+fn classify_member_is_total_over_liveness_and_reached() {
+    use super::{classify_member, MemberOutcome, Reached};
+    use crate::identity::Liveness;
+
+    assert!(matches!(
+        classify_member(1, Liveness::Dead, || panic!("must not reach for Dead")),
+        MemberOutcome::NotASurvivor
+    ));
+    for liveness in [Liveness::Alive, Liveness::Unknown] {
+        assert!(matches!(
+            classify_member(1, liveness, || Reached::Yes),
+            MemberOutcome::NotASurvivor
+        ));
+        assert!(matches!(
+            classify_member(1, liveness, || Reached::No),
+            MemberOutcome::Survivor(1)
+        ));
+        assert!(matches!(
+            classify_member(1, liveness, || Reached::Unknown),
+            MemberOutcome::Unassessable(1)
+        ));
+    }
+}
+
+/// `reconfirm_survivor`'s pure re-check, isolated from any real signal delivery: a
+/// `Survivor` is downgraded ONLY on a positive `Dead` disagreement — a denied reconfirmation
+/// (`Liveness::Unknown`) does NOT overturn the already-observed, authoritative `EPERM` a
+/// `Survivor` carries (see this function's own doc comment for why `Unknown` and `Dead` are
+/// not equivalent here, unlike an earlier round of this plan). `NotASurvivor`/`Unassessable`
+/// pass through untouched (the panicking closure proves no second check runs for them at all
+/// — there is nothing to reconfirm).
+#[test]
+fn reconfirm_survivor_downgrades_only_on_dead() {
+    use super::{reconfirm_survivor, MemberOutcome};
+    use crate::identity::Liveness;
+
+    assert!(matches!(
+        reconfirm_survivor(MemberOutcome::Survivor(1), || Liveness::Alive),
+        MemberOutcome::Survivor(1)
+    ));
+    assert!(matches!(
+        reconfirm_survivor(MemberOutcome::Survivor(1), || Liveness::Dead),
+        MemberOutcome::NotASurvivor
+    ));
+    // Unknown does NOT downgrade: a denied reconfirmation is weaker evidence than the
+    // already-observed EPERM, not a disagreement with it.
+    assert!(matches!(
+        reconfirm_survivor(MemberOutcome::Survivor(1), || Liveness::Unknown),
+        MemberOutcome::Survivor(1)
+    ));
+    assert!(matches!(
+        reconfirm_survivor(MemberOutcome::NotASurvivor, || panic!("must not recheck NotASurvivor")),
+        MemberOutcome::NotASurvivor
+    ));
+    assert!(matches!(
+        reconfirm_survivor(MemberOutcome::Unassessable(1), || panic!(
+            "must not recheck Unassessable"
+        )),
+        MemberOutcome::Unassessable(1)
+    ));
+}
+
+/// `decide`'s pure priority ordering, isolated from any real listing: a known refusal beats
+/// an unresolved member, which beats a clean group — and neither a refuser nor an
+/// unassessable member is ever silently dropped when both are present at once.
+#[test]
+fn decide_prioritizes_refused_over_unassessable_over_cleared() {
+    use super::{decide, GroupState};
+
+    assert!(matches!(
+        decide(1, Signal::SIGKILL, vec![], vec![]),
+        GroupState::Cleared
+    ));
+    match decide(1, Signal::SIGKILL, vec![], vec![5]) {
+        GroupState::Unlistable { detail, .. } => assert!(detail.contains('5'), "got {detail:?}"),
+        other => panic!("expected Unlistable, got {other:?}"),
+    }
+    match decide(1, Signal::SIGKILL, vec![7], vec![5]) {
+        GroupState::Refused { refused, unassessable } => {
+            assert_eq!(
+                refused,
+                vec![7],
+                "a known refuser must not be lost to an unassessable member"
+            );
+            assert_eq!(
+                unassessable,
+                vec![5],
+                "the unassessable member must not be silently dropped either"
+            );
+        }
+        other => panic!("expected Refused, got {other:?}"),
+    }
+}
+
+/// `term_group`'s probe path against pid 1 — the one live, unsignalable-by-an-unprivileged-
+/// caller process every Unix host has. Safe to run for real: `state(pgid, SIGTERM)` on this
+/// pgid only ever *probes* (`kill(pid, 0)`) because `SIGTERM` never triggers this task's
+/// resend path — no signal is delivered to `launchd`/`init` or its group siblings, on any
+/// host, root or not. This exercises the ACTUAL production `state` function, not a parallel
+/// test-only probe. The expectation comes from POSIX (an unprivileged process may not signal
+/// one owned by another user) plus the host's own answer to "who owns pid 1", and it is
+/// total: a root caller, or a host where pid 1 is ours, gets the complementary assertion.
+///
+/// **`reachable` is asked directly of the kernel, not derived from a hand-reconstructed
+/// permission rule.**
+#[test]
+fn term_group_probe_reports_pid_1_as_a_refuser_unless_reachable() {
+    let pgid = nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(1)))
+        .expect("pid 1 has a process group")
+        .as_raw();
+    // SAFETY: pid 1 always exists; signal 0 sends no signal, only performs the kernel's own
+    // permission check — this is the independent oracle, a syscall issued directly by the
+    // test, not a call into any function this plan adds or modifies.
+    let reachable = unsafe { libc::kill(1, 0) } == 0;
+    match (state(pgid, Signal::SIGTERM), reachable) {
+        (GroupState::Refused { refused, .. }, false) => {
+            assert!(
+                refused.contains(&1),
+                "pid 1 must be reported as a refuser, got {refused:?}"
+            );
+        }
+        (GroupState::Cleared, true) => {}
+        (got, reachable) => panic!("pid 1 owned by uid {}, reachable={reachable}: got {got:?}", pid1_uid()),
+    }
+}
+
+/// The real uid of pid 1, read from an oracle independent of this module.
+#[cfg(target_os = "linux")]
+fn pid1_uid() -> u32 {
+    let status = std::fs::read_to_string("/proc/1/status").expect("read /proc/1/status");
+    status
+        .lines()
+        .find_map(|l| l.strip_prefix("Uid:"))
+        .and_then(|v| v.split_whitespace().next())
+        .and_then(|v| v.parse().ok())
+        .expect("Uid: line in /proc/1/status")
+}
+
+/// macOS pid 1 is always `launchd`, started by the kernel as root.
+#[cfg(target_os = "macos")]
+fn pid1_uid() -> u32 {
+    0
 }

--- a/src/containment/unix/group_tests.rs
+++ b/src/containment/unix/group_tests.rs
@@ -1,0 +1,125 @@
+// Unit tests for process-group membership listing and the identity it carries.
+
+use super::{members, Member};
+use crate::identity::{Liveness, ProcessId};
+
+fn is_alive(m: &Member) -> bool {
+    matches!(ProcessId::from_parts(m.pid, m.token).is_alive(), Liveness::Alive)
+}
+
+/// Block until `pid` has exited, leaving it UNREAPED so it is a zombie the
+/// kernel still lists in its process group. `waitid(WEXITED | WNOWAIT)` is the
+/// real primitive for this — nothing here is timed. `nix` does not expose
+/// `waitid` on macOS (0.31 configures it out), so call `libc` directly,
+/// following `src/tokio/child.rs:488-506`'s idiom — including its EINTR
+/// retry, so a stray signal to the test process fails the wait, not the test.
+fn await_zombie(pid: u32) {
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    loop {
+        // SAFETY: a well-formed `waitid` call; `info` is a valid, owned, zeroed
+        // `siginfo_t` the kernel fills in. WNOWAIT leaves the child reapable.
+        let rc = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if rc == 0 {
+            return;
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        panic!("waitid failed: {err}");
+    }
+}
+
+/// A group we lead lists the member we put in it, with a token that resolves to Alive.
+#[test]
+fn members_lists_a_live_owned_group() {
+    use std::os::unix::process::CommandExt;
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .process_group(0)
+        .spawn()
+        .expect("spawn sleep");
+    let pgid = child.id() as i32;
+
+    let listed = members(pgid).expect("list the group");
+    let leader = listed
+        .iter()
+        .find(|m| m.pid == child.id())
+        .unwrap_or_else(|| panic!("leader {} missing from {listed:?}", child.id()));
+    assert!(is_alive(leader), "a running leader's token must resolve to Alive");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Once the leader has exited unreaped, the kernel still lists it in the group,
+/// and its token must resolve to Dead (zombie) — the state that makes an EPERM
+/// answer meaningless.
+#[test]
+fn members_marks_an_unreaped_leader_as_dead() {
+    use std::os::unix::process::CommandExt;
+    let child = std::process::Command::new("true")
+        .process_group(0)
+        .spawn()
+        .expect("spawn true");
+    let pid = child.id();
+    await_zombie(pid);
+
+    let listed = members(pid as i32).expect("list the group");
+    let leader = listed
+        .iter()
+        .find(|m| m.pid == pid)
+        .unwrap_or_else(|| panic!("unreaped leader {pid} missing from {listed:?}"));
+    assert!(!is_alive(leader), "an exited, unreaped leader's token must resolve to Dead, not Alive");
+
+    let mut child = child;
+    child.wait().expect("reap");
+}
+
+/// A pgid with no members at all lists nothing, and that is not an error. Uses `i32::MAX`
+/// (2147483647), not a forward scan from the test's own pid: an earlier draft scanned
+/// upward and asserted on the exact predicate the scan itself already satisfied — a
+/// tautology proving nothing beyond what the helper's own loop condition already
+/// established, AND a genuine (if narrow) check-then-act gap, since the scanned range is
+/// exactly where the kernel's allocator is likely to hand out a NEW pid next, including to
+/// this crate's own sibling tests, several of which spawn `process_group(0)` children whose
+/// pgid == their pid. `i32::MAX` cannot collide: measured directly on this host,
+/// `sysctl(KERN_PROC_PGRP, i32::MAX)` returns `rc=0` with zero actual records (confirming no
+/// real pid/pgid is ever allocated anywhere near it — `kern.maxproc`/`pid_max` stay far
+/// below `2^31` on every real system), so this is a fixed value, not a scan, and the
+/// assertion is a genuine independent check rather than a restatement of the fixture.
+#[test]
+fn members_of_an_absent_group_is_empty() {
+    assert_eq!(members(i32::MAX).expect("list an absent group"), vec![]);
+}
+
+/// The token the listing carries is the SAME encoding a live read of the pid would produce —
+/// not a different, incompatible one — so a later `ProcessId::from_parts` re-check is
+/// comparing like with like. (macOS: pinned across `proc_pidinfo` and `sysctl` by the
+/// existing `kinfo_tests` cross-source oracle; this test pins the listing itself against
+/// `ProcessId::of`'s live read, on both platforms.)
+#[test]
+fn members_token_matches_a_live_read_of_the_same_pid() {
+    use std::os::unix::process::CommandExt;
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .process_group(0)
+        .spawn()
+        .expect("spawn sleep");
+    let pgid = child.id() as i32;
+
+    let listed = members(pgid).expect("list the group");
+    let leader = listed.iter().find(|m| m.pid == child.id()).expect("leader listed");
+    let live = ProcessId::of(child.id()).found().expect("resolve the live leader");
+    assert_eq!(leader.token, live.start_token_raw(), "listing token must match a fresh live read");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/src/containment/unix/group_tests.rs
+++ b/src/containment/unix/group_tests.rs
@@ -12,8 +12,9 @@ fn is_alive(m: &Member) -> bool {
 /// kernel still lists in its process group. `waitid(WEXITED | WNOWAIT)` is the
 /// real primitive for this — nothing here is timed. `nix` does not expose
 /// `waitid` on macOS (0.31 configures it out), so call `libc` directly,
-/// following `src/tokio/child.rs:488-506`'s idiom — including its EINTR
-/// retry, so a stray signal to the test process fails the wait, not the test.
+/// following the same `waitid(WEXITED | WNOWAIT)` idiom `reap_now` uses in
+/// `src/tokio/child.rs` — including its EINTR retry, so a stray signal to the
+/// test process fails the wait, not the test.
 fn await_zombie(pid: u32) {
     let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
     loop {
@@ -81,13 +82,13 @@ fn members_marks_an_unreaped_leader_as_dead() {
 }
 
 /// A pgid with no members at all lists nothing, and that is not an error. Uses `i32::MAX`
-/// (2147483647), not a forward scan from the test's own pid: an earlier draft scanned
-/// upward and asserted on the exact predicate the scan itself already satisfied — a
-/// tautology proving nothing beyond what the helper's own loop condition already
-/// established, AND a genuine (if narrow) check-then-act gap, since the scanned range is
-/// exactly where the kernel's allocator is likely to hand out a NEW pid next, including to
-/// this crate's own sibling tests, several of which spawn `process_group(0)` children whose
-/// pgid == their pid. `i32::MAX` cannot collide: measured directly on this host,
+/// (2147483647), not a forward scan from the test's own pid: a forward scan would assert on
+/// the exact predicate the scan itself already satisfied — a tautology proving nothing beyond
+/// what the loop condition already established — AND a genuine (if narrow) check-then-act
+/// gap, since the scanned range is exactly where the kernel's allocator is likely to hand out
+/// a NEW pid next, including to this crate's own sibling tests, several of which spawn
+/// `process_group(0)` children whose pgid == their pid. `i32::MAX` cannot collide: measured
+/// directly on this host,
 /// `sysctl(KERN_PROC_PGRP, i32::MAX)` returns `rc=0` with zero actual records (confirming no
 /// real pid/pgid is ever allocated anywhere near it — `kern.maxproc`/`pid_max` stay far
 /// below `2^31` on every real system), so this is a fixed value, not a scan, and the
@@ -200,9 +201,8 @@ fn classify_member_is_total_over_liveness_and_reached() {
 /// `Survivor` is downgraded ONLY on a positive `Dead` disagreement — a denied reconfirmation
 /// (`Liveness::Unknown`) does NOT overturn the already-observed, authoritative `EPERM` a
 /// `Survivor` carries (see this function's own doc comment for why `Unknown` and `Dead` are
-/// not equivalent here, unlike an earlier round of this plan). `NotASurvivor`/`Unassessable`
-/// pass through untouched (the panicking closure proves no second check runs for them at all
-/// — there is nothing to reconfirm).
+/// not equivalent here). `NotASurvivor`/`Unassessable` pass through untouched (the panicking
+/// closure proves no second check runs for them at all — there is nothing to reconfirm).
 #[test]
 fn reconfirm_survivor_downgrades_only_on_dead() {
     use super::{reconfirm_survivor, MemberOutcome};
@@ -264,6 +264,28 @@ fn decide_prioritizes_refused_over_unassessable_over_cleared() {
         }
         other => panic!("expected Refused, got {other:?}"),
     }
+}
+
+/// `excluded_from_sigkill_resend`'s pure predicate, isolated from any real listing or signal:
+/// pid 1 is excluded regardless of `system`, a `system`-flagged pid is excluded regardless of
+/// its number, and an ordinary user pid is excluded by neither rule.
+#[test]
+fn excluded_from_sigkill_resend_covers_pid_1_and_system_independently() {
+    use super::excluded_from_sigkill_resend;
+
+    assert!(excluded_from_sigkill_resend(1, false), "pid 1 must be excluded");
+    assert!(
+        excluded_from_sigkill_resend(1, true),
+        "pid 1 must be excluded even if also flagged system"
+    );
+    assert!(
+        excluded_from_sigkill_resend(12345, true),
+        "a system-flagged pid other than 1 must be excluded"
+    );
+    assert!(
+        !excluded_from_sigkill_resend(12345, false),
+        "an ordinary, non-system pid must not be excluded"
+    );
 }
 
 /// `term_group`'s probe path against pid 1 — the one live, unsignalable-by-an-unprivileged-

--- a/src/containment/unix_tests.rs
+++ b/src/containment/unix_tests.rs
@@ -4,33 +4,64 @@
 
 use super::{kill_group, term_group};
 
-// Spawn a short-lived child, retrieve its pid, wait for it to exit, then
-// return the pid of the (now-dead, reaped) process so callers can target a
-// genuinely ESRCH-inducing pgid.
-fn dead_pid() -> i32 {
-    let mut child = std::process::Command::new("true").spawn().expect("spawn true");
-    let pid = child.id() as i32;
-    child.wait().expect("wait true");
-    pid
+// This file deliberately has NO "absent group" test that calls kill_group/term_group on a
+// scanned-forward or freshly-reaped pgid. Once these functions unconditionally verify (this
+// task's note above), they always list whatever pgid they are given and SIGNAL whatever
+// `converge` finds there — so aiming one at a guessed-empty pgid is a check-then-act race
+// against the kernel's own pid allocator (which favors exactly the small, recently-used
+// numbers such a guess would produce) and against this crate's own sibling tests, several of
+// which spawn `process_group(0)` children (pgid == pid). A collision would deliver a REAL
+// SIGKILL to an unrelated process. That coverage is not missing: `converge`'s "empty result
+// list ⇒ Cleared" path is identical whether the listing found zero members or one member
+// `classify_member` immediately drops as `NotASurvivor` (Task 4's pure
+// `classify_member_is_total_over_liveness` test proves the classification directly, with no
+// listing involved at all), and `kill_group_on_an_all_zombie_group_is_ok`/
+// `term_group_on_an_all_zombie_group_is_ok` below exercise that exact shape through the real
+// public API, end to end, without ever risking a signal to a pgid this test does not own.
+
+// Block until `pid` has exited WITHOUT reaping it, so it stays a zombie the
+// kernel still lists in its process group. Nothing here is timed. Retries on
+// EINTR, matching src/tokio/child.rs:488-506's idiom, so a stray signal to
+// the test process fails the wait, not the test.
+fn await_zombie(pid: u32) {
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    loop {
+        // SAFETY: a well-formed `waitid` call; `info` is a valid, owned, zeroed
+        // `siginfo_t` the kernel fills in. WNOWAIT leaves the child reapable.
+        let rc = unsafe { libc::waitid(libc::P_PID, pid as libc::id_t, &mut info, libc::WEXITED | libc::WNOWAIT) };
+        if rc == 0 {
+            return;
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        panic!("waitid failed: {err}");
+    }
 }
 
-/// kill_group with an ESRCH pgid (process already gone) must return Ok — the
-/// goal is "gone" and it already is.
+/// `pgid <= 0` must be rejected before any signal is sent — 0 addresses the CALLER's own
+/// process group (POSIX), and a negative value is the broadcast/double-negation hazard this
+/// plan's Background measures. Safe to test directly: no real process or process group is
+/// involved, and a correct implementation never reaches the `killpg`/`signal_direct` calls
+/// this guards, so there is nothing to signal even if the test is wrong.
 #[test]
-fn kill_group_esrch_is_ok() {
-    // Use a real reaped PID rather than an arbitrary magic number, so the kernel
-    // genuinely returns ESRCH (no process in that group, not EPERM).
-    assert!(kill_group(dead_pid()).is_ok());
+fn kill_group_and_term_group_reject_non_positive_pgid() {
+    for pgid in [0, -1, i32::MIN] {
+        let kill_err = kill_group(pgid).expect_err("kill_group(non-positive) must be Err");
+        assert!(
+            matches!(kill_err, crate::error::Error::Unassessable { .. }),
+            "got {kill_err:?}"
+        );
+        let term_err = term_group(pgid).expect_err("term_group(non-positive) must be Err");
+        assert!(
+            matches!(term_err, crate::error::Error::Unassessable { .. }),
+            "got {term_err:?}"
+        );
+    }
 }
 
-/// term_group with an ESRCH pgid must return Ok.
-#[test]
-fn term_group_esrch_is_ok() {
-    assert!(term_group(dead_pid()).is_ok());
-}
-
-/// kill_group on a real owned process group succeeds; the dead-group ESRCH arm
-/// is also exercised after the child is reaped.
+/// kill_group on a real owned process group succeeds, and really did kill it.
 #[test]
 fn kill_group_on_owned_group_succeeds() {
     use std::os::unix::process::CommandExt;
@@ -43,10 +74,115 @@ fn kill_group_on_owned_group_succeeds() {
         .expect("spawn sleep");
     let pgid = child.id() as i32;
     assert!(kill_group(pgid).is_ok(), "kill_group on owned group must succeed");
-    let _ = child.wait();
-    // After reaping, the same pgid is gone — ESRCH arm must also return Ok.
+    let status = child.wait().expect("wait after kill_group");
     assert!(
-        kill_group(pgid).is_ok(),
-        "kill_group on dead group must still be Ok (ESRCH)"
+        !status.success(),
+        "kill_group must have actually killed the leader, got {status:?}"
     );
+}
+
+/// `term_group` on a real owned, LIVE (non-zombie) group succeeds, and the leader really did
+/// exit because of the delivered `SIGTERM` — not merely because it stayed reachable.
+/// Previously undertested (review): the only prior `term_group` coverage besides the
+/// pgid-guard test was the all-zombie case; the actual real-delivery half of `term_group` —
+/// the initial `killpg(pgid, SIGTERM)` inside `signal_group`, which is the ONLY place a real
+/// SIGTERM is ever sent (`converge`'s own SIGTERM path deliberately only probes,
+/// never resends) — had no test proving delivery landed. Without this, a broken initial
+/// `killpg` call (wrong signal constant, call removed, argument order swapped) would still
+/// pass every other `term_group` test: the probe would confirm the leader is reachable,
+/// `converge` would report `Cleared`, and `term_group` would return `Ok(())` while the leader
+/// stayed alive — exactly the false-`Ok` class #61 exists to close, on the one path with no
+/// closer until now.
+#[test]
+fn term_group_on_owned_group_succeeds() {
+    use std::os::unix::process::CommandExt;
+    // `sleep` has no SIGTERM handler of its own, so a delivered SIGTERM actually ends it —
+    // distinguishing "exited because of the signal" from "merely stayed reachable".
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .process_group(0)
+        .spawn()
+        .expect("spawn sleep");
+    let pgid = child.id() as i32;
+    assert!(term_group(pgid).is_ok(), "term_group on owned group must succeed");
+    let status = child.wait().expect("wait after term_group");
+    assert!(
+        !status.success(),
+        "term_group must have actually delivered SIGTERM and ended the leader, got {status:?}"
+    );
+}
+
+/// The benign half of the bug. A group whose only member is an unreaped zombie
+/// has nothing left to kill, so teardown of it is honestly `Ok`.
+///
+/// On macOS this is the arm that made the bug hard: xnu excludes zombies from
+/// the pgrp iteration before counting, so `killpg` reports EPERM for what is
+/// really an empty group. The assertion below pins that, so the test cannot
+/// quietly stop exercising the interesting path.
+#[test]
+fn kill_group_on_an_all_zombie_group_is_ok() {
+    use std::os::unix::process::CommandExt;
+    let child = std::process::Command::new("true")
+        .process_group(0)
+        .spawn()
+        .expect("spawn true");
+    let pid = child.id();
+    await_zombie(pid);
+
+    #[cfg(target_os = "macos")]
+    assert_eq!(
+        nix::sys::signal::killpg(nix::unistd::Pid::from_raw(pid as i32), None),
+        Err(nix::errno::Errno::EPERM),
+        "macOS reports EPERM for an all-zombie group; if this changed, the arm under test moved"
+    );
+
+    assert!(
+        kill_group(pid as i32).is_ok(),
+        "a group holding only a zombie is already down"
+    );
+    let mut child = child;
+    child.wait().expect("reap");
+}
+
+/// Same, for the graceful signal. Same arm-pinning assertion as
+/// `kill_group_on_an_all_zombie_group_is_ok` above, for the same reason: without it, a
+/// future change to macOS's zombie-exclusion behavior (or a Linux-vs-macOS divergence
+/// change) could leave this test passing on `term_group`'s own answer alone while silently
+/// no longer exercising the branch it documents.
+#[test]
+fn term_group_on_an_all_zombie_group_is_ok() {
+    use std::os::unix::process::CommandExt;
+    let child = std::process::Command::new("true")
+        .process_group(0)
+        .spawn()
+        .expect("spawn true");
+    let pid = child.id();
+    await_zombie(pid);
+
+    #[cfg(target_os = "macos")]
+    assert_eq!(
+        nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGTERM
+        ),
+        Err(nix::errno::Errno::EPERM),
+        "macOS reports EPERM for an all-zombie group; if this changed, the arm under test moved"
+    );
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGTERM
+        ),
+        Ok(()),
+        "Linux reports Ok for an all-zombie group (no live member to refuse); if this changed, \
+         the arm under test moved"
+    );
+
+    assert!(
+        term_group(pid as i32).is_ok(),
+        "a group holding only a zombie is already down"
+    );
+    let mut child = child;
+    child.wait().expect("reap");
 }

--- a/src/containment/unix_tests.rs
+++ b/src/containment/unix_tests.rs
@@ -13,7 +13,7 @@ use super::{kill_group, term_group};
 // which spawn `process_group(0)` children (pgid == pid). A collision would deliver a REAL
 // SIGKILL to an unrelated process. That coverage is not missing: `converge`'s "empty result
 // list ⇒ Cleared" path is identical whether the listing found zero members or one member
-// `classify_member` immediately drops as `NotASurvivor` (Task 4's pure
+// `classify_member` immediately drops as `NotASurvivor` (the pure
 // `classify_member_is_total_over_liveness` test proves the classification directly, with no
 // listing involved at all), and `kill_group_on_an_all_zombie_group_is_ok`/
 // `term_group_on_an_all_zombie_group_is_ok` below exercise that exact shape through the real
@@ -21,8 +21,9 @@ use super::{kill_group, term_group};
 
 // Block until `pid` has exited WITHOUT reaping it, so it stays a zombie the
 // kernel still lists in its process group. Nothing here is timed. Retries on
-// EINTR, matching src/tokio/child.rs:488-506's idiom, so a stray signal to
-// the test process fails the wait, not the test.
+// EINTR, matching the `waitid(WEXITED | WNOWAIT)` idiom `reap_now` uses in
+// `src/tokio/child.rs`, so a stray signal to the test process fails the wait,
+// not the test.
 fn await_zombie(pid: u32) {
     let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
     loop {

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -150,6 +150,11 @@ impl ProcessId {
 #[cfg(windows)]
 pub(crate) use backend::{close as windows_close, open_classified as windows_open_classified, Opened};
 
+/// The `kinfo_proc` ABI is defined once, here, behind the size tripwires in
+/// `macos/kinfo.rs`. Containment's process-group listing reads it too.
+#[cfg(target_os = "macos")]
+pub(crate) use backend::kinfo;
+
 /// What an ALREADY-OPEN Windows handle says about an identity. The held handle pins the
 /// kernel object, so this is pid-reuse-safe (unlike re-resolving by raw pid).
 #[cfg(windows)]

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -86,14 +86,29 @@ impl ProcessId {
         backend::start_token(pid).map(|start| ProcessId { pid, start })
     }
 
-    /// Test-only constructor from raw parts, so sibling modules can build
-    /// synthetic identities (with chosen pid/token) without a live process.
-    #[cfg(test)]
-    pub(crate) fn from_parts_for_test(pid: RawPid, token: u64) -> ProcessId {
+    /// Build a `ProcessId` from an already-known `(pid, raw start token)` pair, without a
+    /// live read. Used where the pair was already read as part of a larger record — the
+    /// containment group listing reads a member's start token in the very sysctl/proc record
+    /// it reads the pid from, and a second, separate read to re-derive it would itself race
+    /// against the pid-reuse hazard this type exists to catch.
+    ///
+    /// `cfg(any(unix, test))`: the only non-test caller (`containment::unix::group`) is
+    /// Unix-only, so a Windows *release* build has no caller for this at all — gated to avoid
+    /// a `dead_code` warning there (`cargo build --target *-pc-windows-msvc` is a real CI job,
+    /// `ci.yaml:82`, and this crate is otherwise warning-clean). Still available under
+    /// `cfg(test)` on every platform, because `from_parts_for_test` below calls it everywhere.
+    #[cfg(any(unix, test))]
+    pub(crate) fn from_parts(pid: RawPid, token: u64) -> ProcessId {
         ProcessId {
             pid,
             start: StartToken::from_raw(token),
         }
+    }
+
+    /// Test-only alias, kept so the many existing test call sites need no rename.
+    #[cfg(test)]
+    pub(crate) fn from_parts_for_test(pid: RawPid, token: u64) -> ProcessId {
+        Self::from_parts(pid, token)
     }
 
     /// This process's own identity. Windows reads the current-process pseudo-handle, which

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -95,7 +95,7 @@ impl ProcessId {
     /// `cfg(any(unix, test))`: the only non-test caller (`containment::unix::group`) is
     /// Unix-only, so a Windows *release* build has no caller for this at all — gated to avoid
     /// a `dead_code` warning there (`cargo build --target *-pc-windows-msvc` is a real CI job,
-    /// `ci.yaml:82`, and this crate is otherwise warning-clean). Still available under
+    /// and this crate is otherwise warning-clean). Still available under
     /// `cfg(test)` on every platform, because `from_parts_for_test` below calls it everywhere.
     #[cfg(any(unix, test))]
     pub(crate) fn from_parts(pid: RawPid, token: u64) -> ProcessId {

--- a/src/identity/macos.rs
+++ b/src/identity/macos.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, SystemTime};
 use super::{Liveness, RawPid, Resolved, StartToken};
 
 #[path = "macos/kinfo.rs"]
-mod kinfo;
+pub(crate) mod kinfo;
 
 fn bsd_info(pid: RawPid) -> Option<libc::proc_bsdinfo> {
     let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };

--- a/src/identity/macos/kinfo.rs
+++ b/src/identity/macos/kinfo.rs
@@ -9,21 +9,21 @@ use super::super::{RawPid, Resolved};
 
 /// `struct kinfo_proc` (LP64): `extern_proc` head + opaque `eproc` tail.
 #[repr(C)]
-pub(super) struct kinfo_proc {
-    pub(super) kp_proc: extern_proc,
+pub(crate) struct kinfo_proc {
+    pub(crate) kp_proc: extern_proc,
     kp_eproc: [u8; 352],
 }
 
 /// `struct extern_proc` (LP64 user copy, from XNU's proc.h). Kernel pointers are
 /// represented as `u64` (they are opaque user_addr_t values in the sysctl copy).
 #[repr(C)]
-pub(super) struct extern_proc {
-    pub(super) p_un: p_un,
+pub(crate) struct extern_proc {
+    pub(crate) p_un: p_un,
     p_vmspace: u64,
     p_sigacts: u64,
     p_flag: libc::c_int,
     pub(super) p_stat: libc::c_char,
-    p_pid: libc::pid_t,
+    pub(crate) p_pid: libc::pid_t,
     p_oppid: libc::pid_t,
     p_dupfd: libc::c_int,
     user_stack: u64,
@@ -62,9 +62,9 @@ pub(super) struct extern_proc {
 }
 
 #[repr(C)]
-pub(super) union p_un {
+pub(crate) union p_un {
     p_st1: run_sleep_queue,
-    pub(super) p_starttime: libc::timeval,
+    pub(crate) p_starttime: libc::timeval,
 }
 
 #[repr(C)]

--- a/src/identity/macos/kinfo.rs
+++ b/src/identity/macos/kinfo.rs
@@ -21,7 +21,7 @@ pub(crate) struct extern_proc {
     pub(crate) p_un: p_un,
     p_vmspace: u64,
     p_sigacts: u64,
-    p_flag: libc::c_int,
+    pub(crate) p_flag: libc::c_int,
     pub(super) p_stat: libc::c_char,
     pub(crate) p_pid: libc::pid_t,
     p_oppid: libc::pid_t,
@@ -85,6 +85,15 @@ struct itimerval {
 // against the running kernel.
 const _: () = assert!(std::mem::size_of::<kinfo_proc>() == 648);
 const _: () = assert!(std::mem::size_of::<extern_proc>() == 296);
+
+/// `p_flag`'s "system process" bit, source-verified against the Xcode Command Line Tools
+/// SDK: `#define P_SYSTEM 0x00000200` in `usr/include/sys/proc.h`. xnu's `killpg1` excludes
+/// it from a process-group signal alongside — but independently of — `initproc` (pid 1),
+/// confirmed against xnu's own `bsd/kern/kern_sig.c`. `containment::unix::group` restates
+/// both exclusions (`excluded_from_sigkill_resend`). `kinfo_tests.rs` cross-checks this bit's
+/// value against a second, independently-issued sysctl query and, where a live process allows
+/// it, `proc_pidinfo`'s own `PROC_FLAG_SYSTEM` bit.
+pub(crate) const P_SYSTEM: libc::c_int = 0x00000200;
 
 /// Read one `kinfo_proc` for `pid`. `None` means "not resolvable" — the EXPECTED miss is
 /// a nonexistent pid (sysctl SUCCESS with `size == 0`); a real sysctl failure or a

--- a/src/identity/macos/kinfo_tests.rs
+++ b/src/identity/macos/kinfo_tests.rs
@@ -99,3 +99,112 @@ fn sysctl_token_matches_libproc_for_a_live_process() {
 
     assert_eq!(ours, theirs, "sysctl and libproc disagree on self's start token");
 }
+
+// Value oracle for `P_SYSTEM`. On this host (and every recent Darwin release checked, up to
+// 26.5.2), `kernproc` (pid 0) is the ONLY process carrying the flag — not `launchd`/`initproc`
+// (pid 1), which xnu's `killpg1` excludes from a process-group signal by a direct `p ==
+// initproc` pointer check, entirely separate from its `P_SYSTEM` test (confirmed against
+// xnu's own `bsd/kern/kern_sig.c`). `libc::proc_pidinfo` cannot serve as an oracle for either
+// root-owned pid measured here (pid 0 or pid 1): it fails to resolve a foreign-uid process
+// without root, the same as it fails for pid 0. The positive case (pid 0) is instead
+// cross-checked against a second, independently-issued sysctl call reading the WHOLE process
+// table (`KERN_PROC_ALL`, a different selector/code path from `kinfo()`'s own `KERN_PROC_PID`)
+// rather than trusting one query alone. The negative case is checked for both pid 1 (sysctl
+// only) and this test's own process — the latter additionally cross-checked against
+// `proc_pidinfo`'s independently-defined `PROC_FLAG_SYSTEM` (`sys/proc_info.h`, no `libc`
+// crate constant, restated here as a local, source-cited value).
+#[test]
+fn p_flag_system_bit_matches_a_second_sysctl_query_and_libproc_disagrees_for_non_system() {
+    const PROC_FLAG_SYSTEM: u32 = 1;
+
+    // Positive: kernproc (pid 0), read via `kinfo()` (production code path, KERN_PROC_PID).
+    let crate::identity::Resolved::Found(k) = kinfo(0) else {
+        panic!("pid 0 (kernproc) resolves via sysctl KERN_PROC_PID");
+    };
+    assert!(
+        k.kp_proc.p_flag & P_SYSTEM != 0,
+        "kernproc (pid 0) must be P_SYSTEM-flagged via KERN_PROC_PID"
+    );
+
+    // Cross-check: an independently-issued KERN_PROC_ALL scan must agree pid 0 carries the
+    // same bit — a different selector/code path from the KERN_PROC_PID query above.
+    let mut mib = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_ALL, 0];
+    let mut len: libc::size_t = 0;
+    // SAFETY: a size query — null buffer, `len` receives the byte count.
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            std::ptr::null_mut(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    assert_eq!(
+        rc,
+        0,
+        "KERN_PROC_ALL sizing query failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let record = std::mem::size_of::<kinfo_proc>();
+    let mut buf: Vec<kinfo_proc> = Vec::with_capacity(len / record + 8);
+    let mut got = buf.capacity() * record;
+    // SAFETY: `buf` has room for `got` bytes of records; sysctl writes at most `got`.
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            buf.as_mut_ptr().cast(),
+            &mut got,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    assert_eq!(rc, 0, "KERN_PROC_ALL fetch failed: {}", std::io::Error::last_os_error());
+    // SAFETY: sysctl initialised exactly `got / record` whole records.
+    unsafe { buf.set_len(got / record) };
+    let kernproc = buf
+        .iter()
+        .find(|k| k.kp_proc.p_pid == 0)
+        .expect("pid 0 (kernproc) present in a KERN_PROC_ALL scan");
+    assert!(
+        kernproc.kp_proc.p_flag & P_SYSTEM != 0,
+        "kernproc (pid 0) must be P_SYSTEM-flagged via the independent KERN_PROC_ALL scan too"
+    );
+
+    // Negative, sysctl-only: neither pid 1 (launchd, root-owned) nor this test process is
+    // P_SYSTEM-flagged. `proc_pidinfo` cannot cross-check pid 1 here — measured, it also
+    // fails to resolve a foreign-uid pid without root, same as it fails for pid 0 above — so
+    // only this test's own pid gets the `proc_pidinfo` cross-check, right below.
+    for pid in [1, std::process::id() as libc::c_int] {
+        let crate::identity::Resolved::Found(k) = kinfo(pid as super::super::RawPid) else {
+            panic!("pid {pid} resolves via sysctl");
+        };
+        assert!(
+            k.kp_proc.p_flag & P_SYSTEM == 0,
+            "pid {pid} must not be P_SYSTEM-flagged via sysctl"
+        );
+    }
+
+    // Negative, cross-checked: this test process itself is not PROC_FLAG_SYSTEM-flagged
+    // either, via proc_pidinfo's independently-defined bit.
+    let me = std::process::id() as libc::c_int;
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    // SAFETY: proc_pidinfo writes up to `size` bytes into `info`.
+    let n = unsafe {
+        libc::proc_pidinfo(
+            me,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    assert_eq!(n, size, "proc_pidinfo oracle failed for self");
+    assert!(
+        info.pbi_flags & PROC_FLAG_SYSTEM == 0,
+        "this test process must not be PROC_FLAG_SYSTEM-flagged via proc_pidinfo"
+    );
+}

--- a/src/identity/stat_parse.rs
+++ b/src/identity/stat_parse.rs
@@ -14,7 +14,7 @@ fn tail(stat: &[u8]) -> Option<&str> {
 }
 
 /// Field 22 (`starttime`) as RAW jiffies since boot.
-pub(super) fn parse_starttime_jiffies(stat: &[u8]) -> Option<u64> {
+pub(crate) fn parse_starttime_jiffies(stat: &[u8]) -> Option<u64> {
     tail(stat)?.split_whitespace().nth(19)?.parse::<u64>().ok()
 }
 
@@ -27,6 +27,12 @@ pub(super) fn parse_state(stat: &[u8]) -> Option<u8> {
 /// containment tree-walk's `/proc` enumerator; comm-safe via the same anchor.
 pub(crate) fn parse_ppid(stat: &[u8]) -> Option<u32> {
     tail(stat)?.split_whitespace().nth(1)?.parse::<u32>().ok()
+}
+
+/// Field 5 (`pgrp`, index 2 of the tail) — the process-group id. Used by the
+/// containment group-membership listing; comm-safe via the same anchor.
+pub(crate) fn parse_pgrp(stat: &[u8]) -> Option<u32> {
+    tail(stat)?.split_whitespace().nth(2)?.parse::<u32>().ok()
 }
 
 /// Decide whether a process is *running* from its raw `/proc/<pid>/stat` bytes: the

--- a/src/identity/stat_parse_tests.rs
+++ b/src/identity/stat_parse_tests.rs
@@ -1,5 +1,5 @@
 use super::super::StartToken;
-use super::{parse_ppid, parse_starttime_jiffies, parse_state, running_from_stat};
+use super::{parse_pgrp, parse_ppid, parse_starttime_jiffies, parse_state, running_from_stat};
 use crate::identity::Liveness;
 
 fn tok(v: u64) -> StartToken {
@@ -41,6 +41,27 @@ fn parses_ppid_with_comm_containing_parens_and_spaces() {
 fn ppid_rejects_truncated_stat() {
     let stat = b"1 (init) S"; // no ppid token after the state
     assert_eq!(parse_ppid(stat), None);
+}
+
+/// Field 5 is the process-group id. Offsets are anchored on the last ')', so a
+/// comm containing spaces and parens must not shift the answer.
+#[test]
+fn parse_pgrp_reads_field_five() {
+    // pid 1234, comm "sh", state S, ppid 1, pgrp 4321, session 4321, ...
+    let stat = b"1234 (sh) S 1 4321 4321 0 -1 4194304 100 0 0 0 1 2 3 4 20 0 1 0 987 0 0";
+    assert_eq!(parse_pgrp(stat), Some(4321));
+}
+
+#[test]
+fn parse_pgrp_survives_a_hostile_comm() {
+    let stat = b"1234 (evil ) S 9 9 9) S 1 4321 4321 0 -1 4194304 100 0 0 0 1 2 3 4 20 0 1 0 987 0 0";
+    assert_eq!(parse_pgrp(stat), Some(4321));
+}
+
+#[test]
+fn parse_pgrp_rejects_a_truncated_record() {
+    assert_eq!(parse_pgrp(b"1234 (sh) S 1"), None);
+    assert_eq!(parse_pgrp(b"no parens here"), None);
 }
 
 #[test]

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -367,8 +367,39 @@ impl Child {
     /// Hard-kill the contained tree. Requires an actionable containment mechanism
     /// (errors `Unsupported` otherwise — use [`kill`](Child::kill) for a lone process).
     /// If both the group teardown and the handle backstop fail, the group error is returned.
+    ///
+    /// On the Unix process-group and session mechanisms this returns
+    /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
+    /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
+    /// tree is still running and this process cannot bring it down.
     pub fn kill_tree(&mut self) -> Result<(), Error> {
         self.require_contained()?;
+        // Precondition (sibling #54's territory — asserted, not fixed, here): the contained
+        // root must not already be reaped when the mechanism is pgid-based (Attached::
+        // ProcessGroup — covers both Containment::ProcessGroup and Containment::Session, which
+        // also lands in this variant at spawn time), or the kernel may have recycled the pgid
+        // onto an unrelated process group. This crate's own `Drop` always kills before it
+        // reaps, so the common path never violates this; an explicit `wait()` then
+        // `kill_tree()`/`terminate_tree()` does — exactly the footgun #54 is about. Gated to
+        // this ONE mechanism: a recycled pgid is meaningless for Cgroup (keyed by an fd),
+        // JobObject (no pgid), Delegated (no mechanism), or TreeWalk (re-resolves identity per
+        // member, immune to this by construction) — asserting it there would be a false alarm
+        // unrelated to what this precondition is about. `Existence::Unknown` (the OS refused
+        // the query) is permitted through: this asserts against POSITIVE evidence of a
+        // violation, not against every case we merely couldn't rule out.
+        //
+        // `#[cfg(unix)]`: `Attached::ProcessGroup` is itself a Unix-only variant — referencing
+        // it unconditionally does not compile on Windows (confirmed via `cargo check --target
+        // x86_64-pc-windows-msvc`, E0599, while implementing the sync twin in `src/child.rs`).
+        #[cfg(unix)]
+        debug_assert!(
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
+                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
+            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
+             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
+             (see #54)",
+            self.id.pid()
+        );
         let group_result = self.attached.hard_kill();
         // Backstop for the TreeWalk mechanism: its hard_kill kills the root by identity, which
         // no-ops if `ProcessId::of` transiently fails to resolve — this handle-based kill
@@ -400,8 +431,24 @@ impl Child {
     /// crate cannot confirm the cause. Treat **any** error here as "no signal was sent, the
     /// tree is still running" rather than keying a fallback on the variant alone. Attach a
     /// console before spawning the tree, or use `kill_tree`, which needs none.
+    ///
+    /// On the Unix process-group and session mechanisms this returns
+    /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
+    /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
+    /// tree is still running and this process cannot bring it down.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
+        // See kill_tree's identical precondition assert for the full rationale, including the
+        // `#[cfg(unix)]` gate (Attached::ProcessGroup does not exist on Windows).
+        #[cfg(unix)]
+        debug_assert!(
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
+                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
+            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
+             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
+             (see #54)",
+            self.id.pid()
+        );
         self.attached.terminate(self.id.pid())
     }
 
@@ -418,6 +465,10 @@ impl Child {
         self.attached.disarm();
     }
 }
+
+#[cfg(test)]
+#[path = "child_drop_tests.rs"]
+mod child_drop_tests;
 
 #[cfg(all(test, windows))]
 impl Child {
@@ -440,11 +491,13 @@ impl Drop for Child {
         // Tree teardown — the SOLE coverage for descendants (reap_now only guarantees the root),
         // so surface a real mechanism failure in debug. A no-op for an uncontained child.
         let tree = self.attached.hard_kill();
-        debug_assert!(
-            tree.is_ok(),
-            "contained-tree teardown failed on async Drop: {:?}",
-            tree.err()
-        );
+        if let Err(e) = &tree {
+            debug_assert!(
+                !crate::child::is_teardown_mechanism_failure(e),
+                "contained-tree teardown failed on async Drop: {e:?}"
+            );
+            log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
+        }
         let _ = tree;
         // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
         // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -374,18 +374,25 @@ impl Child {
     /// tree is still running and this process cannot bring it down.
     pub fn kill_tree(&mut self) -> Result<(), Error> {
         self.require_contained()?;
-        // Precondition (sibling #54's territory — asserted, not fixed, here): the contained
-        // root must not already be reaped when the mechanism is pgid-based (Attached::
-        // ProcessGroup — covers both Containment::ProcessGroup and Containment::Session, which
-        // also lands in this variant at spawn time), or the kernel may have recycled the pgid
-        // onto an unrelated process group. This crate's own `Drop` always kills before it
-        // reaps, so the common path never violates this; an explicit `wait()` then
-        // `kill_tree()`/`terminate_tree()` does — exactly the footgun #54 is about. Gated to
-        // this ONE mechanism: a recycled pgid is meaningless for Cgroup (keyed by an fd),
-        // JobObject (no pgid), Delegated (no mechanism), or TreeWalk (re-resolves identity per
-        // member, immune to this by construction) — asserting it there would be a false alarm
-        // unrelated to what this precondition is about. `Existence::Unknown` (the OS refused
-        // the query) is permitted through: this asserts against POSITIVE evidence of a
+        // Precondition (sibling #54's territory — asserted, not fixed, here): if the pgid-based
+        // mechanism's (Attached::ProcessGroup — covers both Containment::ProcessGroup and
+        // Containment::Session, which also lands in this variant at spawn time) leader pid has
+        // been reaped AND RECYCLED onto a DIFFERENT, LIVE process group, `killpg` would signal
+        // that unrelated group instead. Reaping alone is harmless — `killpg` on an absent pgid
+        // returns `ESRCH`, which `containment::unix::signal_group`/`verify` already treat as
+        // `Cleared` — so this only asserts on POSITIVE evidence of an actual recycle (see
+        // `crate::child::root_pid_was_recycled`), never on a mere reap. That positive-evidence
+        // case is reachable on the ORDINARY spawn-then-teardown path for any fast-exiting
+        // child, not only via an explicit `wait()` before `kill_tree()`/`terminate_tree()`:
+        // `std`'s `SharedChild::new` (inside the sync spawn path, see `child/spawn.rs`'s own
+        // comment on this) can reap a fast-exiting leader itself, before the caller ever gets a
+        // `Child` handle back — this assert can therefore fire on the very first call the
+        // caller makes, whatever ordering they use. Gated to this ONE mechanism: a recycled
+        // pgid is meaningless for Cgroup (keyed by an fd), JobObject (no pgid), Delegated (no
+        // mechanism), or TreeWalk (re-resolves identity per member, immune to this by
+        // construction) — asserting it there would be a false alarm unrelated to what this
+        // precondition is about. An OS refusal to answer either resolve (`Resolved::Unknown` /
+        // `Liveness::Unknown`) is permitted through: this asserts against POSITIVE evidence of a
         // violation, not against every case we merely couldn't rule out.
         //
         // `#[cfg(unix)]`: `Attached::ProcessGroup` is itself a Unix-only variant — referencing
@@ -393,11 +400,19 @@ impl Child {
         // x86_64-pc-windows-msvc`, E0599, while implementing the sync twin in `src/child.rs`).
         #[cfg(unix)]
         debug_assert!(
-            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
-                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
-            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
-             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
-             (see #54)",
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_)) || {
+                let now = ProcessId::of(self.id.pid());
+                let now_liveness = match now {
+                    crate::identity::Resolved::Found(id) => id.is_alive(),
+                    crate::identity::Resolved::Gone | crate::identity::Resolved::Unknown => {
+                        crate::identity::Liveness::Unknown
+                    }
+                };
+                !crate::child::root_pid_was_recycled(self.id, now, now_liveness)
+            },
+            "kill_tree/terminate_tree called after the contained root's pid ({}) was reaped and \
+             recycled onto a different, live process; a pgid-based mechanism would now signal an \
+             unrelated process group (see #54)",
             self.id.pid()
         );
         let group_result = self.attached.hard_kill();
@@ -442,11 +457,19 @@ impl Child {
         // `#[cfg(unix)]` gate (Attached::ProcessGroup does not exist on Windows).
         #[cfg(unix)]
         debug_assert!(
-            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_))
-                || !matches!(self.id.exists(), crate::identity::Existence::Gone),
-            "kill_tree/terminate_tree called after the contained root (pid {}) was already \
-             reaped; a pgid-based mechanism may now signal a recycled, unrelated process group \
-             (see #54)",
+            !matches!(self.attached, crate::containment::Attached::ProcessGroup(_)) || {
+                let now = ProcessId::of(self.id.pid());
+                let now_liveness = match now {
+                    crate::identity::Resolved::Found(id) => id.is_alive(),
+                    crate::identity::Resolved::Gone | crate::identity::Resolved::Unknown => {
+                        crate::identity::Liveness::Unknown
+                    }
+                };
+                !crate::child::root_pid_was_recycled(self.id, now, now_liveness)
+            },
+            "kill_tree/terminate_tree called after the contained root's pid ({}) was reaped and \
+             recycled onto a different, live process; a pgid-based mechanism would now signal an \
+             unrelated process group (see #54)",
             self.id.pid()
         );
         self.attached.terminate(self.id.pid())

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -372,32 +372,23 @@ impl Child {
     /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
     /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
     /// tree is still running and this process cannot bring it down.
+    ///
+    /// **This guarantee, and its converse — that `Ok` is positive proof the group cleared —
+    /// hold only for the `ProcessGroup`/`Session` mechanisms**, not `TreeWalk`: `TreeWalk`
+    /// does not yet propagate a live refuser's outcome into this call's result (#63).
+    ///
+    /// **A `hidepid`-restricted Linux host can still return `Ok` with a live refuser left
+    /// running.** `/proc` is this mechanism's only way to confirm the group cleared, and
+    /// `hidepid=invisible`/`hidepid=2` hides a foreign-uid process from it entirely — the
+    /// ordinary setuid-in-a-container case. That member is then never listed, never
+    /// classified, never signaled, and the group can report cleared regardless. No fix
+    /// exists within this mechanism: the pid is never learned, and `killpg`'s own return
+    /// value is not trustworthy evidence either.
     pub fn kill_tree(&mut self) -> Result<(), Error> {
         self.require_contained()?;
-        // Precondition (sibling #54's territory — asserted, not fixed, here): if the pgid-based
-        // mechanism's (Attached::ProcessGroup — covers both Containment::ProcessGroup and
-        // Containment::Session, which also lands in this variant at spawn time) leader pid has
-        // been reaped AND RECYCLED onto a DIFFERENT, LIVE process group, `killpg` would signal
-        // that unrelated group instead. Reaping alone is harmless — `killpg` on an absent pgid
-        // returns `ESRCH`, which `containment::unix::signal_group`/`verify` already treat as
-        // `Cleared` — so this only asserts on POSITIVE evidence of an actual recycle (see
-        // `crate::child::root_pid_was_recycled`), never on a mere reap. That positive-evidence
-        // case is reachable on the ORDINARY spawn-then-teardown path for any fast-exiting
-        // child, not only via an explicit `wait()` before `kill_tree()`/`terminate_tree()`:
-        // `std`'s `SharedChild::new` (inside the sync spawn path, see `child/spawn.rs`'s own
-        // comment on this) can reap a fast-exiting leader itself, before the caller ever gets a
-        // `Child` handle back — this assert can therefore fire on the very first call the
-        // caller makes, whatever ordering they use. Gated to this ONE mechanism: a recycled
-        // pgid is meaningless for Cgroup (keyed by an fd), JobObject (no pgid), Delegated (no
-        // mechanism), or TreeWalk (re-resolves identity per member, immune to this by
-        // construction) — asserting it there would be a false alarm unrelated to what this
-        // precondition is about. An OS refusal to answer either resolve (`Resolved::Unknown` /
-        // `Liveness::Unknown`) is permitted through: this asserts against POSITIVE evidence of a
-        // violation, not against every case we merely couldn't rule out.
-        //
-        // `#[cfg(unix)]`: `Attached::ProcessGroup` is itself a Unix-only variant — referencing
-        // it unconditionally does not compile on Windows (confirmed via `cargo check --target
-        // x86_64-pc-windows-msvc`, E0599, while implementing the sync twin in `src/child.rs`).
+        // Precondition (sibling #54's territory — asserted, not fixed, here): see the sync
+        // twin, `Child::kill_tree` in `src/child.rs`, for the full rationale (including why
+        // this is gated to `Attached::ProcessGroup` alone, and why it is `#[cfg(unix)]`).
         #[cfg(unix)]
         debug_assert!(
             !matches!(self.attached, crate::containment::Attached::ProcessGroup(_)) || {
@@ -451,6 +442,10 @@ impl Child {
     /// [`Error::Containment`](crate::error::Error::Containment) when a live member of the
     /// group refused the signal — a setuid binary in the tree is the ordinary cause. The
     /// tree is still running and this process cannot bring it down.
+    ///
+    /// See [`kill_tree`](Child::kill_tree)'s doc for two things that also apply here: the
+    /// `ProcessGroup`/`Session`-only scope of this guarantee (`TreeWalk` is #63's territory),
+    /// and the residual `hidepid` gap on Linux.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
         // See kill_tree's identical precondition assert for the full rationale, including the

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -101,12 +101,14 @@ impl Child {
     /// ([`Error::Containment`](crate::error::Error::Containment) or
     /// [`Error::Unassessable`](crate::error::Error::Unassessable) with no I/O `source` — see
     /// [`terminate_tree`](Child::terminate_tree)), the grace is still waited and the sweep
-    /// still runs; the held error resurfaces only after a successful sweep and reap (mirroring
-    /// how a watch failure is held above), so a member that only needed the follow-up `SIGKILL`
-    /// does not strand the rest of the tree. A genuine listing-mechanism failure (an
-    /// `Unassessable` with an I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`,
-    /// it returns immediately: no signal is confirmed sent, so there is nothing for a grace
-    /// wait or sweep to act on yet.
+    /// still runs, so a member that only needed the follow-up `SIGKILL` does not strand the
+    /// rest of the tree. A subsequent successful sweep is fresher, positive proof the group
+    /// cleared, which supersedes the earlier refusal: it is logged and discarded, and this
+    /// call reports `Ok`. It resurfaces only indirectly, as the sweep's own error, if the
+    /// sweep then fails too. A genuine listing-mechanism failure (an `Unassessable` with an
+    /// I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`, it returns
+    /// immediately: no signal is confirmed sent, so there is nothing for a grace wait or
+    /// sweep to act on yet.
     ///
     /// # Runtime
     ///
@@ -133,7 +135,7 @@ impl Child {
             Ok(()) => Ok(()),
             Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
                 log::debug!(
-                    "graceful_shutdown_tree({id}): terminate_tree refused (subsumed if the sweep also fails): {e}",
+                    "graceful_shutdown_tree({id}): terminate_tree refused; the sweep's own outcome decides what surfaces: {e}",
                     id = self.id().pid()
                 );
                 Err(e)
@@ -170,7 +172,15 @@ impl Child {
         }
         let status = self.wait().await?;
         watch?;
-        term?;
+        // The sweep just returned `Ok`: positive, freshly-measured proof the group cleared,
+        // superseding whatever `term` held. Discard it here rather than returning it — an
+        // already-disproved refusal must never outrank the evidence that disproved it.
+        if let Err(e) = &term {
+            log::debug!(
+                "graceful_shutdown_tree({id}): sweep succeeded; discarding the superseded terminate_tree refusal: {e}",
+                id = self.id().pid()
+            );
+        }
         Ok(status)
     }
 }

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -95,6 +95,19 @@ impl Child {
     /// a graceful root exit (survivors may remain; the root is still reaped first when its
     /// exit was observed, otherwise the child stays owned for `Drop`).
     ///
+    /// **A refused or unconfirmed graceful signal never skips the grace wait and hard sweep
+    /// either.** If the initial group signal reaches a live member that refuses it, or a
+    /// member's post-signal state cannot be confirmed
+    /// ([`Error::Containment`](crate::error::Error::Containment) or
+    /// [`Error::Unassessable`](crate::error::Error::Unassessable) with no I/O `source` — see
+    /// [`terminate_tree`](Child::terminate_tree)), the grace is still waited and the sweep
+    /// still runs; the held error resurfaces only after a successful sweep and reap (mirroring
+    /// how a watch failure is held above), so a member that only needed the follow-up `SIGKILL`
+    /// does not strand the rest of the tree. A genuine listing-mechanism failure (an
+    /// `Unassessable` with an I/O `source`) is not held — like `NoConsole`/`Unsupported`/`Io`,
+    /// it returns immediately: no signal is confirmed sent, so there is nothing for a grace
+    /// wait or sweep to act on yet.
+    ///
     /// # Runtime
     ///
     /// On Unix, needs a runtime with the IO **and** time drivers enabled (the
@@ -105,13 +118,35 @@ impl Child {
     pub async fn graceful_shutdown_tree(&mut self, grace: Duration) -> Result<ExitStatus, Error> {
         // terminate_tree's own require_contained guard fires before any signal, so an
         // uncontained child errors up front.
-        self.terminate_tree()?;
+        #[cfg(test)]
+        let term_result = match fault::take_force_terminate() {
+            fault::Forced::None => self.terminate_tree(),
+            kind => Err(fault::forced_terminate_error(kind)),
+        };
+        #[cfg(not(test))]
+        let term_result = self.terminate_tree();
+
+        // Hold-and-continue ONLY for the error shapes #61's fix can produce as ORDINARY
+        // outcomes — see the sync `src/child/graceful.rs` twin's identical match for the full
+        // rationale.
+        let term = match term_result {
+            Ok(()) => Ok(()),
+            Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
+                log::debug!(
+                    "graceful_shutdown_tree({id}): terminate_tree refused (subsumed if the sweep also fails): {e}",
+                    id = self.id().pid()
+                );
+                Err(e)
+            }
+            Err(e) => return Err(e), // unchanged pre-existing behavior: no signal sent, no grace, no sweep
+        };
+
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
         let watch = crate::tokio::wait::grace_wait(self.id(), grace).await;
         // The sweep is unconditional — a gracefully-exited root does NOT mean the descendants
-        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch Err; it must
-        // propagate before the reap on a LIVE root (waiting unswept would hang), but once the
-        // root's exit was observed, the reap runs first so no zombie is stranded.
+        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch or terminate Err;
+        // it must propagate before the reap on a LIVE root (waiting unswept would hang), but once
+        // the root's exit was observed, the reap runs first so no zombie is stranded.
         if let Err(e) = &watch {
             log::debug!(
                 "graceful_shutdown_tree({id}): watch error before escalation (subsumed if it also fails): {e}",
@@ -120,17 +155,85 @@ impl Child {
         }
         if let Err(sweep) = self.kill_tree() {
             if matches!(watch, Ok(true)) {
-                // The root is a zombie — this reap cannot hang (which is why it is gated on the
-                // observed exit). The sweep Err stays the verdict: the status, and even a distinct
-                // reap Err (a wait failure on the zombie), are subsumed — live survivors are the
-                // actionable failure, and the child stays owned for Drop's teardown.
-                let _ = self.wait().await;
+                // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
+                // (below) is already the error this call reports, so a failure here is
+                // secondary — but every other discarded error in this module is still logged,
+                // and a silent one here would obscure a second, independent failure mode.
+                if let Err(e) = self.wait().await {
+                    log::debug!(
+                        "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
+                        id = self.id().pid()
+                    );
+                }
             }
             return Err(sweep);
         }
         let status = self.wait().await?;
         watch?;
+        term?;
         Ok(status)
+    }
+}
+
+/// Test-only fault-injection seam for a forced `terminate_tree` failure inside
+/// `graceful_shutdown_tree`, mirroring `crate::wait::fault`'s shape. Duplicated (not shared)
+/// with `crate::child::graceful::fault` — see this crate's `#61` implementation plan, Task 7,
+/// "Structural note", for why: `mod graceful;` is private in both `src/child.rs` and
+/// `src/tokio/child.rs`, so a seam here is not nameable from the sync tree without widening
+/// that visibility, which is out of scope here.
+#[cfg(test)]
+pub(crate) mod fault {
+    use std::cell::Cell;
+
+    /// Which `terminate_tree` failure to fabricate on the next call, on this thread.
+    /// `Containment` and `UnassessablePerMember` exercise the hold-and-continue path this
+    /// task adds — both ORDINARY #61 outcomes, a signal was attempted. `Unsupported` and
+    /// `UnassessableMechanism` exercise fail-fast paths: `Unsupported` models the
+    /// PRE-EXISTING console-less-caller shape (`NoConsole`/`Unsupported`) this task must not
+    /// touch; `UnassessableMechanism` models `Error::Unassessable { source: Some(_), .. }` —
+    /// `group::state`'s own listing failure, `crate::child::is_teardown_mechanism_failure`'s
+    /// classification for the identical shape reaching `Child::drop` — which this task's
+    /// `graceful_shutdown_tree` match must treat the SAME way (fail-fast), not fold into the
+    /// per-member `Unassessable{source: None}` hold-and-continue case.
+    #[derive(Clone, Copy, PartialEq, Eq, Default)]
+    pub(crate) enum Forced {
+        #[default]
+        None,
+        Containment,
+        UnassessablePerMember,
+        UnassessableMechanism,
+        Unsupported,
+    }
+    thread_local! {
+        static FORCE_TERMINATE: Cell<Forced> = const { Cell::new(Forced::None) };
+    }
+    pub(crate) fn set_force_terminate(kind: Forced) {
+        FORCE_TERMINATE.with(|f| f.set(kind));
+    }
+    pub(crate) fn take_force_terminate() -> Forced {
+        FORCE_TERMINATE.with(|f| f.replace(Forced::None))
+    }
+    // No `armed()` here — see the sync twin's identical note.
+    pub(crate) fn forced_terminate_error(kind: Forced) -> crate::error::Error {
+        match kind {
+            Forced::None => unreachable!("forced_terminate_error called with Forced::None"),
+            Forced::Containment => crate::error::Error::Containment {
+                detail: "forced term_group refusal (test seam)".into(),
+            },
+            Forced::UnassessablePerMember => crate::error::Error::Unassessable {
+                detail: "forced per-member unconfirmed state (test seam) — group::decide's shape".into(),
+                source: None,
+            },
+            Forced::UnassessableMechanism => crate::error::Error::Unassessable {
+                detail: "forced listing-mechanism failure (test seam) — group::state's shape".into(),
+                source: Some(std::io::Error::other("forced (test seam)")),
+            },
+            Forced::Unsupported => crate::error::Error::Unsupported {
+                op: "terminate_tree".into(),
+                platform: "test",
+                detail: "forced (test seam) — models NoConsole/Unsupported, NOT a #61 refusal".into(),
+            },
+        }
     }
 }
 

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -102,17 +102,29 @@ async fn async_graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
     crate::log_capture::install();
     let mark = crate::log_capture::mark();
     term_fault::set_force_terminate(term_fault::Forced::Containment);
-    let err = child
+    // A successful sweep is fresher, positive proof the group cleared, superseding the held
+    // refusal — the call must report `Ok`, not resurface the disproved `Containment` error.
+    let status = child
         .graceful_shutdown_tree(Duration::ZERO)
         .await
-        .expect_err("the forced terminate refusal must surface");
-    assert!(matches!(err, crate::error::Error::Containment { .. }), "got {err:?}");
+        .expect("a successful sweep must supersede the forced terminate refusal");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
     assert!(
         crate::log_capture::contains_since(
             mark,
             &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
         ),
         "the terminate-refusal trace specifically must fire"
+    );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!(
+                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                pid = id.pid()
+            )
+        ),
+        "the refusal must be logged as discarded, not silently dropped"
     );
     #[cfg(unix)]
     assert_eq!(
@@ -122,11 +134,6 @@ async fn async_graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
     );
     #[cfg(windows)]
     let _ = id;
-    let status = child
-        .wait()
-        .await
-        .expect("cached status — already reaped by the graceful op");
-    assert!(!status.success(), "swept root cannot report success, got {status:?}");
 }
 
 // Async twin of `graceful_tree_unassessable_per_member_still_sweeps_and_reaps`.
@@ -143,20 +150,29 @@ async fn async_graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
     crate::log_capture::install();
     let mark = crate::log_capture::mark();
     term_fault::set_force_terminate(term_fault::Forced::UnassessablePerMember);
-    let err = child
+    // Same supersession as the `Containment` test above: the sweep's success disproves the
+    // held per-member-unconfirmed state, so the call must report `Ok`.
+    let status = child
         .graceful_shutdown_tree(Duration::ZERO)
         .await
-        .expect_err("the forced per-member-unassessable state must surface");
-    assert!(
-        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
-        "got {err:?}"
-    );
+        .expect("a successful sweep must supersede the forced unassessable state");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
     assert!(
         crate::log_capture::contains_since(
             mark,
             &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
         ),
         "the terminate-refusal trace specifically must fire"
+    );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!(
+                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                pid = id.pid()
+            )
+        ),
+        "the refusal must be logged as discarded, not silently dropped"
     );
     #[cfg(unix)]
     assert_eq!(
@@ -166,11 +182,6 @@ async fn async_graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
     );
     #[cfg(windows)]
     let _ = id;
-    let status = child
-        .wait()
-        .await
-        .expect("cached status — already reaped by the graceful op");
-    assert!(!status.success(), "swept root cannot report success, got {status:?}");
 }
 
 // Async twin of `graceful_tree_unassessable_mechanism_failure_fails_fast`.

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use super::fault as term_fault;
 use crate::wait::fault;
 
 #[tokio::test]
@@ -84,4 +85,147 @@ async fn async_graceful_lone_watch_error_still_escalates_and_reaps() {
         !status.success(),
         "escalated child cannot report success, got {status:?}"
     );
+}
+
+// Async twin of `graceful_tree_terminate_refusal_still_sweeps_and_reaps` in
+// `src/child/graceful_tests.rs` — see there for the full rationale.
+#[tokio::test]
+async fn async_graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    term_fault::set_force_terminate(term_fault::Forced::Containment);
+    let err = child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect_err("the forced terminate refusal must surface");
+    assert!(matches!(err, crate::error::Error::Containment { .. }), "got {err:?}");
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "the terminate-refusal trace specifically must fire"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "root must be swept AND reaped despite the forced terminate refusal"
+    );
+    #[cfg(windows)]
+    let _ = id;
+    let status = child
+        .wait()
+        .await
+        .expect("cached status — already reaped by the graceful op");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
+}
+
+// Async twin of `graceful_tree_unassessable_per_member_still_sweeps_and_reaps`.
+#[tokio::test]
+async fn async_graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    term_fault::set_force_terminate(term_fault::Forced::UnassessablePerMember);
+    let err = child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect_err("the forced per-member-unassessable state must surface");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
+        "got {err:?}"
+    );
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "the terminate-refusal trace specifically must fire"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "root must be swept AND reaped despite the forced unassessable state"
+    );
+    #[cfg(windows)]
+    let _ = id;
+    let status = child
+        .wait()
+        .await
+        .expect("cached status — already reaped by the graceful op");
+    assert!(!status.success(), "swept root cannot report success, got {status:?}");
+}
+
+// Async twin of `graceful_tree_unassessable_mechanism_failure_fails_fast`.
+#[tokio::test]
+async fn async_graceful_tree_unassessable_mechanism_failure_fails_fast() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    term_fault::set_force_terminate(term_fault::Forced::UnassessableMechanism);
+    let err = child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect_err("the forced listing-mechanism failure must surface immediately");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: Some(_), .. }),
+        "got {err:?}"
+    );
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Present,
+        "a listing-mechanism failure must return before any grace wait or sweep"
+    );
+    // Clean up: the child is still running by design (no sweep happened above).
+    let _ = child.kill_tree();
+    let _ = child.wait().await;
+}
+
+// Async twin of `graceful_tree_non_containment_terminate_error_fails_fast`.
+#[tokio::test]
+async fn async_graceful_tree_non_containment_terminate_error_fails_fast() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    term_fault::set_force_terminate(term_fault::Forced::Unsupported);
+    let err = child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect_err("the forced Unsupported error must surface immediately");
+    assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Present,
+        "a non-containment terminate error must return before any grace wait or sweep"
+    );
+    // Clean up: the child is still running by design (no sweep happened above).
+    let _ = child.kill_tree();
+    let _ = child.wait().await;
 }

--- a/src/tokio/child_drop_tests.rs
+++ b/src/tokio/child_drop_tests.rs
@@ -1,0 +1,31 @@
+// Exercises the ACTUAL shared classifier both Drop impls call (crate::child::
+// is_teardown_mechanism_failure), not a hand-copied duplicate — a future edit to the real
+// condition is caught here automatically. Cannot force a REAL Containment through a live
+// Drop without root (same constraint as the rest of this plan), so this drives the
+// classifier directly with constructed Error values. Both Unassessable shapes are exercised
+// because they classify oppositely: `source: None` (an ordinary "member unconfirmed" outcome
+// from group::decide) is NOT a mechanism failure; `source: Some(_)` (group::state's listing
+// itself failed) IS one.
+#[test]
+fn teardown_mechanism_failure_excludes_containment_and_per_member_unassessable() {
+    use crate::child::is_teardown_mechanism_failure;
+    assert!(!is_teardown_mechanism_failure(&crate::error::Error::Containment {
+        detail: "refused".into()
+    }));
+    assert!(!is_teardown_mechanism_failure(&crate::error::Error::Unassessable {
+        detail: "unknown".into(),
+        source: None
+    }));
+    assert!(is_teardown_mechanism_failure(&crate::error::Error::Io(
+        std::io::Error::other("mechanism failure")
+    )));
+}
+
+#[test]
+fn teardown_mechanism_failure_includes_listing_failure_unassessable() {
+    use crate::child::is_teardown_mechanism_failure;
+    assert!(is_teardown_mechanism_failure(&crate::error::Error::Unassessable {
+        detail: "process group 372 could not be listed after SIGKILL".into(),
+        source: Some(std::io::Error::other("sysctl KERN_PROC_PGRP failed"))
+    }));
+}

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -211,6 +211,91 @@ fn main() {
             let _ = sock.read(&mut buf);
         }
         #[cfg(unix)]
+        "spawn-grandchild-setuid" => {
+            // Like spawn-grandchild, but the grandchild is a SEPARATE, pre-provisioned
+            // setuid-root binary (argv[3]) rather than this same executable — proving issue
+            // #61's fix against a mixed real process group: an ordinary member (us, the
+            // group leader) plus one the caller genuinely cannot signal. The grandchild
+            // inherits OUR process group (no setpgid call), so `killpg`/`kill_group` on our
+            // pgid addresses both.
+            let addr = args[2].clone();
+            let setuid_helper = args[3].clone();
+            #[allow(clippy::zombie_processes)] // intentional: grandchild must outlive us; containment kills/refuses us
+            let _gc = std::process::Command::new(setuid_helper)
+                .args(["setuid-control-block", &addr, "P"])
+                .spawn()
+                .unwrap();
+            // Become a control-block ourselves (no test-owned stdin → no EOF confound).
+            let mut sock = std::net::TcpStream::connect(&addr).unwrap();
+            sock.write_all(b"R\n").unwrap();
+            sock.flush().unwrap();
+            let mut buf = [0u8; 1];
+            let _ = sock.read(&mut buf);
+        }
+        #[cfg(unix)]
+        "setuid-control-block" => {
+            // Only ever exec'd from a SEPARATE, pre-provisioned copy of this binary that CI
+            // chowns root:root and chmods u+s (see `COSCA_TEST_SETUID_HELPER` in
+            // tests/group_teardown_setuid.rs). Reports readiness (or a provisioning
+            // failure) as ONE line, then blocks like control-block. A single connect: every
+            // outcome — success or failure — is reported over the SAME socket, so the
+            // harness always gets a definite answer instead of an ambiguous connect-refused.
+            let addr = &args[2];
+            let tag = args.get(3).map(String::as_str).unwrap_or("?");
+            let mut sock = std::net::TcpStream::connect(addr).unwrap();
+
+            // The setuid-root file bit must already have made us effective-root at exec
+            // time. If not, the copy is not actually setuid-root (wrong owner/mode) or the
+            // filesystem it lives on is mounted `nosuid` — report loudly, never silently
+            // proceed as an ordinary (killable) process, which would make the caller's
+            // later "still alive" assertion pass for the wrong reason.
+            // Safety: geteuid() has no preconditions.
+            let euid_before = unsafe { libc::geteuid() };
+            if euid_before != 0 {
+                sock.write_all(
+                    format!(
+                        "F effective uid is {euid_before}, not 0 at exec — the setuid-root bit \
+                         did not take effect (wrong owner/mode on COSCA_TEST_SETUID_HELPER's \
+                         target, or a nosuid mount)\n"
+                    )
+                    .as_bytes(),
+                )
+                .unwrap();
+                sock.flush().unwrap();
+                exit(3);
+            }
+            // setuid(0): collapse the REAL uid to 0 too, not just the effective/saved uid the
+            // exec-time setuid bit already granted. This is what makes us unsignalable by the
+            // original unprivileged caller IN FACT: the kernel's own permission check
+            // (`kill_ok_by_cred`) treats a matching REAL uid as sufficient permission on its
+            // own, so without this call our real uid would still equal the caller's and this
+            // whole scenario would not reproduce the bug at all — see group.rs's module docs.
+            // Safety: setuid() has no preconditions; failure is reported below, not ignored.
+            let rc = unsafe { libc::setuid(0) };
+            if rc != 0 {
+                let err = std::io::Error::last_os_error();
+                sock.write_all(format!("F setuid(0) failed: {err}\n").as_bytes())
+                    .unwrap();
+                sock.flush().unwrap();
+                exit(3);
+            }
+            // Safety: getuid()/geteuid() have no preconditions.
+            let (ruid, euid) = unsafe { (libc::getuid(), libc::geteuid()) };
+            if ruid != 0 || euid != 0 {
+                sock.write_all(format!("F post-setuid(0) ids are ruid={ruid} euid={euid}, expected 0/0\n").as_bytes())
+                    .unwrap();
+                sock.flush().unwrap();
+                exit(3);
+            }
+            // Success: report OUR pid so the harness can independently probe kill(pid, 0)
+            // from the ORIGINAL caller's uid — an oracle outside this crate's own code path.
+            sock.write_all(format!("{tag} {}\n", std::process::id()).as_bytes())
+                .unwrap();
+            sock.flush().unwrap();
+            let mut buf = [0u8; 1];
+            let _ = sock.read(&mut buf);
+        }
+        #[cfg(unix)]
         "spawn-grandchild-escapee" => {
             // Like spawn-grandchild, but FIRST escape any process group / session
             // the parent put us in by calling setsid(2). A killpg-based teardown

--- a/tests/group_teardown_setuid.rs
+++ b/tests/group_teardown_setuid.rs
@@ -1,0 +1,209 @@
+//! Issue #61's end-to-end reproduction: a REAL process group holding a mixed membership — one
+//! member the caller may signal, one it genuinely may not (a real setuid-root process that has
+//! called `setuid(0)` itself, so it is unsignalable IN FACT, not merely by a file mode bit) —
+//! torn down through the crate's real public path, `Child::kill_tree` (which calls
+//! `containment::unix::kill_group`, `SIGKILL`).
+//!
+//! Every OTHER real-process test in this suite (`tests/spawn_io.rs`'s `unix_kill_tree_reaps_the_
+//! grandchild` and friends) spawns a group where every member is equally killable by the test's
+//! own uid, so a regression that made `converge` silently drop a real refuser would still pass
+//! them all. This is the one test that would fail if issue #61's fix were reverted — see the
+//! module docs on `containment::unix::group` for the exact bug (`killpg`'s return value reports
+//! only whether *at least one* member took the signal, never who it refused).
+//!
+//! # Platform scope
+//! Linux only. The original bug was reproduced (and is reproduced here) via `/proc`-based group
+//! membership and `kill(2)`'s real permission check (`kill_ok_by_cred`, `kernel/signal.c`),
+//! which requires the target's REAL uid — not merely its effective/saved uid — to differ from
+//! the caller's. macOS is deliberately excluded, not silently skipped there: SIP and the
+//! hardened-runtime/notarization requirements on modern macOS make a locally-built setuid-root
+//! binary unreliable to provision in CI (SIP can strip privileges from unsigned/ad-hoc-signed
+//! binaries depending on where they live and how they were built), and there is no equivalent to
+//! Linux's straightforward "chown root, chmod u+s, exec" contract to build an honest CI lane on.
+//! Windows has no setuid concept at all. `containment::unix::group::members` itself is only
+//! implemented for Linux and macOS (see that module), so this gap does not exist on Windows
+//! regardless.
+//!
+//! # Gating
+//! `COSCA_TEST_SETUID_HELPER` must hold the absolute path to a pre-provisioned COPY of
+//! `cosca_testbin` that CI has `chown root:root` + `chmod u+s`'d (see `.github/workflows/
+//! ci.yaml`, the "Set up setuid-root helper" step). Absent: a true no-op (the marker precedent
+//! `COSCA_TEST_CGROUP` already established for a live, root-requiring facility). Present: the
+//! test must fail LOUDLY if the helper does not actually achieve real uid 0 — never silently
+//! pass or skip. That check is performed by the spawned helper itself (`setuid-control-block` in
+//! `testbin/main.rs`) and reported back over the same control socket used for the readiness
+//! handshake, so a nosuid mount or a wrong owner/mode surfaces as a loud panic here, not a false
+//! green.
+
+// The whole file is Linux-only in purpose (see the module docs above) — gated here, once, rather
+// than on every item, so the file compiles to nothing (no unused-code warnings) elsewhere.
+#![cfg(target_os = "linux")]
+
+use std::io::{BufRead, BufReader, Read};
+use std::net::{TcpListener, TcpStream};
+
+fn testbin() -> &'static str {
+    env!("CARGO_BIN_EXE_cosca_testbin")
+}
+
+fn gated() -> Option<String> {
+    std::env::var("COSCA_TEST_SETUID_HELPER").ok()
+}
+
+/// `kill(pid, 0)` performs only the existence/permission check, sending nothing. `Ok(())` means
+/// the pid is live and this caller may signal it. `EPERM` ALSO means alive — this is the exact
+/// property under test: an unprivileged caller probing a genuinely-root-owned process gets
+/// `EPERM` from the permission check itself, not `ESRCH`. Only `ESRCH` (or any other errno) means
+/// the pid is actually gone. Independent of the crate's own code path — this is the same raw
+/// syscall POSIX specifies `kill_group`'s underlying mechanism against, used here purely as an
+/// oracle, not as a fixture of the code under test.
+fn probe_kill0(pid: u32) -> Result<(), Option<i32>> {
+    // Safety: signal 0 performs only the existence/permission check, sends nothing.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return Ok(());
+    }
+    Err(std::io::Error::last_os_error().raw_os_error())
+}
+
+/// One accepted control connection, classified by its first line:
+/// - `"R"` — the ordinary group leader, ready and blocked.
+/// - `"P <pid>"` — the setuid-root helper, ready (fully real-uid-0) and blocked, reporting its
+///   own pid so the harness can independently probe it.
+/// - `"F <reason>"` — the setuid-root helper detected its OWN provisioning failed (wrong owner/
+///   mode, nosuid mount, or `setuid(0)` itself failing) and is about to exit; never silently
+///   treated as "ready".
+enum Handshake {
+    Root(BufReader<TcpStream>),
+    Privileged { pid: u32, sock: BufReader<TcpStream> },
+}
+
+fn accept_one(listener: &TcpListener) -> Handshake {
+    let (stream, _) = listener.accept().expect("accept control connection");
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read control handshake line");
+    let line = line.trim_end_matches('\n');
+    if let Some(reason) = line.strip_prefix("F ") {
+        panic!(
+            "setuid helper provisioning failed: {reason}\n\
+             (check that COSCA_TEST_SETUID_HELPER points at a copy of cosca_testbin that is \
+             owned by root, mode u+s, on a filesystem NOT mounted nosuid)"
+        );
+    }
+    if line == "R" {
+        return Handshake::Root(reader);
+    }
+    if let Some(pid_str) = line.strip_prefix("P ") {
+        let pid: u32 = pid_str.parse().expect("privileged helper reported a non-numeric pid");
+        return Handshake::Privileged { pid, sock: reader };
+    }
+    panic!("unexpected control handshake line: {line:?}");
+}
+
+/// The one test that proves issue #61's fix actually works end to end, through the REAL public
+/// `Child::kill_tree` path (not a pure helper, not a fault-injection seam) against a REAL mixed
+/// process group.
+#[test]
+fn kill_tree_reports_refused_and_leaves_the_real_setuid_survivor_running() {
+    let Some(helper) = gated() else {
+        return; // unprovisioned: not a CI lane that has set up the setuid-root helper.
+    };
+    assert!(
+        std::path::Path::new(&helper).is_file(),
+        "COSCA_TEST_SETUID_HELPER={helper:?} does not point at an existing file"
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind control listener");
+    let addr = listener.local_addr().unwrap().to_string();
+
+    let mut cmd = cosca::Command::new();
+    cmd.executable(testbin())
+        .args(["cosca_testbin", "spawn-grandchild-setuid", &addr, &helper]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn contained root");
+
+    // The pgid-based mechanism specifically — NOT cgroup v2 (whose `cgroup.kill` bypasses the
+    // ordinary kill(2) permission check entirely and would not reproduce the bug at all) and NOT
+    // Delegated/None. `.contain()`'s cgroup path only activates given a delegated cgroup v2
+    // slice, which this lane's ordinary (unprivileged) `cargo test` invocation does not have —
+    // asserted, not assumed, exactly like this suite's existing `unix_kill_tree_reaps_the_
+    // grandchild` (tests/spawn_io.rs).
+    assert_eq!(
+        child.containment(),
+        cosca::Containment::ProcessGroup,
+        "expected the pgid-based ProcessGroup mechanism, got {:?}",
+        child.containment()
+    );
+
+    // Accept both connections; classify by content, not arrival order (real scheduling gives no
+    // ordering guarantee between the root and the grandchild it spawns).
+    let mut root_sock = None;
+    let mut priv_pid = None;
+    let mut priv_sock = None;
+    for _ in 0..2 {
+        match accept_one(&listener) {
+            Handshake::Root(s) => root_sock = Some(s),
+            Handshake::Privileged { pid, sock } => {
+                priv_pid = Some(pid);
+                priv_sock = Some(sock);
+            }
+        }
+    }
+    let mut root_sock = root_sock.expect("ordinary root connected");
+    let priv_pid = priv_pid.expect("privileged helper connected and reported its pid");
+    let priv_sock = priv_sock.expect("privileged helper connected");
+
+    // Independent, pre-teardown confirmation that the helper is genuinely unsignalable by this
+    // caller RIGHT NOW — not merely "we expect it will be later". If this is Ok(()), the helper
+    // never actually became real-uid 0 and the whole scenario would not exercise the bug; fail
+    // loudly rather than let the later assertion pass for the wrong reason.
+    assert_eq!(
+        probe_kill0(priv_pid),
+        Err(Some(libc::EPERM)),
+        "the setuid-root helper (pid {priv_pid}) must be confirmed unsignalable (EPERM) by this \
+         caller BEFORE teardown — if it is not, provisioning did not achieve real uid 0"
+    );
+
+    // The real public path: SIGKILL via killpg, converge on delivering it to every reachable
+    // member, and report the group's ACTUAL membership state — not killpg's own lying success.
+    let result = child.kill_tree();
+
+    // (1) The teardown reports Err(Containment), not Ok(()).
+    match &result {
+        Err(cosca::error::Error::Containment { detail }) => {
+            assert!(
+                detail.contains(&priv_pid.to_string()),
+                "Containment error should name the refusing pid {priv_pid}, got: {detail}"
+            );
+        }
+        other => panic!(
+            "expected Err(Error::Containment{{..}}) naming the unsignalable pid {priv_pid}, got \
+             {other:?} — issue #61's fix reverted: killpg's partial success is being reported as \
+             a false Ok"
+        ),
+    }
+    let _ = child.wait(); // reap the (actually dead) root
+
+    // (2) The ordinary member is actually dead: its control socket EOFs (the kernel closed the
+    // connection on the process's real exit — a real event, not a liveness poll).
+    let mut buf = [0u8; 1];
+    let n = root_sock.read(&mut buf).expect("read root control socket");
+    assert_eq!(n, 0, "the ordinary group member must have been killed for real");
+
+    // (3) The privileged member is actually STILL alive, and still genuinely unsignalable by
+    // this caller — the one assertion no synthetic/pure-function test in this suite can make.
+    assert_eq!(
+        probe_kill0(priv_pid),
+        Err(Some(libc::EPERM)),
+        "the setuid-root helper (pid {priv_pid}) must still be alive AND unsignalable (EPERM) \
+         after kill_tree() — issue #61's fix reverted: it was silently killed or dropped from \
+         the verdict"
+    );
+
+    // Cleanup: dropping our end of the privileged helper's control socket closes the
+    // connection; the helper (blocked reading it, per `setuid-control-block`) observes EOF and
+    // exits on its own — the only way this test can end it, since it is genuinely unkillable by
+    // this process. Its new parent (reparented off the killed root) reaps it in due course.
+    drop(priv_sock);
+}

--- a/tests/group_teardown_setuid.rs
+++ b/tests/group_teardown_setuid.rs
@@ -25,15 +25,25 @@
 //! regardless.
 //!
 //! # Gating
+//! This test is `#[ignore]`d by default, so an ordinary `cargo test` — locally, or in every CI
+//! step that doesn't explicitly ask for it — prints `... ignored`, never `... ok`. A vacuous pass
+//! that merely returned early (the shape this file used at first) is indistinguishable in the log
+//! from a real one, which is exactly the failure this rule exists to prevent: a test name reading
+//! "ok" must mean the scenario it describes was actually exercised. Only the one CI step that has
+//! provisioned the helper runs it, via `cargo test --test group_teardown_setuid -- --ignored` (see
+//! `.github/workflows/ci.yaml`, the "Run setuid-root process-group teardown test" step, which
+//! follows "Set up setuid-root helper").
+//!
 //! `COSCA_TEST_SETUID_HELPER` must hold the absolute path to a pre-provisioned COPY of
-//! `cosca_testbin` that CI has `chown root:root` + `chmod u+s`'d (see `.github/workflows/
-//! ci.yaml`, the "Set up setuid-root helper" step). Absent: a true no-op (the marker precedent
-//! `COSCA_TEST_CGROUP` already established for a live, root-requiring facility). Present: the
-//! test must fail LOUDLY if the helper does not actually achieve real uid 0 — never silently
-//! pass or skip. That check is performed by the spawned helper itself (`setuid-control-block` in
-//! `testbin/main.rs`) and reported back over the same control socket used for the readiness
-//! handshake, so a nosuid mount or a wrong owner/mode surfaces as a loud panic here, not a false
-//! green.
+//! `cosca_testbin` that CI has `chown root:root` + `chmod u+s`'d (see the "Set up setuid-root
+//! helper" step). Once a caller has explicitly opted in to running this ignored test, there is no
+//! honest silent case left: the variable being unset there is a misconfiguration, not an
+//! environment the test doesn't apply to, so it panics rather than no-op-returning. And with the
+//! variable set, the test must fail LOUDLY if the helper does not actually achieve real uid 0 —
+//! never silently pass. That check is performed by the spawned helper itself
+//! (`setuid-control-block` in `testbin/main.rs`) and reported back over the same control socket
+//! used for the readiness handshake, so a nosuid mount or a wrong owner/mode surfaces as a loud
+//! panic here, not a false green.
 
 // The whole file is Linux-only in purpose (see the module docs above) — gated here, once, rather
 // than on every item, so the file compiles to nothing (no unused-code warnings) elsewhere.
@@ -46,8 +56,18 @@ fn testbin() -> &'static str {
     env!("CARGO_BIN_EXE_cosca_testbin")
 }
 
-fn gated() -> Option<String> {
-    std::env::var("COSCA_TEST_SETUID_HELPER").ok()
+/// Panics if unset: by the time this runs, the caller has already explicitly opted in (the test
+/// is `#[ignore]`d, so it only executes given `--ignored`/`--include-ignored` or an exact-name
+/// filter combined with one of those). An unset variable at that point is a misconfigured CI lane
+/// or a developer who ran the wrong command, not a platform this test legitimately doesn't apply
+/// to — see the module docs' "Gating" section.
+fn gated() -> String {
+    std::env::var("COSCA_TEST_SETUID_HELPER").unwrap_or_else(|_| {
+        panic!(
+            "this test was explicitly requested (it is #[ignore]d) but COSCA_TEST_SETUID_HELPER \
+             is not set — see the module docs' \"Gating\" section for what it must point at"
+        )
+    })
 }
 
 /// `kill(pid, 0)` performs only the existence/permission check, sending nothing. `Ok(())` means
@@ -104,11 +124,15 @@ fn accept_one(listener: &TcpListener) -> Handshake {
 /// The one test that proves issue #61's fix actually works end to end, through the REAL public
 /// `Child::kill_tree` path (not a pure helper, not a fault-injection seam) against a REAL mixed
 /// process group.
+///
+/// `#[ignore]`d by default so an ordinary `cargo test` reports it honestly as `ignored`, not a
+/// vacuous `ok` — see the module docs' "Gating" section for why, and for the one CI step that
+/// runs it with `--ignored` after provisioning `COSCA_TEST_SETUID_HELPER`.
 #[test]
+#[ignore = "requires COSCA_TEST_SETUID_HELPER (a real setuid-root helper); run with `cargo test \
+            --test group_teardown_setuid -- --ignored` — see this file's module docs"]
 fn kill_tree_reports_refused_and_leaves_the_real_setuid_survivor_running() {
-    let Some(helper) = gated() else {
-        return; // unprovisioned: not a CI lane that has set up the setuid-root helper.
-    };
+    let helper = gated();
     assert!(
         std::path::Path::new(&helper).is_file(),
         "COSCA_TEST_SETUID_HELPER={helper:?} does not point at an existing file"


### PR DESCRIPTION
`killpg` answers "was at least one member signalled?", not "is the group down?". `kill_group`/`term_group` mapped that onto `Ok(())`, so a group with a live member that refused the signal tore down "successfully" while still running.

Reproduced end to end at the syscall level on Linux: from uid 1000, a group holding a setuid-root helper answers `killpg(pgid, SIGKILL)` → `0`/OK, the leader dies, and the helper survives — on the `Ok` path. On macOS the ambiguity is worse: `EPERM` means "only zombies survive" as often as it means a real refusal, and both answer identically to a `kill(pid, 0)` probe.

## What changed

After `killpg`, the group's actual membership decides, in exactly one listing pass — not a repeat-until-stable loop, which would hang against an ordinary respawning supervisor from `Child::drop`. A new `containment::unix::group` module lists members (`sysctl(KERN_PROC_PGRP)` on macOS, `/proc` on Linux) and classifies each one.

`ProcessId::is_alive` gates every member first, so a zombie, a departed pid, or a pid recycled onto an unrelated process is never counted as a survivor — this matters because a foreign-uid zombie answers `EPERM` exactly like a foreign-uid live refuser. A member confirmed alive is then handled by one shared function: `SIGKILL` re-sends the real signal, since delivering it twice is identical to delivering it once; `SIGTERM` only probes with `kill(pid, 0)`, because real programs treat a second `SIGTERM` as "abort now, skip cleanup". The `SIGTERM` path's guarantee is correspondingly narrower and says so in its rustdoc. Anything unexpected is `Unassessable`, never folded into either "refused" or "cleared".

`graceful_shutdown_tree` holds the refusal and continues rather than returning it from its first line — otherwise reporting the refusal honestly would skip the grace wait and the hard sweep, stranding every member that could still have been reached. Both `Child::drop` impls classify teardown failures so that #61's own honest error does not fire the `debug_assert` and abort during unwind.

## Interaction with #54

`converge` lists the pgid at a strictly later instant than `killpg`'s own delivery, so a pgid recycled in between is a hazard #54 owns. That window is wider than #54 currently describes: `SharedChild::new`'s internal `try_wait()` reaps a fast-exiting child inside `spawn()` itself, so a contained root can reach teardown already reaped on the ordinary spawn-then-drop path, with no `wait()` call by the caller ([detail on #54](https://github.com/bindreams/cosca/issues/54#issuecomment-5303632866)).

This change does not widen it. Both new signal-delivery paths re-verify identity before delivering — on Linux atomically, through `open_verified`'s pidfd — and the two paths that signal without an identity check, `killpg` itself and the direct-to-leader `EPERM` fallback, are inherited unmodified. Reaping alone is harmless anyway: an absent pgid answers `ESRCH` and lists as empty, so teardown converges to cleared. The exposure is reap *plus* reuse before the signal lands, and #54 owns pinning the pgid.

## Not included

Task 6 of the plan needs `testbin/` and `.github/workflows/ci.yaml`, outside this change's file scope.
