### PR TITLE
feat(macos): expose the marker's EOF as a tree-drained edge (closes #60)

### DIFF
--- a/src/containment.rs
+++ b/src/containment.rs
@@ -213,6 +213,10 @@ pub(crate) mod dispatch;
 #[allow(unused_imports)]
 pub(crate) use dispatch::{attach, prepare, Attached, Prepared};
 
+#[cfg(target_os = "macos")]
+#[path = "containment/marker_eof.rs"]
+pub(crate) mod marker_eof;
+
 #[cfg(test)]
 #[path = "containment_tests.rs"]
 mod containment_tests;

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -164,21 +164,6 @@ impl Attached {
         }
     }
 
-    /// The supervisor's read end of the marker pipe, when this mechanism is the macOS fd
-    /// marker. `None` for every other mechanism (nothing else exposes a kernel drain edge).
-    ///
-    /// No non-test caller exists yet outside `wait_drained` below — wiring an actual consumer
-    /// (`graceful_shutdown_tree`'s conditional escalation) is a later change's job, not this
-    /// accessor's. `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
-    #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
-    pub(crate) fn marker_read_end(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
-        match self {
-            Attached::FdMarker(m) => Some(m.read_end()),
-            _ => None,
-        }
-    }
-
     /// Block until every member of the contained tree has EXITED (not reaped), or until
     /// `deadline`. `Unsupported` on every mechanism without a kernel drain edge — presently all
     /// of them except the macOS fd marker.
@@ -186,33 +171,25 @@ impl Attached {
     /// No non-test caller exists yet: wiring `graceful_shutdown_tree`'s conditional escalation
     /// to consult this is a later change's deliverable, not this one's. `#[allow(dead_code)]`
     /// reflects that honestly, mirroring `marker_eof::probe`.
+    ///
+    /// Delegates to [`Marker::wait_drained`](crate::containment::fdmarker::Marker::wait_drained)
+    /// rather than handing out a bare `BorrowedFd` (as an earlier `marker_read_end` accessor
+    /// did): that method re-checks the read end's identity first, the same way
+    /// `hard_kill`/`terminate` do, before trusting the descriptor at all.
     #[cfg(target_os = "macos")]
     #[allow(dead_code)]
     pub(crate) fn wait_drained(
         &self,
         deadline: Option<Option<std::time::Instant>>,
     ) -> Result<crate::containment::marker_eof::TreeDrain, Error> {
-        if let Some(read_end) = self.marker_read_end() {
-            // This process is the supervisor: it must have closed its own copy of the write
-            // end at spawn time (fdmarker::install's contract), or the edge could never fire.
-            // A deliberately-constructed HeldByUs condition still needs a real Err, not a
-            // panic, so the enforcement lives in
-            // `refuse_if_write_end_held`'s Err return, not here; this assert instead catches
-            // a violation of that contract reaching THIS, the crate's own call site, in debug
-            // builds — the crate's own code path, not a test deliberately constructing the
-            // condition.
-            debug_assert_ne!(
-                crate::containment::marker_eof::write_end_check(read_end),
-                crate::containment::marker_eof::WriteEndCheck::HeldByUs,
-                "the supervisor still holds a copy of the marker write end - the tree-drain edge can never fire"
-            );
-            return crate::containment::marker_eof::block_until_drained(read_end, deadline);
+        match self {
+            Attached::FdMarker(m) => m.wait_drained(deadline),
+            _ => Err(Error::Unsupported {
+                op: "wait for the contained tree to drain".into(),
+                platform: std::env::consts::OS,
+                detail: "this child's containment mechanism exposes no kernel edge for tree drain".into(),
+            }),
         }
-        Err(Error::Unsupported {
-            op: "wait for the contained tree to drain".into(),
-            platform: std::env::consts::OS,
-            detail: "this child's containment mechanism exposes no kernel edge for tree drain".into(),
-        })
     }
 }
 

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -163,6 +163,57 @@ impl Attached {
             Attached::TreeWalk(_) => true,
         }
     }
+
+    /// The supervisor's read end of the marker pipe, when this mechanism is the macOS fd
+    /// marker. `None` for every other mechanism (nothing else exposes a kernel drain edge).
+    ///
+    /// No non-test caller exists yet outside `wait_drained` below — wiring an actual consumer
+    /// (`graceful_shutdown_tree`'s conditional escalation) is #62's job, not this accessor's.
+    /// `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
+    #[cfg(target_os = "macos")]
+    #[allow(dead_code)]
+    pub(crate) fn marker_read_end(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        match self {
+            Attached::FdMarker(m) => Some(m.read_end()),
+            _ => None,
+        }
+    }
+
+    /// Block until every member of the contained tree has EXITED (not reaped), or until
+    /// `deadline`. `Unsupported` on every mechanism without a kernel drain edge — presently all
+    /// of them except the macOS fd marker. The cross-platform surface over this is #62.
+    ///
+    /// No non-test caller exists yet: wiring `graceful_shutdown_tree`'s conditional escalation
+    /// to consult this is #62's deliverable, not #60's. `#[allow(dead_code)]` reflects that
+    /// honestly, mirroring `marker_eof::probe`.
+    #[cfg(target_os = "macos")]
+    #[allow(dead_code)]
+    pub(crate) fn wait_drained(
+        &self,
+        deadline: Option<Option<std::time::Instant>>,
+    ) -> Result<crate::containment::marker_eof::TreeDrain, Error> {
+        if let Some(read_end) = self.marker_read_end() {
+            // This process is the supervisor: it must have closed its own copy of the write
+            // end at spawn time (fdmarker::install's contract), or the edge could never fire.
+            // A deliberately-constructed HeldByUs condition (Task 2's own unit tests) still
+            // needs a real Err, not a panic, so the enforcement lives in
+            // `refuse_if_write_end_held`'s Err return, not here; this assert instead catches
+            // a violation of that contract reaching THIS, the crate's own call site, in debug
+            // builds — the crate's own code path, not a test deliberately constructing the
+            // condition.
+            debug_assert_ne!(
+                crate::containment::marker_eof::write_end_check(read_end),
+                crate::containment::marker_eof::WriteEndCheck::HeldByUs,
+                "the supervisor still holds a copy of the marker write end - the tree-drain edge can never fire"
+            );
+            return crate::containment::marker_eof::block_until_drained(read_end, deadline);
+        }
+        Err(Error::Unsupported {
+            op: "wait for the contained tree to drain".into(),
+            platform: std::env::consts::OS,
+            detail: "this child's containment mechanism exposes no kernel edge for tree drain".into(),
+        })
+    }
 }
 
 /// Returns `true` when the current process is the outermost contained root

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -168,8 +168,8 @@ impl Attached {
     /// marker. `None` for every other mechanism (nothing else exposes a kernel drain edge).
     ///
     /// No non-test caller exists yet outside `wait_drained` below — wiring an actual consumer
-    /// (`graceful_shutdown_tree`'s conditional escalation) is #62's job, not this accessor's.
-    /// `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
+    /// (`graceful_shutdown_tree`'s conditional escalation) is a later change's job, not this
+    /// accessor's. `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
     #[cfg(target_os = "macos")]
     #[allow(dead_code)]
     pub(crate) fn marker_read_end(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
@@ -181,11 +181,11 @@ impl Attached {
 
     /// Block until every member of the contained tree has EXITED (not reaped), or until
     /// `deadline`. `Unsupported` on every mechanism without a kernel drain edge — presently all
-    /// of them except the macOS fd marker. The cross-platform surface over this is #62.
+    /// of them except the macOS fd marker.
     ///
     /// No non-test caller exists yet: wiring `graceful_shutdown_tree`'s conditional escalation
-    /// to consult this is #62's deliverable, not #60's. `#[allow(dead_code)]` reflects that
-    /// honestly, mirroring `marker_eof::probe`.
+    /// to consult this is a later change's deliverable, not this one's. `#[allow(dead_code)]`
+    /// reflects that honestly, mirroring `marker_eof::probe`.
     #[cfg(target_os = "macos")]
     #[allow(dead_code)]
     pub(crate) fn wait_drained(
@@ -195,8 +195,8 @@ impl Attached {
         if let Some(read_end) = self.marker_read_end() {
             // This process is the supervisor: it must have closed its own copy of the write
             // end at spawn time (fdmarker::install's contract), or the edge could never fire.
-            // A deliberately-constructed HeldByUs condition (Task 2's own unit tests) still
-            // needs a real Err, not a panic, so the enforcement lives in
+            // A deliberately-constructed HeldByUs condition still needs a real Err, not a
+            // panic, so the enforcement lives in
             // `refuse_if_write_end_held`'s Err return, not here; this assert instead catches
             // a violation of that contract reaching THIS, the crate's own call site, in debug
             // builds — the crate's own code path, not a test deliberately constructing the

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -408,3 +408,52 @@ fn wait_drained_is_unsupported_without_a_marker() {
         assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
     }
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn wait_drained_reports_members_remain_then_all_members_exited() {
+    use super::Attached;
+    use crate::containment::fdmarker::{pipe_handle_of, Marker, PreparedMarker};
+    use crate::containment::marker_eof::TreeDrain;
+    use std::os::fd::{AsFd, OwnedFd};
+
+    // A real holder in a separate process, mirroring marker_eof_tests.rs's
+    // spawn_marker_holder: the marker's write end lives in the child, not in-process, so
+    // wait_drained observes a genuinely open, then genuinely closed, write end.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh").args(["sh", "-c", "exec cat >/dev/null"]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+
+    // wait_drained/marker_read_end never consult handle/read_handle/fd — only
+    // hard_kill/terminate do — so a real value for the read end's own handle stands in for
+    // both fields here without replicating install()'s full write-end capture sequence.
+    let handle = pipe_handle_of(marker.as_fd()).expect("handle");
+    let prepared = PreparedMarker {
+        read: OwnedFd::from(marker),
+        handle,
+        read_handle: handle,
+        fd: 3,
+    };
+    let attached = Attached::FdMarker(Marker::new(prepared, None, None, false));
+
+    assert_eq!(
+        attached
+            .wait_drained(Some(Some(std::time::Instant::now())))
+            .expect("bounded wait while the holder is alive"),
+        TreeDrain::MembersRemain
+    );
+
+    drop(stdin); // cat's stdin EOFs, so cat exits, closing its inherited marker write end
+    child.wait().expect("reap");
+
+    assert_eq!(
+        attached
+            .wait_drained(None)
+            .expect("unbounded wait after the holder exits"),
+        TreeDrain::AllMembersExited
+    );
+}

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -334,9 +334,9 @@ fn a_failed_marker_install_leaves_prepare_without_one() {
     use crate::containment::{ContainMode, ContainRequest, Nesting};
     // This test doesn't assert on log content itself, but triggering `Fault::Pipe` DOES emit
     // "fd marker: pipe() failed" into the shared `log_capture` buffer once any test has called
-    // `log_capture::install()` — held for the whole body so it cannot land inside
-    // `fdmarker_tests.rs`'s `each_install_failure_arm_falls_back_and_says_which_step_failed`'s
-    // scanned window on another thread.
+    // `log_capture::install()` — held for the whole body so it cannot land inside the sibling
+    // fd-marker test module's fault-injection log-scanning test's scanned window on another
+    // thread.
     let _serialize = lock_for_log_assertion();
     let mut cmd = std::process::Command::new("/usr/bin/true");
     set_fault(Some(Fault::Pipe));
@@ -428,9 +428,10 @@ fn wait_drained_reports_members_remain_then_all_members_exited() {
     let marker = child.fd_read_end(3.into()).expect("marker read end");
     let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
 
-    // wait_drained/marker_read_end never consult handle/read_handle/fd — only
-    // hard_kill/terminate do — so a real value for the read end's own handle stands in for
-    // both fields here without replicating install()'s full write-end capture sequence.
+    // wait_drained now consults read_handle too (Marker::wait_drained calls
+    // check_read_end_still_valid first, same as hard_kill/terminate) — so this uses the read
+    // end's REAL current handle for both fields, standing in for install()'s full write-end
+    // capture sequence without replicating it.
     let handle = pipe_handle_of(marker.as_fd()).expect("handle");
     let prepared = PreparedMarker {
         read: OwnedFd::from(marker),

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -394,3 +394,17 @@ fn resolve_root_id_distinguishes_a_denied_pid_from_a_vanished_one() {
     };
     assert!(detail.contains("vanished"), "absence must not read as denial: {detail}");
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn wait_drained_is_unsupported_without_a_marker() {
+    // Mirrors `require_contained`: a mechanism that cannot answer says so, rather than
+    // implying a guarantee it has not got.
+    use super::Attached;
+    for attached in [Attached::None, Attached::Delegated] {
+        let err = attached
+            .wait_drained(Some(Some(std::time::Instant::now())))
+            .expect_err("a mechanism with no drain edge must be Unsupported");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+}

--- a/src/containment/fdmarker.rs
+++ b/src/containment/fdmarker.rs
@@ -90,8 +90,8 @@ pub(crate) struct ProcFileInfo {
 pub(crate) struct PipeFdInfo {
     pfi: ProcFileInfo,
     pipe_stat: libc::vinfo_stat,
-    pipe_handle: u64,
-    pipe_peerhandle: u64,
+    pub(crate) pipe_handle: u64,
+    pub(crate) pipe_peerhandle: u64,
     pipe_status: i32,
     rfu_1: i32,
 }
@@ -117,7 +117,7 @@ pub(crate) fn pipe_handle_of(fd: BorrowedFd<'_>) -> Option<u64> {
 /// reported as a pipe, so a denial here is not the routine "not a pipe" case; it means the
 /// query was refused between the two calls (matching the module docs' credential-changing-exec
 /// scenario), and each caller needs to react to that specifically — see each call site.
-enum FdPipeInfoQuery {
+pub(crate) enum FdPipeInfoQuery {
     Found(PipeFdInfo),
     /// Not a pipe, the fd closed, or the pid is gone — indistinguishable at this layer, and
     /// (unlike `PipeQuery`) not worth separating: nothing calls this hoping to count denials
@@ -127,7 +127,7 @@ enum FdPipeInfoQuery {
     Denied,
 }
 
-fn fd_pipe_info(pid: RawPid, fd: libc::c_int) -> FdPipeInfoQuery {
+pub(crate) fn fd_pipe_info(pid: RawPid, fd: libc::c_int) -> FdPipeInfoQuery {
     let mut info: PipeFdInfo = unsafe { std::mem::zeroed() };
     let size = std::mem::size_of::<PipeFdInfo>() as libc::c_int;
     // SAFETY: proc_pidfdinfo writes up to `size` bytes into `info`; pointer and size match.
@@ -170,7 +170,7 @@ pub(crate) struct Holder {
 /// because `holders()` (scanning the WHOLE host) and `holds_marker_query()` (re-checking a
 /// KNOWN candidate) need to react to a denial completely differently. See the module docs and
 /// each caller for why.
-enum PipeQuery {
+pub(crate) enum PipeQuery {
     /// The fd table was read; these are its pipe descriptors (possibly none).
     Found(Vec<libc::c_int>),
     /// The pid is gone (`ESRCH`) — expected, never worth logging.
@@ -364,7 +364,7 @@ fn fd_list_buf_bytes(cap: usize, entry: usize) -> std::io::Result<libc::c_int> {
         })
 }
 
-fn pipe_fds_of(pid: RawPid) -> PipeQuery {
+pub(crate) fn pipe_fds_of(pid: RawPid) -> PipeQuery {
     let entry = std::mem::size_of::<libc::proc_fdinfo>();
     let needed = clear_errno_and_call(|| unsafe {
         libc::proc_pidinfo(pid as libc::c_int, libc::PROC_PIDLISTFDS, 0, std::ptr::null_mut(), 0)

--- a/src/containment/fdmarker.rs
+++ b/src/containment/fdmarker.rs
@@ -901,7 +901,6 @@ impl Marker {
 
     /// The supervisor's read end. `read()` on it returns EOF exactly when the last holder of
     /// the write end is gone.
-    #[allow(dead_code)]
     pub(crate) fn read_end(&self) -> BorrowedFd<'_> {
         self.read.as_fd()
     }

--- a/src/containment/fdmarker.rs
+++ b/src/containment/fdmarker.rs
@@ -57,6 +57,7 @@
 //! principle, stumble onto by number.
 
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::time::Instant;
 
 use crate::identity::RawPid;
 
@@ -903,6 +904,38 @@ impl Marker {
     /// the write end is gone.
     pub(crate) fn read_end(&self) -> BorrowedFd<'_> {
         self.read.as_fd()
+    }
+
+    /// Block until every holder of the marker's write end has EXITED (not reaped), or until
+    /// `deadline` — see `marker_eof::block_until_drained`'s own doc for what `deadline` means
+    /// and what it guarantees.
+    ///
+    /// Calls [`check_read_end_still_valid`](Self::check_read_end_still_valid) FIRST, exactly
+    /// like `hard_kill`/`terminate` do: `marker_eof::block_until_drained` takes a bare
+    /// `BorrowedFd` and has no way to know it is still the SAME kernel object `self` was built
+    /// around, only that the number is still open. Skipping this check here would let a
+    /// reissued fd (an unrelated pipe with no open write end) deliver `EV_EOF` immediately and
+    /// report `AllMembersExited` for a fully live tree — the same false-edge risk `hard_kill`
+    /// refuses on, not merely a discrepancy between two code paths.
+    #[allow(dead_code)] // no non-test caller yet; mirrors marker_eof::probe / Attached::wait_drained
+    pub(crate) fn wait_drained(
+        &self,
+        deadline: Option<Option<Instant>>,
+    ) -> Result<crate::containment::marker_eof::TreeDrain, Error> {
+        self.check_read_end_still_valid()?;
+        // This process is the supervisor: it must have closed its own copy of the write end at
+        // spawn time (`install`'s contract), or the edge could never fire. A deliberately
+        // constructed `HeldByUs` condition still needs a real `Err`, not a panic, so the
+        // enforcement lives in `refuse_if_write_end_held`'s `Err` return, not here; this assert
+        // instead catches a violation of that contract reaching THIS, the crate's own call
+        // site, in debug builds — the crate's own code path, not a test deliberately
+        // constructing the condition.
+        debug_assert_ne!(
+            crate::containment::marker_eof::write_end_check(self.read_end()),
+            crate::containment::marker_eof::WriteEndCheck::HeldByUs,
+            "the supervisor still holds a copy of the marker write end - the tree-drain edge can never fire"
+        );
+        crate::containment::marker_eof::block_until_drained(self.read_end(), deadline)
     }
 
     /// `Err` distinguishes a genuine teardown-mechanism failure (`Error::Io`/`Unsupported`,

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -43,6 +43,13 @@
 //!   proportional to what the writer produces, for as long as the writer keeps producing it) —
 //!   this module chooses zero CPU for the unbounded case, since that is also the case with no
 //!   deadline to bound the alternative.
+//!
+//!   The verdict stays TRUE while that writer is blocked, which is why this is a cost and not a
+//!   wrong answer: a member parked in `write()` is still alive and still holds a write end, so
+//!   the tree really does still have a member and `MembersRemain` is what an honest observer
+//!   reports. The blocked member is visible in the process table; the alternative trades that
+//!   visibility for a supervisor quietly spending a third of a core (measured 23-37% against a
+//!   writer sustaining ~1 GB/s) to carry a member that is already outside the marker's contract.
 
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::time::Instant;

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -1,0 +1,352 @@
+//! The macOS fd-marker's EOF edge: the event that fires when the last holder of the marker's
+//! write end exits.
+//!
+//! Every member of the tree inherits the write end (`fdmarker`); the supervisor keeps the read
+//! end. The kernel closes descriptors on process exit unconditionally, so the edge needs no
+//! cooperation from the tree, no bookkeeping from the supervisor, and — unlike ppid
+//! enumeration — it covers members reparented to launchd.
+//!
+//! Two limits, both structural rather than incidental:
+//!
+//! - **Exited, not reaped.** A descriptor closes before the zombie is collected, so the edge
+//!   says every member has *exited*; it says nothing about statuses. A caller wanting a
+//!   status still waits on the root.
+//! - **A member that `close()`s the descriptor leaves the set.** The edge is exactly as
+//!   trustworthy as the marker's membership: it can fire while such a member still runs.
+//!   That is the same trust model as the marker itself — naive-child containment.
+//!
+//! Every knote here is armed with `NOTE_LOWAT` and a high low-water mark. `EV_EOF` is always
+//! the sole verdict, unconditional of buffered bytes — but the low-water mark itself is
+//! clamped by the kernel to the pipe's actual buffer capacity (measured ~64 KiB on this host),
+//! so it suppresses wakeups for ordinary writes (which is all the crate should ever produce —
+//! nothing in the crate writes to the marker) without being an absolute guarantee against a
+//! member that sustains output at or above that ceiling. That residual case degrades to a
+//! bounded, deadline-respecting, CPU-proportional drain rather than a genuine kernel block —
+//! documented and tested, not assumed away.
+
+use std::os::fd::{AsRawFd, BorrowedFd};
+use std::time::Instant;
+
+use nix::sys::event::{EvFlags, EventFilter, FilterFlag, KEvent, Kqueue};
+
+use crate::error::Error;
+
+#[cfg(test)]
+#[path = "marker_eof_tests.rs"]
+mod marker_eof_tests;
+
+/// Whether every holder of the marker's write end has **exited**.
+///
+/// Exited is not reaped: descriptors close before the zombie is collected, so
+/// `AllMembersExited` never implies a status is available. It also means every holder of the
+/// *marker*, which a member that closed the descriptor has stopped being.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TreeDrain {
+    /// Every marker holder has exited. Statuses have NOT been collected.
+    AllMembersExited,
+    /// At least one marker holder was still running at the deadline.
+    MembersRemain,
+}
+
+/// The `NOTE_LOWAT` low-water mark every knote in this module is armed with. Clamped by the
+/// kernel to the pipe's actual buffer capacity — see the module doc for what this does and
+/// does not guarantee.
+const LOW_WATER_MARK: isize = 1 << 20; // 1 MiB (requested; effectively min(this, pipe capacity))
+
+/// Make the read end non-blocking (idempotent). Raw `libc::fcntl`, matching the crate's
+/// existing style (`src/elevation/posix.rs`) rather than `nix::fcntl`. The read end belongs
+/// solely to the supervisor, so the file-status flag is ours to set.
+fn ensure_nonblocking(read_end: BorrowedFd<'_>) -> Result<(), Error> {
+    let fd = read_end.as_raw_fd();
+    // SAFETY: fcntl(F_GETFL/F_SETFL) on a live borrowed fd; no pointer args beyond the flags.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 {
+            return Err(Error::Io(std::io::Error::last_os_error()));
+        }
+        if flags & libc::O_NONBLOCK != 0 {
+            return Ok(());
+        }
+        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            return Err(Error::Io(std::io::Error::last_os_error()));
+        }
+    }
+    Ok(())
+}
+
+/// Read and discard up to `n` bytes, tolerating short reads. Bounded by `n` — a count the
+/// KERNEL just reported via the triggering kevent's own `data` field, never "keep reading
+/// until it stops." Below the low-water clamp this branch never runs at all; at or above it,
+/// this is what keeps a single round bounded — the OUTER loop (`block_until_drained`) is what
+/// keeps the total wait bounded by the caller's deadline despite repeated rounds.
+fn drain_pending(read_end: BorrowedFd<'_>, mut n: usize) -> Result<(), Error> {
+    let mut buf = [0u8; 4096];
+    while n > 0 {
+        let want = n.min(buf.len());
+        match nix::unistd::read(read_end, &mut buf[..want]) {
+            Ok(0) => return Ok(()), // EOF raced ahead of us; nothing left to drain
+            Ok(got) => n -= got,
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(nix::errno::Errno::EAGAIN) => return Ok(()), // a concurrent reader won the race
+            Err(e) => return Err(Error::Io(e.into())),
+        }
+    }
+    Ok(())
+}
+
+/// Create a kqueue with `EVFILT_READ` armed on the marker read end, `NOTE_LOWAT`-gated (see
+/// the module doc for what this does and does not guarantee) so ordinary writes never wake
+/// it — only `EV_EOF` does.
+///
+/// One kqueue PER WAITER, deliberately: a knote is keyed on `(kqueue, fd, filter)`, so private
+/// kqueues compose (two waiters both see the edge) where two registrations of the same
+/// descriptor on one shared queue would take each other's place.
+///
+/// `unbounded_wait` says whether the caller intends to wait with no deadline: an `Unassessable`
+/// write-end check combined with an unbounded wait is exactly the condition under which this
+/// primitive could hang forever with no elevated runtime signal — see
+/// `refuse_if_write_end_held`.
+pub(crate) fn arm(read_end: BorrowedFd<'_>, unbounded_wait: bool) -> Result<Kqueue, Error> {
+    ensure_nonblocking(read_end)?;
+    refuse_if_write_end_held(read_end, unbounded_wait)?;
+    let kq = Kqueue::new().map_err(|e| Error::Io(e.into()))?;
+    let change = KEvent::new(
+        read_end.as_raw_fd() as usize,
+        EventFilter::EVFILT_READ,
+        EvFlags::EV_ADD | EvFlags::EV_RECEIPT,
+        FilterFlag::NOTE_LOWAT,
+        LOW_WATER_MARK,
+        0,
+    );
+    let add_result = crate::wait::backend::add_with_receipt(&kq, change)?;
+    if add_result != 0 {
+        return Err(Error::Io(std::io::Error::from_raw_os_error(add_result as i32)));
+    }
+    Ok(kq)
+}
+
+/// Interpret ONE `EVFILT_READ` event on the marker read end — the single definition shared by
+/// the one-shot drain (`drain_kqueue`) and the blocking wait's loop body
+/// (`block_until_drained`), so there is no hand-rolled twin to drift.
+///
+/// `Ok(Some(AllMembersExited))` = `EV_EOF` was set — final, regardless of buffered bytes, so no
+/// read happens in this branch. `Ok(None)` = readable without `EV_EOF`, which with
+/// `NOTE_LOWAT` armed only happens once buffered bytes reach the clamp: `event.data()` is
+/// exactly how many are queued, discarded in one bounded round via `drain_pending`. `Err` =
+/// `EV_ERROR` or a `kevent`/read failure.
+fn interpret_read_event(event: &KEvent, read_end: BorrowedFd<'_>) -> Result<Option<TreeDrain>, Error> {
+    if event.flags().contains(EvFlags::EV_ERROR) {
+        return Err(Error::Io(std::io::Error::from_raw_os_error(event.data() as i32)));
+    }
+    if event.flags().contains(EvFlags::EV_EOF) {
+        return Ok(Some(TreeDrain::AllMembersExited));
+    }
+    // `data` is a byte count for a readable, non-EOF, non-error EVFILT_READ event — never
+    // negative per the kqueue contract this module relies on everywhere else. `.max(0)` is a
+    // release-build fallback only; a violation here is a kqueue/ABI surprise or a bug in this
+    // module's own event handling, not an ordinary runtime condition, so it gets a loud
+    // debug_assert rather than being silently absorbed into the routine "nothing to drain yet"
+    // code path.
+    debug_assert!(
+        event.data() >= 0,
+        "EVFILT_READ data must be non-negative per kernel contract, got {}",
+        event.data()
+    );
+    drain_pending(read_end, event.data().max(0) as usize)?;
+    Ok(None) // bytes discarded; holders remain (EV_EOF was clear)
+}
+
+/// Take one pending event from an armed kqueue without blocking. `Ok(Some(_))` = the drain was
+/// observed; `Ok(None)` = nothing conclusive yet (nothing pending, or — only once the
+/// low-water clamp is reached — a member's bytes, discarded) — re-wait; `Err` = see
+/// `interpret_read_event`.
+pub(crate) fn drain_kqueue(kq: &Kqueue, read_end: BorrowedFd<'_>) -> Result<Option<TreeDrain>, Error> {
+    let zero = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+    let mut events = [KEvent::new(0, EventFilter::EVFILT_READ, EvFlags::empty(), FilterFlag::empty(), 0, 0)];
+    loop {
+        match kq.kevent(&[], &mut events, Some(zero)) {
+            Ok(0) => return Ok(None), // nothing pending
+            Ok(_) => return interpret_read_event(&events[0], read_end),
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(e) => return Err(Error::Io(e.into())),
+        }
+    }
+}
+
+/// One-shot drain check: exact, not heuristic — arms a private kqueue and reads its
+/// zero-timeout verdict off `EV_EOF`, the same authoritative signal `block_until_drained`
+/// uses. `Ok(None)` from `drain_kqueue` (nothing pending yet) means a write end is open with
+/// nothing queued: `MembersRemain`, correctly, since `AllMembersExited` is only ever reported
+/// when the kernel itself said `EV_EOF`.
+///
+/// No production caller exists yet — kept as crate-internal primitive surface for a future
+/// consumer, exercised directly by the unit tests below. `#[allow(dead_code)]` reflects that
+/// honestly instead of leaving the lib target to fail `cargo clippy --all-targets -D
+/// warnings`, which sees no test-cfg code and would otherwise flag this as unused. A one-shot
+/// check never blocks, so it never risks a caller-invisible hang: it always passes `false` for
+/// `arm`'s `unbounded_wait`.
+#[allow(dead_code)]
+pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
+    let kq = arm(read_end, false)?;
+    match drain_kqueue(&kq, read_end)? {
+        Some(verdict) => Ok(verdict),
+        None => Ok(TreeDrain::MembersRemain),
+    }
+}
+
+/// Block until every marker holder has exited, or until `deadline`.
+///
+/// `deadline` follows the crate's watch convention: `None` = block indefinitely, `Some(None)`
+/// = a duration that overflowed `Instant` (also indefinite), `Some(Some(at))` = an absolute
+/// deadline; a deadline already in the past makes this behave exactly like `probe` (there is a
+/// dedicated test pinning that equivalence). Uses one kernel syscall per wait round — no
+/// interval is chosen anywhere in this path.
+///
+/// **The deadline is checked explicitly at the top of every round, not inferred from `kevent`
+/// returning 0.** A member sustaining writes past the `NOTE_LOWAT` clamp keeps the descriptor
+/// continuously ready, and `kevent` returns as soon as ANY event is ready — including with a
+/// zero/expired timeout — so it never actually returns "0 events, timed out" while the pipe
+/// stays full; relying on that alone lets the wait overrun the deadline by an unbounded number
+/// of rounds. Checking `remaining(deadline)` before each `kevent` call bounds the overrun to at
+/// most one in-flight round's drain instead.
+pub(crate) fn block_until_drained(
+    read_end: BorrowedFd<'_>,
+    deadline: Option<Option<Instant>>,
+) -> Result<TreeDrain, Error> {
+    let unbounded_wait = crate::wait::remaining(deadline).is_none();
+    let kq = arm(read_end, unbounded_wait)?;
+    let mut events = [KEvent::new(0, EventFilter::EVFILT_READ, EvFlags::empty(), FilterFlag::empty(), 0, 0)];
+    loop {
+        // Recompute from the absolute deadline so an EINTR retry cannot extend the total wait,
+        // AND so a continuously-ready descriptor (a sustained writer) cannot make `kevent`
+        // return real events forever without this loop ever noticing the deadline passed.
+        let remaining = crate::wait::remaining(deadline);
+        if remaining == Some(std::time::Duration::ZERO) {
+            return Ok(TreeDrain::MembersRemain); // deadline elapsed, a holder is alive
+        }
+        let timeout = remaining.map(|d| libc::timespec {
+            tv_sec: d.as_secs().min(i64::MAX as u64) as libc::time_t,
+            tv_nsec: d.subsec_nanos() as libc::c_long,
+        });
+        match kq.kevent(&[], &mut events, timeout) {
+            Ok(0) => return Ok(TreeDrain::MembersRemain), // genuinely timed out, no events
+            Ok(_) => {
+                if let Some(verdict) = interpret_read_event(&events[0], read_end)? {
+                    return Ok(verdict);
+                }
+                // bytes discarded (only past the low-water clamp), holders remain — loop back,
+                // where the deadline is re-checked BEFORE the next kevent call
+            }
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(e) => return Err(Error::Io(e.into())),
+        }
+    }
+}
+
+// Detecting a supervisor-retained write-end copy =====
+//
+// Reuses `fdmarker`'s own `PROC_PIDFDPIPEINFO` FFI surface (already `pub(crate)`) instead of
+// declaring a second copy of the same struct layout.
+
+use crate::containment::fdmarker::{fd_pipe_info, pipe_fds_of, FdPipeInfoQuery, PipeQuery};
+
+/// Whether THIS process still holds a copy of the marker's write end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteEndCheck {
+    /// No descriptor in this process refers to the marker's write end.
+    Clear,
+    /// The supervisor kept a copy — the edge can never fire.
+    HeldByUs,
+    /// The kernel would not describe our own descriptors, or `read_end` is not a pipe at all —
+    /// the check is inconclusive.
+    Unassessable,
+}
+
+/// Scan this process's own descriptors for a copy of the marker's write end.
+///
+/// Exact rather than heuristic: the read end's `pipe_peerhandle` IS the write end's
+/// `pipe_handle`, so the comparison names one kernel object. Costs one `PROC_PIDLISTFDS` plus
+/// one `proc_pidfdinfo` per pipe descriptor of this process, once per arm.
+///
+/// **Scope, stated honestly:** this catches a supervisor bug (its OWN retained copy) at the
+/// instant of the scan. It is not a general liveness oracle for the write end: a foreign
+/// process holding a copy is invisible to a self-scan by construction (mitigated instead by
+/// the marker's parent-side descriptor not being inheritable), and a copy created in THIS
+/// process after the scan (e.g. a `dup()` racing the caller) is a snapshot gap of the same
+/// irreducible-window kind already documented at the `kill(2)` re-verify in
+/// `src/wait/macos.rs` — checked-then-acted-on, not held under a lock.
+pub(crate) fn write_end_check(read_end: BorrowedFd<'_>) -> WriteEndCheck {
+    let me = std::process::id();
+    let write_handle = match fd_pipe_info(me, read_end.as_raw_fd()) {
+        FdPipeInfoQuery::Found(info) => info.pipe_peerhandle,
+        FdPipeInfoQuery::Absent | FdPipeInfoQuery::Denied => return WriteEndCheck::Unassessable,
+    };
+    let fds = match pipe_fds_of(me) {
+        PipeQuery::Found(fds) => fds,
+        PipeQuery::Gone | PipeQuery::Denied => return WriteEndCheck::Unassessable,
+    };
+    let mut any_probe_failed = false;
+    for fd in fds {
+        if fd == read_end.as_raw_fd() {
+            continue; // the read end itself
+        }
+        match fd_pipe_info(me, fd) {
+            FdPipeInfoQuery::Found(info) if info.pipe_handle == write_handle => return WriteEndCheck::HeldByUs,
+            FdPipeInfoQuery::Found(_) => {}
+            // `pipe_fds_of` just reported this exact fd as a pipe (moments ago), so this is
+            // the routine "vanished between the two calls" case, not a probe failure.
+            FdPipeInfoQuery::Absent => {}
+            // A per-fd probe can fail transiently (the fd closed between listing and query).
+            // Folded into Unassessable rather than silently treated as "not a match": the ONE
+            // probe that would have found the retained copy is exactly the one that can fail
+            // this way, and "exact rather than heuristic" (above) must not quietly degrade to
+            // "exact except when it isn't."
+            FdPipeInfoQuery::Denied => any_probe_failed = true,
+        }
+    }
+    if any_probe_failed {
+        return WriteEndCheck::Unassessable;
+    }
+    WriteEndCheck::Clear
+}
+
+/// Refuse to watch an edge that provably cannot fire. `Unassessable` proceeds UNLESS the
+/// caller intends to wait with no deadline: an inconclusive scan combined with a bounded wait
+/// is capped by the caller's own deadline regardless, but combined with an UNBOUNDED wait it is
+/// exactly the condition under which this primitive could hang forever with no elevated
+/// runtime signal at all — so only that combination is refused.
+fn refuse_if_write_end_held(read_end: BorrowedFd<'_>, unbounded_wait: bool) -> Result<(), Error> {
+    match write_end_check(read_end) {
+        WriteEndCheck::Clear => Ok(()),
+        WriteEndCheck::Unassessable if !unbounded_wait => {
+            log::debug!("marker EOF: could not confirm this process holds no copy of the marker write end");
+            Ok(())
+        }
+        WriteEndCheck::Unassessable => {
+            log::warn!(
+                "marker EOF: could not confirm this process holds no copy of the marker write end, \
+                 and the caller is waiting with no deadline - refusing rather than risking an \
+                 unbounded hang"
+            );
+            Err(Error::Unassessable {
+                detail: "could not confirm this process holds no copy of the containment marker's \
+                         write end, and the wait has no deadline"
+                    .into(),
+                source: None,
+            })
+        }
+        WriteEndCheck::HeldByUs => {
+            // No debug_assert here: a deliberately-constructed HeldByUs condition must return
+            // Err, not panic, so callers (including tests) can observe it.
+            log::error!(
+                "marker EOF: this process still holds a copy of the marker write end - the tree-drain \
+                 edge can never fire. This is a cosca bug: the write end must be closed after spawn."
+            );
+            Err(Error::Containment {
+                detail: "the supervisor still holds a copy of the containment marker's write end, so the \
+                         tree-drain edge can never fire"
+                    .into(),
+            })
+        }
+    }
+}

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -162,7 +162,14 @@ fn interpret_read_event(event: &KEvent, read_end: BorrowedFd<'_>) -> Result<Opti
 /// `interpret_read_event`.
 pub(crate) fn drain_kqueue(kq: &Kqueue, read_end: BorrowedFd<'_>) -> Result<Option<TreeDrain>, Error> {
     let zero = libc::timespec { tv_sec: 0, tv_nsec: 0 };
-    let mut events = [KEvent::new(0, EventFilter::EVFILT_READ, EvFlags::empty(), FilterFlag::empty(), 0, 0)];
+    let mut events = [KEvent::new(
+        0,
+        EventFilter::EVFILT_READ,
+        EvFlags::empty(),
+        FilterFlag::empty(),
+        0,
+        0,
+    )];
     loop {
         match kq.kevent(&[], &mut events, Some(zero)) {
             Ok(0) => return Ok(None), // nothing pending
@@ -198,9 +205,12 @@ pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
 ///
 /// `deadline` follows the crate's watch convention: `None` = block indefinitely, `Some(None)`
 /// = a duration that overflowed `Instant` (also indefinite), `Some(Some(at))` = an absolute
-/// deadline; a deadline already in the past makes this behave exactly like `probe` (there is a
-/// dedicated test pinning that equivalence). Uses one kernel syscall per wait round — no
-/// interval is chosen anywhere in this path.
+/// deadline; a deadline already in the past still performs exactly one non-blocking check
+/// before concluding — the sticky, level-triggered `EV_EOF` a genuinely-already-drained tree
+/// left pending must be observed, not assumed away by the elapsed deadline alone (there is a
+/// dedicated test pinning this: an already-drained tree checked past a stale deadline still
+/// reports `AllMembersExited`, not a verdict inferred from "no time is left"). Uses one kernel
+/// syscall per wait round — no interval is chosen anywhere in this path.
 ///
 /// **The deadline is checked explicitly at the top of every round, not inferred from `kevent`
 /// returning 0.** A member sustaining writes past the `NOTE_LOWAT` clamp keeps the descriptor
@@ -208,22 +218,30 @@ pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
 /// zero/expired timeout — so it never actually returns "0 events, timed out" while the pipe
 /// stays full; relying on that alone lets the wait overrun the deadline by an unbounded number
 /// of rounds. Checking `remaining(deadline)` before each `kevent` call bounds the overrun to at
-/// most one in-flight round's drain instead.
+/// most one in-flight round's drain: once a round starts with the deadline already elapsed, a
+/// non-EOF event in THAT round (bytes drained, holders remain) returns immediately rather than
+/// looping back for another round — otherwise a sustained writer whose deadline has already
+/// elapsed would spin forever, since "elapsed" never becomes "more elapsed."
 pub(crate) fn block_until_drained(
     read_end: BorrowedFd<'_>,
     deadline: Option<Option<Instant>>,
 ) -> Result<TreeDrain, Error> {
     let unbounded_wait = crate::wait::remaining(deadline).is_none();
     let kq = arm(read_end, unbounded_wait)?;
-    let mut events = [KEvent::new(0, EventFilter::EVFILT_READ, EvFlags::empty(), FilterFlag::empty(), 0, 0)];
+    let mut events = [KEvent::new(
+        0,
+        EventFilter::EVFILT_READ,
+        EvFlags::empty(),
+        FilterFlag::empty(),
+        0,
+        0,
+    )];
     loop {
         // Recompute from the absolute deadline so an EINTR retry cannot extend the total wait,
         // AND so a continuously-ready descriptor (a sustained writer) cannot make `kevent`
         // return real events forever without this loop ever noticing the deadline passed.
         let remaining = crate::wait::remaining(deadline);
-        if remaining == Some(std::time::Duration::ZERO) {
-            return Ok(TreeDrain::MembersRemain); // deadline elapsed, a holder is alive
-        }
+        let already_elapsed = remaining == Some(std::time::Duration::ZERO);
         let timeout = remaining.map(|d| libc::timespec {
             tv_sec: d.as_secs().min(i64::MAX as u64) as libc::time_t,
             tv_nsec: d.subsec_nanos() as libc::c_long,
@@ -234,8 +252,14 @@ pub(crate) fn block_until_drained(
                 if let Some(verdict) = interpret_read_event(&events[0], read_end)? {
                     return Ok(verdict);
                 }
-                // bytes discarded (only past the low-water clamp), holders remain — loop back,
-                // where the deadline is re-checked BEFORE the next kevent call
+                // Bytes discarded (only past the low-water clamp), holders remain. A round that
+                // started with the deadline already elapsed stops here rather than looping back:
+                // see the doc comment above for why (a sustained writer past an elapsed deadline
+                // must not spin).
+                if already_elapsed {
+                    return Ok(TreeDrain::MembersRemain);
+                }
+                // otherwise loop back, where the deadline is re-checked BEFORE the next kevent call
             }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(e) => return Err(Error::Io(e.into())),

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -102,10 +102,8 @@ fn drain_pending(read_end: BorrowedFd<'_>, mut n: usize) -> Result<(), Error> {
 /// kqueues compose (two waiters both see the edge) where two registrations of the same
 /// descriptor on one shared queue would take each other's place.
 ///
-/// `unbounded_wait` says whether the caller intends to wait with no deadline: an `Unassessable`
-/// write-end check combined with an unbounded wait is exactly the condition under which this
-/// primitive could hang forever with no elevated runtime signal — see
-/// `refuse_if_write_end_held`.
+/// `unbounded_wait` says whether the caller intends to wait with no deadline — see
+/// `refuse_if_write_end_held` for why that matters.
 pub(crate) fn arm(read_end: BorrowedFd<'_>, unbounded_wait: bool) -> Result<Kqueue, Error> {
     ensure_nonblocking(read_end)?;
     refuse_if_write_end_held(read_end, unbounded_wait)?;
@@ -207,64 +205,21 @@ pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
 /// = a duration that overflowed `Instant` (also indefinite), `Some(Some(at))` = an absolute
 /// deadline; a deadline already in the past still performs exactly one non-blocking check
 /// before concluding — the sticky, level-triggered `EV_EOF` a genuinely-already-drained tree
-/// left pending must be observed, not assumed away by the elapsed deadline alone (there is a
-/// dedicated test pinning this: an already-drained tree checked past a stale deadline still
-/// reports `AllMembersExited`, not a verdict inferred from "no time is left"). Uses one kernel
-/// syscall per wait round — no interval is chosen anywhere in this path.
+/// left pending must be observed, not assumed away by the elapsed deadline alone. Uses one
+/// kernel syscall per wait round — no interval is chosen anywhere in this path.
 ///
-/// **The deadline is checked explicitly at the top of every round, not inferred from `kevent`
-/// returning 0.** A member sustaining writes past the `NOTE_LOWAT` clamp keeps the descriptor
-/// continuously ready, and `kevent` returns as soon as ANY event is ready — including with a
-/// zero/expired timeout — so it never actually returns "0 events, timed out" while the pipe
-/// stays full; relying on that alone lets the wait overrun the deadline by an unbounded number
-/// of rounds. Checking `remaining(deadline)` before each `kevent` call bounds the overrun to at
-/// most one in-flight round's drain: once a round starts with the deadline already elapsed, a
-/// non-EOF event in THAT round (bytes drained, holders remain) returns immediately rather than
-/// looping back for another round — otherwise a sustained writer whose deadline has already
-/// elapsed would spin forever, since "elapsed" never becomes "more elapsed."
+/// The per-round deadline-checking and `kevent` mechanics live in `wait::backend::block_on_kqueue`
+/// (shared with the proc-exit watch); this function supplies only the marker's own arm and
+/// per-event interpretation (`interpret_read_event`).
 pub(crate) fn block_until_drained(
     read_end: BorrowedFd<'_>,
     deadline: Option<Option<Instant>>,
 ) -> Result<TreeDrain, Error> {
     let unbounded_wait = crate::wait::remaining(deadline).is_none();
     let kq = arm(read_end, unbounded_wait)?;
-    let mut events = [KEvent::new(
-        0,
-        EventFilter::EVFILT_READ,
-        EvFlags::empty(),
-        FilterFlag::empty(),
-        0,
-        0,
-    )];
-    loop {
-        // Recompute from the absolute deadline so an EINTR retry cannot extend the total wait,
-        // AND so a continuously-ready descriptor (a sustained writer) cannot make `kevent`
-        // return real events forever without this loop ever noticing the deadline passed.
-        let remaining = crate::wait::remaining(deadline);
-        let already_elapsed = remaining == Some(std::time::Duration::ZERO);
-        let timeout = remaining.map(|d| libc::timespec {
-            tv_sec: d.as_secs().min(i64::MAX as u64) as libc::time_t,
-            tv_nsec: d.subsec_nanos() as libc::c_long,
-        });
-        match kq.kevent(&[], &mut events, timeout) {
-            Ok(0) => return Ok(TreeDrain::MembersRemain), // genuinely timed out, no events
-            Ok(_) => {
-                if let Some(verdict) = interpret_read_event(&events[0], read_end)? {
-                    return Ok(verdict);
-                }
-                // Bytes discarded (only past the low-water clamp), holders remain. A round that
-                // started with the deadline already elapsed stops here rather than looping back:
-                // see the doc comment above for why (a sustained writer past an elapsed deadline
-                // must not spin).
-                if already_elapsed {
-                    return Ok(TreeDrain::MembersRemain);
-                }
-                // otherwise loop back, where the deadline is re-checked BEFORE the next kevent call
-            }
-            Err(nix::errno::Errno::EINTR) => continue,
-            Err(e) => return Err(Error::Io(e.into())),
-        }
-    }
+    crate::wait::backend::block_on_kqueue(&kq, deadline, TreeDrain::MembersRemain, |event| {
+        interpret_read_event(event, read_end)
+    })
 }
 
 // Detecting a supervisor-retained write-end copy =====

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -15,14 +15,34 @@
 //!   trustworthy as the marker's membership: it can fire while such a member still runs.
 //!   That is the same trust model as the marker itself — naive-child containment.
 //!
-//! Every knote here is armed with `NOTE_LOWAT` and a high low-water mark. `EV_EOF` is always
-//! the sole verdict, unconditional of buffered bytes — but the low-water mark itself is
-//! clamped by the kernel to the pipe's actual buffer capacity (measured ~64 KiB on this host),
-//! so it suppresses wakeups for ordinary writes (which is all the crate should ever produce —
-//! nothing in the crate writes to the marker) without being an absolute guarantee against a
-//! member that sustains output at or above that ceiling. That residual case degrades to a
-//! bounded, deadline-respecting, CPU-proportional drain rather than a genuine kernel block —
-//! documented and tested, not assumed away.
+//! Every knote here is armed with `NOTE_LOWAT`, a high low-water mark, and `EV_CLEAR` (arm once
+//! per genuinely new edge, not once per `kevent` call while the condition merely holds).
+//! `EV_EOF` is always the sole verdict, unconditional of buffered bytes — but the low-water
+//! mark itself is clamped by the kernel to the pipe's actual buffer capacity (measured ~64 KiB
+//! on this host), so it suppresses wakeups for ordinary writes (which is all the crate should
+//! ever produce — nothing in the crate writes to the marker) without being an absolute
+//! guarantee against a member that sustains output at or above that ceiling.
+//!
+//! That residual case is handled differently depending on whether the wait is bounded:
+//!
+//! - **Bounded** (a caller-supplied deadline): the excess is drained in bounded rounds, an
+//!   accommodation for a misbehaving-but-eventually-cooperative writer, paid for by the
+//!   caller's own deadline — CPU-proportional to the writer's throughput for the wait's
+//!   duration, same as the drain itself, but never longer than the deadline allows.
+//! - **Unbounded** (no deadline at all): nothing is drained. The effective low-water clamp
+//!   equals the pipe's full capacity, so the very edge that makes the knote ready is also the
+//!   instant the writer's own `write()` call blocks in the kernel — the original design
+//!   assumption this module's misuse contract already documents (see `fdmarker`'s module doc:
+//!   a member that writes to its inherited marker descriptor "blocks once the kernel pipe
+//!   buffer fills"). Not draining lets that self-limiting behavior stand: with `EV_CLEAR` set
+//!   and no new bytes possible while the writer stays blocked, the wait genuinely blocks in the
+//!   kernel — poll-free, not CPU-proportional — until the writer's descriptor closes (forcibly
+//!   or otherwise) or, for the bounded callers layered on top of this primitive, a deadline is
+//!   reached. An unbounded wait cannot honestly offer both zero CPU AND forward progress for a
+//!   sustained writer at the same time (continuing to drain IS continuing to do work
+//!   proportional to what the writer produces, for as long as the writer keeps producing it) —
+//!   this module chooses zero CPU for the unbounded case, since that is also the case with no
+//!   deadline to bound the alternative.
 
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::time::Instant;
@@ -76,9 +96,10 @@ fn ensure_nonblocking(read_end: BorrowedFd<'_>) -> Result<(), Error> {
 
 /// Read and discard up to `n` bytes, tolerating short reads. Bounded by `n` — a count the
 /// KERNEL just reported via the triggering kevent's own `data` field, never "keep reading
-/// until it stops." Below the low-water clamp this branch never runs at all; at or above it,
-/// this is what keeps a single round bounded — the OUTER loop (`block_until_drained`) is what
-/// keeps the total wait bounded by the caller's deadline despite repeated rounds.
+/// until it stops." Below the low-water clamp this branch never runs at all; at or above it —
+/// and only for a caller with an actual deadline, see `interpret_read_event` — this is what
+/// keeps a single round bounded — the OUTER loop (`block_until_drained`) is what keeps the
+/// total wait bounded by the caller's deadline despite repeated rounds.
 fn drain_pending(read_end: BorrowedFd<'_>, mut n: usize) -> Result<(), Error> {
     let mut buf = [0u8; 4096];
     while n > 0 {
@@ -111,7 +132,7 @@ pub(crate) fn arm(read_end: BorrowedFd<'_>, unbounded_wait: bool) -> Result<Kque
     let change = KEvent::new(
         read_end.as_raw_fd() as usize,
         EventFilter::EVFILT_READ,
-        EvFlags::EV_ADD | EvFlags::EV_RECEIPT,
+        EvFlags::EV_ADD | EvFlags::EV_RECEIPT | EvFlags::EV_CLEAR,
         FilterFlag::NOTE_LOWAT,
         LOW_WATER_MARK,
         0,
@@ -129,10 +150,29 @@ pub(crate) fn arm(read_end: BorrowedFd<'_>, unbounded_wait: bool) -> Result<Kque
 ///
 /// `Ok(Some(AllMembersExited))` = `EV_EOF` was set — final, regardless of buffered bytes, so no
 /// read happens in this branch. `Ok(None)` = readable without `EV_EOF`, which with
-/// `NOTE_LOWAT` armed only happens once buffered bytes reach the clamp: `event.data()` is
-/// exactly how many are queued, discarded in one bounded round via `drain_pending`. `Err` =
-/// `EV_ERROR` or a `kevent`/read failure.
-fn interpret_read_event(event: &KEvent, read_end: BorrowedFd<'_>) -> Result<Option<TreeDrain>, Error> {
+/// `NOTE_LOWAT` armed only happens once buffered bytes reach the clamp — i.e. the pipe is at
+/// capacity, so a writer that keeps writing is, at that exact instant, already blocked in its
+/// own `write()`. `unbounded_wait` decides what happens next:
+///
+/// - **Bounded** (a real deadline bounds the caller's wait): `event.data()` bytes are discarded
+///   via `drain_pending`, in one round bounded by the count the kernel itself reported — the
+///   crate's accommodation for a misbehaving-but-eventually-cooperative writer, paid for by the
+///   caller's own deadline.
+/// - **Unbounded**: nothing is read. The armed knote carries `EV_CLEAR` (see `arm`), so with no
+///   bytes drained there is no new edge to refire on until the writer's OWN blocked `write()`
+///   unblocks (impossible while the pipe stays full) or the descriptor closes (`EV_EOF`,
+///   unconditional of buffered bytes). The wait genuinely blocks in the kernel rather than
+///   draining on the writer's behalf forever — see the module doc for why an indefinite wait
+///   cannot honestly offer both zero CPU and forward progress for a sustained writer, and why
+///   this crate chooses zero CPU plus the writer's own original self-limiting contract
+///   (`fdmarker`'s module doc) for that case.
+///
+/// `Err` = `EV_ERROR` or a `kevent`/read failure.
+fn interpret_read_event(
+    event: &KEvent,
+    read_end: BorrowedFd<'_>,
+    unbounded_wait: bool,
+) -> Result<Option<TreeDrain>, Error> {
     if event.flags().contains(EvFlags::EV_ERROR) {
         return Err(Error::Io(std::io::Error::from_raw_os_error(event.data() as i32)));
     }
@@ -140,25 +180,40 @@ fn interpret_read_event(event: &KEvent, read_end: BorrowedFd<'_>) -> Result<Opti
         return Ok(Some(TreeDrain::AllMembersExited));
     }
     // `data` is a byte count for a readable, non-EOF, non-error EVFILT_READ event — never
-    // negative per the kqueue contract this module relies on everywhere else. `.max(0)` is a
-    // release-build fallback only; a violation here is a kqueue/ABI surprise or a bug in this
-    // module's own event handling, not an ordinary runtime condition, so it gets a loud
-    // debug_assert rather than being silently absorbed into the routine "nothing to drain yet"
-    // code path.
+    // negative per the kqueue contract this module relies on everywhere else. A violation here
+    // is a kqueue/ABI surprise or a bug in this module's own event handling, not an ordinary
+    // runtime condition: `debug_assert!` catches it loudly in debug builds, and `log::warn!`
+    // leaves a trace in release ones too — clamping to `0` and returning the routine "nothing to
+    // drain yet" verdict must not happen in total silence, unlike an ordinary empty drain.
+    if event.data() < 0 {
+        log::warn!(
+            "marker EOF: EVFILT_READ reported a negative data field ({}) on a non-EOF event — a \
+             kqueue ABI surprise or a bug in this module's own event handling",
+            event.data()
+        );
+    }
     debug_assert!(
         event.data() >= 0,
         "EVFILT_READ data must be non-negative per kernel contract, got {}",
         event.data()
     );
-    drain_pending(read_end, event.data().max(0) as usize)?;
-    Ok(None) // bytes discarded; holders remain (EV_EOF was clear)
+    if !unbounded_wait {
+        drain_pending(read_end, event.data().max(0) as usize)?;
+    }
+    Ok(None) // holders remain (EV_EOF was clear)
 }
 
 /// Take one pending event from an armed kqueue without blocking. `Ok(Some(_))` = the drain was
 /// observed; `Ok(None)` = nothing conclusive yet (nothing pending, or — only once the
-/// low-water clamp is reached — a member's bytes, discarded) — re-wait; `Err` = see
-/// `interpret_read_event`.
-pub(crate) fn drain_kqueue(kq: &Kqueue, read_end: BorrowedFd<'_>) -> Result<Option<TreeDrain>, Error> {
+/// low-water clamp is reached, and only for a bounded wait — a member's bytes, discarded) —
+/// re-wait; `Err` = see `interpret_read_event`. `unbounded_wait` must match what the kqueue was
+/// armed with (`arm`'s own parameter of the same name) — see `interpret_read_event` for why it
+/// changes what a non-EOF event does.
+pub(crate) fn drain_kqueue(
+    kq: &Kqueue,
+    read_end: BorrowedFd<'_>,
+    unbounded_wait: bool,
+) -> Result<Option<TreeDrain>, Error> {
     let zero = libc::timespec { tv_sec: 0, tv_nsec: 0 };
     let mut events = [KEvent::new(
         0,
@@ -171,7 +226,7 @@ pub(crate) fn drain_kqueue(kq: &Kqueue, read_end: BorrowedFd<'_>) -> Result<Opti
     loop {
         match kq.kevent(&[], &mut events, Some(zero)) {
             Ok(0) => return Ok(None), // nothing pending
-            Ok(_) => return interpret_read_event(&events[0], read_end),
+            Ok(_) => return interpret_read_event(&events[0], read_end, unbounded_wait),
             Err(nix::errno::Errno::EINTR) => continue,
             Err(e) => return Err(Error::Io(e.into())),
         }
@@ -193,7 +248,7 @@ pub(crate) fn drain_kqueue(kq: &Kqueue, read_end: BorrowedFd<'_>) -> Result<Opti
 #[allow(dead_code)]
 pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
     let kq = arm(read_end, false)?;
-    match drain_kqueue(&kq, read_end)? {
+    match drain_kqueue(&kq, read_end, false)? {
         Some(verdict) => Ok(verdict),
         None => Ok(TreeDrain::MembersRemain),
     }
@@ -211,6 +266,11 @@ pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
 /// The per-round deadline-checking and `kevent` mechanics live in `wait::backend::block_on_kqueue`
 /// (shared with the proc-exit watch); this function supplies only the marker's own arm and
 /// per-event interpretation (`interpret_read_event`).
+///
+/// A genuinely unbounded wait (`None`, or `Some(None)`) never drains bytes past the low-water
+/// clamp on a sustained writer — see the module doc for why, and `interpret_read_event` for
+/// where that decision is made. A bounded wait (`Some(Some(_))`, including one already past)
+/// keeps draining as before.
 pub(crate) fn block_until_drained(
     read_end: BorrowedFd<'_>,
     deadline: Option<Option<Instant>>,
@@ -218,7 +278,7 @@ pub(crate) fn block_until_drained(
     let unbounded_wait = crate::wait::remaining(deadline).is_none();
     let kq = arm(read_end, unbounded_wait)?;
     crate::wait::backend::block_on_kqueue(&kq, deadline, TreeDrain::MembersRemain, |event| {
-        interpret_read_event(event, read_end)
+        interpret_read_event(event, read_end, unbounded_wait)
     })
 }
 

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -33,7 +33,7 @@ fn marker_pipe() -> (OwnedFd, OwnedFd) {
     (OwnedFd::from(r), OwnedFd::from(w))
 }
 
-/// A fd number NEVER allocated in this process (M14/M16): using it instead of a real,
+/// A fd number NEVER allocated in this process: using it instead of a real,
 /// just-closed fd means these tests cannot race a concurrently-running test that reuses a
 /// freed number, and its errno (EBADF) was independently reproduced multiple times, unlike a
 /// freshly-closed-then-reused fd's (EINVAL — a different, not-useful-here path).
@@ -51,7 +51,7 @@ fn never_allocated_fd() -> BorrowedFd<'static> {
 /// Deliberately used even by tests below that just want "the write end is open, held by
 /// SOMETHING that isn't me": once `refuse_if_write_end_held` is added to `arm`, a bare second
 /// in-process fd (as plain `marker_pipe()` would give) is indistinguishable from the exact
-/// supervisor bug (M3) the guard exists to catch, and would make `arm`/`probe` refuse rather
+/// supervisor bug the guard exists to catch, and would make `arm`/`probe` refuse rather
 /// than report `MembersRemain`. A real holder in ANOTHER process is what "the write end is
 /// open" is supposed to mean here.
 fn spawn_marker_holder(script: &str) -> (crate::Child, std::io::PipeReader, std::io::PipeWriter) {
@@ -95,8 +95,8 @@ fn probe_reports_members_remain_while_the_write_end_is_open() {
 
 #[test]
 fn probe_on_an_invalid_descriptor_reports_an_io_error() {
-    // A borrowed fd the caller passed after it was already invalid (e.g. a #59 lifecycle
-    // bug) must fail loudly, never silently report a verdict.
+    // A borrowed fd the caller passed after it was already invalid must fail loudly, never
+    // silently report a verdict.
     let err = probe(never_allocated_fd()).expect_err("an invalid descriptor must error");
     assert!(
         matches!(err, crate::error::Error::Io(_)),
@@ -141,7 +141,7 @@ fn block_until_drained_with_a_past_deadline_still_reports_an_already_drained_tre
 #[test]
 fn arm_on_an_invalid_descriptor_reports_an_io_error() {
     // Exercises `ensure_nonblocking`'s guard inside `arm` — the actual reachable failure mode
-    // for a bad descriptor (M14). `add_with_receipt`'s own EV_ERROR branch (for EVFILT_READ,
+    // for a bad descriptor. `add_with_receipt`'s own EV_ERROR branch (for EVFILT_READ,
     // via `arm`) has no test anywhere in this module: a descriptor that passes
     // `ensure_nonblocking`'s fcntl check yet still fails kqueue's EV_ADD is not something this
     // module found a reliable, portable way to construct.
@@ -195,7 +195,7 @@ fn write_end_check_is_unassessable_for_a_descriptor_that_is_not_a_pipe() {
 
 #[test]
 fn an_unassessable_write_end_check_refuses_only_an_unbounded_wait() {
-    // Q7's settled behavior: `Unassessable` is not evidence of a bug (an ordinary transient
+    // `Unassessable` is not evidence of a bug (an ordinary transient
     // scan gap under concurrent spawning), so a BOUNDED wait proceeds — its own deadline
     // already caps the exposure. Only an UNBOUNDED wait is refused, because that combination
     // is exactly the condition under which the primitive could otherwise hang forever with no
@@ -605,14 +605,11 @@ async fn async_wait_resolves_immediately_for_an_already_drained_tree() {
 
 #[cfg(feature = "tokio")]
 #[tokio::test]
-async fn async_wait_discards_small_bytes_written_by_a_member() {
-    // The async counterpart to the sync `small_bytes_from_a_member_are_not_a_drain`: the
-    // integration between `drain_kqueue` and `watch_readable`'s clear_ready discipline is new
-    // code. (A few bytes stay below the NOTE_LOWAT clamp, so this resolves via the real EOF
-    // from `drop(stdin)`, not via the discard branch — that branch's async coverage would
-    // need a >64 KiB write, which is deliberately left to the sync suite (Task 3), since
-    // proving the SAME bounded-drain mechanics twice adds little once the sync path already
-    // pins it directly.)
+async fn async_wait_resolves_via_eof_with_small_buffered_bytes() {
+    // The async counterpart to the sync `small_bytes_from_a_member_are_not_a_drain`: a few
+    // bytes stay below the NOTE_LOWAT clamp, so this resolves via the real EOF from
+    // `drop(stdin)`, not via `drain_kqueue`'s discard branch — the test below this one is what
+    // exercises that branch, through a write that forces genuine backpressure.
     let mut cmd = crate::Command::new();
     cmd.executable("/bin/sh")
         .args(["sh", "-c", "echo noise >&3; echo ready >&4; exec cat >/dev/null"]);
@@ -643,5 +640,27 @@ async fn async_wait_discards_small_bytes_written_by_a_member() {
     };
     let (watched, ()) = ::tokio::join!(watch, end);
     watched.expect("async drain watch after discarding bytes");
+    child.wait().expect("reap");
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_wait_drains_bytes_past_the_low_water_clamp_through_the_real_reactor() {
+    // The async counterpart to the sync `bytes_past_the_low_water_clamp_are_drained_without_a_wrong_verdict`:
+    // >64 KiB exceeds the pipe's own buffer capacity, so the writer BLOCKS mid-write until the
+    // reactor's drain loop empties it below capacity — forcing at least one genuine
+    // discard-then-`clear_ready`-then-reawait round through `watch_readable`'s real `AsyncFd`
+    // registration, strictly before the writer can even reach its own `exec 3>&-`. The 10s
+    // bound is a failure bound (a regression here should fail fast), not the mechanism the
+    // assertion depends on.
+    let (child, marker, stdin) = spawn_marker_holder("yes | head -c 200000 >&3; exec 3>&-; exec cat >/dev/null");
+    ::tokio::time::timeout(
+        Duration::from_secs(10),
+        crate::tokio::wait::wait_tree_drained(marker.as_fd()),
+    )
+    .await
+    .expect("the discard-then-reawait loop must not hang")
+    .expect("async drain watch past the low-water clamp");
+    drop(stdin);
     child.wait().expect("reap");
 }

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -1,0 +1,176 @@
+//! Unit tests for the macOS marker EOF edge. In the library because the primitive is
+//! `pub(crate)`. Nothing here sleeps: every "the tree drained" event is caused by closing a
+//! descriptor a child is blocked on, and every "the tree has not drained" assertion is a
+//! ZERO-deadline check, which is exact rather than timed.
+
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::time::Instant;
+
+use super::{block_until_drained, probe, TreeDrain};
+
+/// A marker pipe: `(read_end, write_end)`, both owned by this process. Built with
+/// `std::io::pipe()` (CLOEXEC by default, matching `fdmarker::create_pipe`'s own convention) —
+/// NOT `nix::unistd::pipe()` (raw POSIX semantics, not CLOEXEC) — because `cargo test --lib`
+/// runs every test in this crate concurrently in one process, and a non-CLOEXEC test pipe fd
+/// would be inherited by any OTHER concurrently-running test's spawned child, keeping that
+/// child a spurious extra "holder" of a pipe this test never intended to share.
+fn marker_pipe() -> (OwnedFd, OwnedFd) {
+    let (r, w) = std::io::pipe().expect("pipe");
+    (OwnedFd::from(r), OwnedFd::from(w))
+}
+
+/// A fd number NEVER allocated in this process (M14/M16): using it instead of a real,
+/// just-closed fd means these tests cannot race a concurrently-running test that reuses a
+/// freed number, and its errno (EBADF) was independently reproduced multiple times, unlike a
+/// freshly-closed-then-reused fd's (EINVAL — a different, not-useful-here path).
+fn never_allocated_fd() -> BorrowedFd<'static> {
+    // SAFETY: this fd number is never used for I/O by this process (nothing opens a million
+    // descriptors in a unit test), so it stays unallocated for the lifetime of the borrow;
+    // every call through it is expected to fail with EBADF, which is exactly what's tested.
+    unsafe { BorrowedFd::borrow_raw(1_000_000) }
+}
+
+/// A live tree member: `/bin/sh` holding the marker on fd 3 and blocked on stdin, so a test
+/// ends it by closing a descriptor rather than by timing anything. Returns the owned child,
+/// the marker read end, and the stdin write end whose close makes it exit.
+///
+/// Deliberately used even by tests below that just want "the write end is open, held by
+/// SOMETHING that isn't me": once `refuse_if_write_end_held` is added to `arm`, a bare second
+/// in-process fd (as plain `marker_pipe()` would give) is indistinguishable from the exact
+/// supervisor bug (M3) the guard exists to catch, and would make `arm`/`probe` refuse rather
+/// than report `MembersRemain`. A real holder in ANOTHER process is what "the write end is
+/// open" is supposed to mean here.
+fn spawn_marker_holder(script: &str) -> (crate::Child, std::io::PipeReader, std::io::PipeWriter) {
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh").args(["sh", "-c", script]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+    (child, marker, stdin)
+}
+
+#[test]
+fn probe_reports_drained_when_the_last_write_end_is_gone() {
+    let (r, w) = marker_pipe();
+    drop(w); // the last holder's descriptor closed
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+}
+
+#[test]
+fn probe_reports_drained_even_with_bytes_still_buffered() {
+    // kqueue(2): EV_EOF is set once the write end is closed even with data pending — checked
+    // and returned before any read happens (`interpret_read_event`'s EV_EOF branch), so this
+    // does NOT exercise `drain_pending`'s discard path (that needs bytes past the NOTE_LOWAT
+    // clamp). What this pins: bytes must never change the verdict — the marker pipe is not a
+    // data channel — regardless of which branch produces it.
+    let (r, w) = marker_pipe();
+    nix::unistd::write(&w, b"noise from a member").expect("write");
+    drop(w);
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+}
+
+#[test]
+fn probe_reports_members_remain_while_the_write_end_is_open() {
+    let (_child, marker, _stdin) = spawn_marker_holder("exec cat >/dev/null");
+    assert_eq!(probe(marker.as_fd()).expect("probe"), TreeDrain::MembersRemain);
+}
+
+#[test]
+fn probe_on_an_invalid_descriptor_reports_an_io_error() {
+    // A borrowed fd the caller passed after it was already invalid (e.g. a #59 lifecycle
+    // bug) must fail loudly, never silently report a verdict.
+    let err = probe(never_allocated_fd()).expect_err("an invalid descriptor must error");
+    assert!(matches!(err, crate::error::Error::Io(_)), "expected Error::Io, got {err:?}");
+}
+
+#[test]
+fn block_until_drained_with_a_past_deadline_behaves_like_a_one_shot_probe() {
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("probe"),
+        TreeDrain::MembersRemain
+    );
+    drop(stdin);
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
+        TreeDrain::AllMembersExited
+    );
+    child.wait().expect("reap");
+}
+
+#[test]
+fn arm_on_an_invalid_descriptor_reports_an_io_error() {
+    // Exercises `ensure_nonblocking`'s guard inside `arm` — the actual reachable failure mode
+    // for a bad descriptor (M14). `add_with_receipt`'s own EV_ERROR branch (for EVFILT_READ,
+    // via `arm`) has no test anywhere in this module: a descriptor that passes
+    // `ensure_nonblocking`'s fcntl check yet still fails kqueue's EV_ADD is not something this
+    // module found a reliable, portable way to construct.
+    let err = super::arm(never_allocated_fd(), false).expect_err("arming an invalid descriptor must error");
+    assert!(matches!(err, crate::error::Error::Io(_)), "expected Error::Io, got {err:?}");
+}
+
+#[test]
+fn a_retained_supervisor_write_end_is_refused_not_waited_on() {
+    // Measured: with the supervisor's own copy of the write end open, the edge NEVER fires
+    // though every member exited. A wait here could only ever burn the caller's deadline, so
+    // the primitive must refuse instead of pretending to watch.
+    let (r, w) = marker_pipe();
+    assert_eq!(super::write_end_check(r.as_fd()), super::WriteEndCheck::HeldByUs);
+    let err = probe(r.as_fd()).expect_err("a retained write end must be refused");
+    assert!(
+        matches!(err, crate::error::Error::Containment { .. }),
+        "expected Error::Containment, got {err:?}"
+    );
+    drop(w);
+    // NOT `assert_eq!(..., Clear)`: `cargo test` runs concurrently, and this process's fd
+    // table is being churned by every other test running at the same moment. The property
+    // under test is that a CLEARED write end is never mistaken for a still-held one.
+    assert_ne!(super::write_end_check(r.as_fd()), super::WriteEndCheck::HeldByUs);
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+}
+
+#[test]
+fn write_end_check_ignores_unrelated_pipes_this_process_holds() {
+    // The check must key on the marker's own kernel object, not on "this process holds some
+    // pipe write end" — a supervisor holds many (every child's stdin). Same concurrency note
+    // as above: assert the property (not HeldByUs), not an exact Clear.
+    let (r, w) = marker_pipe();
+    let (_other_r, _other_w) = marker_pipe();
+    drop(w);
+    assert_ne!(super::write_end_check(r.as_fd()), super::WriteEndCheck::HeldByUs);
+}
+
+#[test]
+fn write_end_check_is_unassessable_for_a_descriptor_that_is_not_a_pipe() {
+    // proc_pidfdinfo(PROC_PIDFDPIPEINFO) on a non-pipe fd fails (wrong type) — the check must
+    // say "inconclusive", never misreport it as Clear (which `probe`/`arm` would then trust).
+    let f = std::fs::File::open("/dev/null").expect("open /dev/null");
+    assert_eq!(super::write_end_check(f.as_fd()), super::WriteEndCheck::Unassessable);
+}
+
+#[test]
+fn an_unassessable_write_end_check_refuses_only_an_unbounded_wait() {
+    // Q7's settled behavior: `Unassessable` is not evidence of a bug (an ordinary transient
+    // scan gap under concurrent spawning), so a BOUNDED wait proceeds — its own deadline
+    // already caps the exposure. Only an UNBOUNDED wait is refused, because that combination
+    // is exactly the condition under which the primitive could otherwise hang forever with no
+    // elevated runtime signal at all.
+    let f = std::fs::File::open("/dev/null").expect("open /dev/null");
+    assert_eq!(super::write_end_check(f.as_fd()), super::WriteEndCheck::Unassessable);
+    // Bounded (a real, already-past deadline): proceeds past the write-end guard, then fails
+    // for the ordinary reason (not a pipe, so `EVFILT_READ` cannot be armed on it) — never
+    // `Error::Unassessable`.
+    let bounded = block_until_drained(f.as_fd(), Some(Some(Instant::now())));
+    assert!(
+        !matches!(bounded, Err(crate::error::Error::Unassessable { .. })),
+        "a bounded wait must not be refused on an Unassessable write-end check, got {bounded:?}"
+    );
+    // Unbounded: refused outright.
+    let unbounded = block_until_drained(f.as_fd(), None);
+    assert!(
+        matches!(unbounded, Err(crate::error::Error::Unassessable { .. })),
+        "an unbounded wait must be refused on an Unassessable write-end check, got {unbounded:?}"
+    );
+}

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -323,14 +323,63 @@ fn an_orphan_reparented_to_launchd_holds_the_edge_shut() {
 }
 
 #[test]
+fn all_members_exited_requires_every_simultaneous_holder_to_exit() {
+    // Every test above this one has exactly ONE write-end holder at a time, so none of them can
+    // tell "some closed" from "all closed" apart — a bug that reported `AllMembersExited` the
+    // moment ANY single holder's copy closed, ignoring the rest, would still pass every one of
+    // them. This test needs two INDEPENDENTLY closable holders alive at once: a single root
+    // `/bin/sh` backgrounds two separate `cat` processes, each with its OWN stdin pipe (fd 0
+    // and fd 5) so each can be closed on its own, both inheriting the same fd 3 from the one
+    // spawn. The root closes its own fd 3 copy right after backgrounding (`exec 3>&-`) so it is
+    // never itself a third holder, then `wait`s for both children instead of exiting — nothing
+    // here depends on reparenting, unlike the orphan test above.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh").args([
+        "sh",
+        "-c",
+        "cat 0<&0 >/dev/null & cat 0<&5 >/dev/null & exec 3>&-; wait",
+    ]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe for holder A");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    cmd.fd(5, crate::Stdio::pipe_in()).expect("stdin pipe for holder B");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let stdin_a = child.fd_write_end(crate::Fd::STDIN).expect("holder A stdin write end");
+    let stdin_b = child.fd_write_end(5.into()).expect("holder B stdin write end");
+
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("probe"),
+        TreeDrain::MembersRemain,
+        "two live holders must hold the edge shut"
+    );
+
+    drop(stdin_a); // holder A sees EOF on its own stdin and exits; holder B is untouched
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("probe"),
+        TreeDrain::MembersRemain,
+        "one holder exiting while a second remains must not be mistaken for a full drain"
+    );
+
+    drop(stdin_b); // holder B sees EOF and exits; no holder remains
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
+        TreeDrain::AllMembersExited,
+        "the edge must fire only once the LAST simultaneous holder is gone"
+    );
+    child
+        .wait()
+        .expect("reap the root sh, which itself waited for both background cats");
+}
+
+#[test]
 fn small_bytes_from_a_member_are_not_a_drain() {
     // The verdict-level half of the NOTE_LOWAT claim: a handful of buffered bytes must never
     // read as a drain, gated or not (`interpret_read_event`'s non-EOF branch reports
     // `MembersRemain` either way). The ZERO-deadline check is the exact, correct tool here
     // (matching this file's own header promise), not a multi-second real wait. Whether the
-    // wakeup itself is actually suppressed is a SEPARATE, lower-level claim, pinned by
-    // `note_lowat_suppresses_a_wakeup_for_bytes_under_the_clamp` below (a verdict-only
-    // assertion cannot distinguish "suppressed" from "delivered but harmless"). The child
+    // wakeup itself is actually suppressed is a SEPARATE, lower-level claim, pinned by the
+    // low-water suppression test below (a verdict-only assertion cannot distinguish
+    // "suppressed" from "delivered but harmless"). The child
     // signals readiness on a SEPARATE report pipe right after writing to fd 3, so the ordering
     // ("the write already happened") is real synchronization, not assumed.
     let mut cmd = crate::Command::new();
@@ -518,6 +567,51 @@ fn a_sustained_writer_never_exceeds_the_deadline() {
     child.wait().expect("reap");
 }
 
+#[test]
+fn an_unbounded_wait_against_a_sustained_writer_blocks_without_spending_cpu() {
+    // The unbounded counterpart to the quiet-holder CPU test above, and the
+    // case the sync death-watch's CPU-proportional accounting explicitly does NOT cover: with
+    // `deadline: None` there is no caller-supplied bound to pay a per-round drain against, so
+    // (per the module doc) this wait must not drain past the low-water clamp at all — the
+    // writer's own `write()` blocks against the full pipe instead, and the wait genuinely
+    // blocks in the kernel rather than busy-looping `kevent`-drain-repeat forever. A background
+    // thread kills the writer after the measurement window so the unbounded wait has a way to
+    // conclude at all; the measurement itself covers only the window BEFORE that kill, on THIS
+    // thread, same idiom and same reasoning as the quiet-holder test above.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh").args(["sh", "-c", "exec yes >&3"]);
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    let mut child = cmd.spawn().expect("spawn yes");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let window = Duration::from_millis(300);
+    let cpu_before = self_thread_cpu_time();
+    let wall_before = Instant::now();
+    let verdict = std::thread::scope(|s| {
+        s.spawn(|| {
+            std::thread::sleep(window);
+            child.kill().expect("kill the sustained writer");
+        });
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait against a sustained writer")
+    });
+    let wall_elapsed = wall_before.elapsed();
+    let cpu_elapsed = self_thread_cpu_time() - cpu_before;
+
+    assert_eq!(
+        verdict,
+        TreeDrain::AllMembersExited,
+        "killing the writer closes the marker descriptor, which must still be observed"
+    );
+    // Generous (5%), matching the quiet-holder test's own margin: proving "genuinely blocked,
+    // not spinning," not chasing a tight bound sensitive to scheduling noise.
+    assert!(
+        cpu_elapsed < wall_elapsed / 20,
+        "CPU time ({cpu_elapsed:?}) too high relative to wall time ({wall_elapsed:?}) for an \
+         unbounded wait against a sustained writer — looks like a busy-poll, not a genuine kernel block"
+    );
+
+    child.wait().expect("reap");
+}
+
 /// This CALLING THREAD's own CPU time, via `clock_gettime(CLOCK_THREAD_CPUTIME_ID)` — NOT
 /// `getrusage(RUSAGE_SELF)`, which is process-wide and would be contaminated by whatever other
 /// tests `cargo test`'s concurrent thread pool happens to be running during the same
@@ -566,9 +660,9 @@ async fn two_concurrent_async_waiters_both_observe_the_drain() {
     // Registering the same raw descriptor twice on the reactor instead would park one waiter
     // forever — but that only manifests across a LIVE-to-DRAINED transition (stickiness means
     // an already-drained descriptor resolves both registrations on the spot even with the
-    // collision bug present, silently duplicating
-    // `async_wait_resolves_immediately_for_an_already_drained_tree` instead of catching
-    // anything). So both waiters get their own armed handshake, and `drop(stdin)` is provably
+    // collision bug present, silently duplicating the already-drained-resolves-immediately test
+    // below instead of catching anything). So both waiters get their own armed handshake, and
+    // `drop(stdin)` is provably
     // AFTER both have armed — not left to `tokio::join!`'s poll order, the same reasoning the
     // sibling test above this one already applies.
     let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
@@ -606,10 +700,10 @@ async fn async_wait_resolves_immediately_for_an_already_drained_tree() {
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn async_wait_resolves_via_eof_with_small_buffered_bytes() {
-    // The async counterpart to the sync `small_bytes_from_a_member_are_not_a_drain`: a few
-    // bytes stay below the NOTE_LOWAT clamp, so this resolves via the real EOF from
-    // `drop(stdin)`, not via `drain_kqueue`'s discard branch — the test below this one is what
-    // exercises that branch, through a write that forces genuine backpressure.
+    // The async counterpart to the sync small-bytes-are-not-a-drain test above: a few bytes
+    // stay below the NOTE_LOWAT clamp, so this resolves via the real EOF from `drop(stdin)`,
+    // not via `drain_kqueue`'s discard branch — the test below this one is what exercises that
+    // branch, through a write that forces genuine backpressure.
     let mut cmd = crate::Command::new();
     cmd.executable("/bin/sh")
         .args(["sh", "-c", "echo noise >&3; echo ready >&4; exec cat >/dev/null"]);
@@ -645,22 +739,34 @@ async fn async_wait_resolves_via_eof_with_small_buffered_bytes() {
 
 #[cfg(feature = "tokio")]
 #[tokio::test]
-async fn async_wait_drains_bytes_past_the_low_water_clamp_through_the_real_reactor() {
-    // The async counterpart to the sync `bytes_past_the_low_water_clamp_are_drained_without_a_wrong_verdict`:
-    // >64 KiB exceeds the pipe's own buffer capacity, so the writer BLOCKS mid-write until the
-    // reactor's drain loop empties it below capacity — forcing at least one genuine
-    // discard-then-`clear_ready`-then-reawait round through `watch_readable`'s real `AsyncFd`
-    // registration, strictly before the writer can even reach its own `exec 3>&-`. The 10s
-    // bound is a failure bound (a regression here should fail fast), not the mechanism the
-    // assertion depends on.
+async fn async_wait_never_drains_past_the_low_water_clamp() {
+    // The async counterpart to the sync past-the-clamp test above — but with the OPPOSITE
+    // expectation, because `wait_tree_drained` has no deadline at all
+    // (see its doc): draining on a stuck writer's behalf forever is exactly the unbounded CPU
+    // spin this primitive must not have, so past the clamp it does not drain and the writer's
+    // own `write()` blocks instead (the marker fd's documented misuse contract). >64 KiB exceeds
+    // the pipe's own buffer capacity, so the writer never reaches its own `exec 3>&-` and the
+    // future never resolves; the external `tokio::time::timeout` here bounds the TEST's
+    // patience, not the primitive's — it is the caller-supplied bound the primitive's doc says a
+    // caller wanting one must supply itself.
     let (child, marker, stdin) = spawn_marker_holder("yes | head -c 200000 >&3; exec 3>&-; exec cat >/dev/null");
-    ::tokio::time::timeout(
-        Duration::from_secs(10),
+    let outcome = ::tokio::time::timeout(
+        Duration::from_millis(300),
         crate::tokio::wait::wait_tree_drained(marker.as_fd()),
     )
-    .await
-    .expect("the discard-then-reawait loop must not hang")
-    .expect("async drain watch past the low-water clamp");
+    .await;
+    assert!(
+        outcome.is_err(),
+        "a writer stuck past the low-water clamp must not resolve the wait — it should never be drained"
+    );
+    assert_eq!(
+        child.is_alive(),
+        crate::identity::Liveness::Alive,
+        "the writer must still be blocked in its own write(), not exited"
+    );
     drop(stdin);
+    child
+        .kill()
+        .expect("kill the writer, which can never finish its write() on its own");
     child.wait().expect("reap");
 }

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -2,11 +2,25 @@
 //! `pub(crate)`. Nothing here sleeps: every "the tree drained" event is caused by closing a
 //! descriptor a child is blocked on, and every "the tree has not drained" assertion is a
 //! ZERO-deadline check, which is exact rather than timed.
+//!
+//! Every test that opens a `marker_pipe()` write end holds `test_spawn_lock()` for its WHOLE
+//! body, whether or not that test itself spawns — the same rule `fdmarker_tests.rs` documents:
+//! a sibling test's `fork()` elsewhere in this shared, parallel test binary can land while THIS
+//! test's write end happens to be open, transiently inheriting a duplicate into a not-yet-`exec`ed
+//! child (CLOEXEC only closes it AT exec, not at fork), which then reads as an extra holder and
+//! delays the EOF this module exists to detect. `test_spawn_lock()` is `spawn_lock()` itself, not
+//! a private mutex, because `crate::Command::spawn()` already takes it on macOS around its own
+//! fork+exec — reusing it serializes against every cosca-originated spawn in this binary, not
+//! just the ones in this file.
 
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
-use std::time::Instant;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+use std::time::{Duration, Instant};
 
 use super::{block_until_drained, probe, TreeDrain};
+
+fn test_spawn_lock() -> std::sync::MutexGuard<'static, ()> {
+    crate::child::spawn::spawn_lock()
+}
 
 /// A marker pipe: `(read_end, write_end)`, both owned by this process. Built with
 /// `std::io::pipe()` (CLOEXEC by default, matching `fdmarker::create_pipe`'s own convention) —
@@ -53,6 +67,7 @@ fn spawn_marker_holder(script: &str) -> (crate::Child, std::io::PipeReader, std:
 
 #[test]
 fn probe_reports_drained_when_the_last_write_end_is_gone() {
+    let _serialize = test_spawn_lock();
     let (r, w) = marker_pipe();
     drop(w); // the last holder's descriptor closed
     assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
@@ -65,6 +80,7 @@ fn probe_reports_drained_even_with_bytes_still_buffered() {
     // does NOT exercise `drain_pending`'s discard path (that needs bytes past the NOTE_LOWAT
     // clamp). What this pins: bytes must never change the verdict — the marker pipe is not a
     // data channel — regardless of which branch produces it.
+    let _serialize = test_spawn_lock();
     let (r, w) = marker_pipe();
     nix::unistd::write(&w, b"noise from a member").expect("write");
     drop(w);
@@ -82,7 +98,10 @@ fn probe_on_an_invalid_descriptor_reports_an_io_error() {
     // A borrowed fd the caller passed after it was already invalid (e.g. a #59 lifecycle
     // bug) must fail loudly, never silently report a verdict.
     let err = probe(never_allocated_fd()).expect_err("an invalid descriptor must error");
-    assert!(matches!(err, crate::error::Error::Io(_)), "expected Error::Io, got {err:?}");
+    assert!(
+        matches!(err, crate::error::Error::Io(_)),
+        "expected Error::Io, got {err:?}"
+    );
 }
 
 #[test]
@@ -101,6 +120,25 @@ fn block_until_drained_with_a_past_deadline_behaves_like_a_one_shot_probe() {
 }
 
 #[test]
+fn block_until_drained_with_a_past_deadline_still_reports_an_already_drained_tree() {
+    // The equivalence the test above cannot pin: there the true state at the deadline is
+    // `MembersRemain`, so a buggy short-circuit that returns `MembersRemain` without ever
+    // consulting the kqueue would pass it too. Here the tree has ALREADY, GENUINELY drained
+    // before the (already past) deadline is even passed in, so only a real check of the
+    // sticky, level-triggered `EV_EOF` — not an assumption keyed on "deadline elapsed" — can
+    // produce the right verdict.
+    let _serialize = test_spawn_lock();
+    let (r, w) = marker_pipe();
+    let already_past = Instant::now();
+    drop(w); // drained before the deadline below is even evaluated
+    assert_eq!(
+        block_until_drained(r.as_fd(), Some(Some(already_past))).expect("probe"),
+        TreeDrain::AllMembersExited,
+        "an already-drained tree must be reported as drained even past a stale deadline"
+    );
+}
+
+#[test]
 fn arm_on_an_invalid_descriptor_reports_an_io_error() {
     // Exercises `ensure_nonblocking`'s guard inside `arm` — the actual reachable failure mode
     // for a bad descriptor (M14). `add_with_receipt`'s own EV_ERROR branch (for EVFILT_READ,
@@ -108,7 +146,10 @@ fn arm_on_an_invalid_descriptor_reports_an_io_error() {
     // `ensure_nonblocking`'s fcntl check yet still fails kqueue's EV_ADD is not something this
     // module found a reliable, portable way to construct.
     let err = super::arm(never_allocated_fd(), false).expect_err("arming an invalid descriptor must error");
-    assert!(matches!(err, crate::error::Error::Io(_)), "expected Error::Io, got {err:?}");
+    assert!(
+        matches!(err, crate::error::Error::Io(_)),
+        "expected Error::Io, got {err:?}"
+    );
 }
 
 #[test]
@@ -116,6 +157,7 @@ fn a_retained_supervisor_write_end_is_refused_not_waited_on() {
     // Measured: with the supervisor's own copy of the write end open, the edge NEVER fires
     // though every member exited. A wait here could only ever burn the caller's deadline, so
     // the primitive must refuse instead of pretending to watch.
+    let _serialize = test_spawn_lock();
     let (r, w) = marker_pipe();
     assert_eq!(super::write_end_check(r.as_fd()), super::WriteEndCheck::HeldByUs);
     let err = probe(r.as_fd()).expect_err("a retained write end must be refused");
@@ -136,6 +178,7 @@ fn write_end_check_ignores_unrelated_pipes_this_process_holds() {
     // The check must key on the marker's own kernel object, not on "this process holds some
     // pipe write end" — a supervisor holds many (every child's stdin). Same concurrency note
     // as above: assert the property (not HeldByUs), not an exact Clear.
+    let _serialize = test_spawn_lock();
     let (r, w) = marker_pipe();
     let (_other_r, _other_w) = marker_pipe();
     drop(w);
@@ -173,4 +216,322 @@ fn an_unassessable_write_end_check_refuses_only_an_unbounded_wait() {
         matches!(unbounded, Err(crate::error::Error::Unassessable { .. })),
         "an unbounded wait must be refused on an Unassessable write-end check, got {unbounded:?}"
     );
+}
+
+#[test]
+fn a_live_member_holds_the_edge_shut_and_releases_it_on_exit() {
+    // `cat` blocks on stdin and holds the inherited fd 3; closing our stdin write end is the
+    // only thing that ends it, so the drain is caused by an event, never awaited on a clock.
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("probe"),
+        TreeDrain::MembersRemain,
+        "a live marker holder must hold the edge shut"
+    );
+    drop(stdin); // cat sees EOF on stdin and exits
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
+        TreeDrain::AllMembersExited
+    );
+    child.wait().expect("reap");
+}
+
+#[test]
+fn the_edge_is_sticky_for_a_waiter_that_arrives_late() {
+    // kqueue EVFILT_READ is level-triggered on a pipe: a kqueue armed after the drain
+    // reports EV_EOF immediately, so a late waiter can never miss the edge.
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    drop(stdin);
+    child.wait().expect("reap");
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("late wait"),
+        TreeDrain::AllMembersExited
+    );
+}
+
+#[test]
+fn a_member_that_closes_the_marker_leaves_the_set_early() {
+    // The documented limit, pinned as behaviour rather than prose: `exec 3>&-` drops the
+    // descriptor, so the edge fires while the member is demonstrably still running.
+    let (child, marker, stdin) = spawn_marker_holder("exec 3>&-; exec cat >/dev/null");
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("wait"),
+        TreeDrain::AllMembersExited,
+        "a member that closed the marker must leave the membership set"
+    );
+    assert_eq!(
+        child.is_alive(),
+        crate::identity::Liveness::Alive,
+        "the false edge is only meaningful if the member is still running"
+    );
+    drop(stdin);
+    child.wait().expect("reap");
+}
+
+#[test]
+fn an_orphan_reparented_to_launchd_holds_the_edge_shut() {
+    // The population no other mechanism on this platform can see. `sh` backgrounds `cat`,
+    // reports its pid on fd 4 and exits, so `cat` is reparented to launchd (ppid == 1) while
+    // still holding the inherited marker on fd 3 across `sh`'s own exec.
+    //
+    // `cat` needs an EXPLICIT stdin redirect (`0<&0`) even though it is already fd 0 as
+    // inherited: macOS `/bin/sh` (bash 3.2.57) redirects a backgrounded job's stdin to
+    // /dev/null when the job has no redirection of its OWN and job control is off (the
+    // normal state for a non-interactive `-c` script) — without `0<&0`, this exact fd
+    // plumbing produces a `cat` that reads immediate EOF and exits, never becoming the
+    // long-lived orphan the test needs; WITH it, the orphan survives and holds the marker.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh")
+        .args(["sh", "-c", "cat 0<&0 >/dev/null & echo $! >&4"]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    cmd.fd(4, crate::Stdio::pipe_out()).expect("report pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let report = child.fd_read_end(4.into()).expect("report read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+
+    let orphan_pid: u32 = {
+        use std::io::BufRead;
+        let mut line = String::new();
+        std::io::BufReader::new(report).read_line(&mut line).expect("read pid");
+        line.trim().parse().expect("pid")
+    };
+    child.wait().expect("the root sh exits once it has backgrounded cat");
+
+    // The root is reaped; the only marker holder left is the orphan.
+    let parents = crate::containment::enumerate::process_parents();
+    let ppid = parents
+        .iter()
+        .find(|(pid, _)| *pid == orphan_pid)
+        .map(|(_, ppid)| *ppid)
+        .expect("the orphan is in the process table");
+    assert_eq!(ppid, 1, "the orphan must be reparented to launchd");
+
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("probe"),
+        TreeDrain::MembersRemain,
+        "an orphan at ppid=1 must hold the edge shut after the root is gone"
+    );
+
+    drop(stdin); // the orphan's only exit path — no signal, no timer
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
+        TreeDrain::AllMembersExited,
+        "the edge must fire when the orphan exits"
+    );
+}
+
+#[test]
+fn small_bytes_from_a_member_are_not_a_drain() {
+    // The verdict-level half of the NOTE_LOWAT claim: a handful of buffered bytes must never
+    // read as a drain, gated or not (`interpret_read_event`'s non-EOF branch reports
+    // `MembersRemain` either way). The ZERO-deadline check is the exact, correct tool here
+    // (matching this file's own header promise), not a multi-second real wait. Whether the
+    // wakeup itself is actually suppressed is a SEPARATE, lower-level claim, pinned by
+    // `note_lowat_suppresses_a_wakeup_for_bytes_under_the_clamp` below (a verdict-only
+    // assertion cannot distinguish "suppressed" from "delivered but harmless"). The child
+    // signals readiness on a SEPARATE report pipe right after writing to fd 3, so the ordering
+    // ("the write already happened") is real synchronization, not assumed.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh")
+        .args(["sh", "-c", "echo noise >&3; echo ready >&4; exec cat >/dev/null"]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    cmd.fd(4, crate::Stdio::pipe_out()).expect("report pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let mut report = child.fd_read_end(4.into()).expect("report read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+
+    use std::io::Read;
+    let mut byte = [0u8; 1];
+    report
+        .read_exact(&mut byte)
+        .expect("the child wrote to fd 3 before this returns");
+
+    assert_eq!(
+        block_until_drained(marker.as_fd(), Some(Some(Instant::now()))).expect("zero-deadline check"),
+        TreeDrain::MembersRemain,
+        "a handful of buffered bytes under the low-water clamp must not be mistaken for a drain"
+    );
+    drop(stdin);
+    assert_eq!(
+        block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
+        TreeDrain::AllMembersExited
+    );
+    child.wait().expect("reap");
+}
+
+#[test]
+fn note_lowat_suppresses_a_wakeup_for_bytes_under_the_clamp() {
+    // The lower-level half of the claim the test above cannot reach: a write under the clamp
+    // must not even make the kqueue itself ready, not merely "ready but harmlessly
+    // reinterpreted." Polling the KQUEUE'S OWN fd (a kqueue is itself pollable) with a zero
+    // timeout reads the raw pending-event state directly, bypassing `drain_kqueue`/
+    // `interpret_read_event` — both of whose non-EOF branches report `MembersRemain` whether
+    // the underlying event fired or not, which is exactly why a verdict-only assertion cannot
+    // tell "suppressed" from "delivered but harmless" apart. No timing is involved: the write
+    // completes (kernel-buffered) before the poll call runs, both on this same thread, in
+    // program order — nothing is awaited. A real child (not a bare in-process pipe) holds the
+    // write end: `arm` itself refuses a write end this process retains, so proving "arm even
+    // succeeds here" needs a holder `write_end_check` reports as `Clear`, not `HeldByUs`.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh")
+        .args(["sh", "-c", "echo noise >&3; echo ready >&4; exec cat >/dev/null"]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    cmd.fd(4, crate::Stdio::pipe_out()).expect("report pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let mut report = child.fd_read_end(4.into()).expect("report read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+
+    use std::io::Read;
+    let mut byte = [0u8; 1];
+    report
+        .read_exact(&mut byte)
+        .expect("the child wrote to fd 3 before this returns");
+
+    let kq = super::arm(marker.as_fd(), false).expect("arm");
+    let mut pfd = libc::pollfd {
+        fd: kq.as_fd().as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: `pfd` is a single, correctly-initialized `pollfd`; `poll` writes only within its
+    // bounds, and the `1` count matches the slice length passed.
+    let rc = unsafe { libc::poll(&mut pfd, 1, 0) };
+    assert_eq!(
+        rc, 0,
+        "NOTE_LOWAT must suppress a wakeup for bytes under the clamp, but the kqueue reports ready"
+    );
+    drop(stdin);
+    child.wait().expect("reap");
+}
+
+#[test]
+fn bytes_past_the_low_water_clamp_are_drained_without_a_wrong_verdict() {
+    // Exercises `interpret_read_event`'s discard branch for real (below the clamp it is never
+    // entered at all — a handful of bytes, as in the test above, cannot reach it). The member
+    // writes >64 KiB via `yes | head`, well past the measured clamp, THEN closes fd 3 itself
+    // (`exec 3>&-`) so the test's own completion is event-driven, not a fixed wait for
+    // "probably done writing by now." A generous bound is still passed to
+    // `block_until_drained` as a FAILURE bound (a real regression here should fail fast, not
+    // hang the suite), not as the mechanism the assertion depends on.
+    let (child, marker, stdin) = spawn_marker_holder("yes | head -c 200000 >&3; exec 3>&-; exec cat >/dev/null");
+    assert_eq!(
+        block_until_drained(
+            marker.as_fd(),
+            Some(Instant::now().checked_add(Duration::from_secs(10)))
+        )
+        .expect("wait past the low-water clamp"),
+        TreeDrain::AllMembersExited,
+        "closing the marker after writing past the clamp must still report drained, not hang or misfire"
+    );
+    assert_eq!(
+        child.is_alive(),
+        crate::identity::Liveness::Alive,
+        "the member closed only the marker fd, not itself — same false-edge shape as the small case"
+    );
+    drop(stdin);
+    child.wait().expect("reap");
+}
+
+#[test]
+fn a_quiet_live_holder_blocks_without_spending_cpu() {
+    // The realistic case (nothing in the crate writes to the marker) — this is the claim
+    // "poll-free" is actually supposed to stand behind, verified rather than assumed: a live
+    // holder that never writes must genuinely BLOCK in the kernel for the wait's duration, not
+    // merely return the right verdict at the right time (a verdict-only assertion cannot tell
+    // "blocked" from "busy-polled the whole time" apart — both produce `MembersRemain` at the
+    // same instant).
+    //
+    // The 300ms is a MEASUREMENT WINDOW, not a synchronization timeout: nothing is being
+    // awaited here (the holder never exits during this test), it is how long CPU usage is
+    // sampled for — there is no shorter, event-driven way to observe "no CPU was spent doing
+    // nothing" than watching for a while. This is the one deliberate, named exception to the
+    // "no synchronisation via time" global constraint, for exactly this reason.
+    //
+    // CPU is measured on THIS THREAD specifically (`CLOCK_THREAD_CPUTIME_ID`, not
+    // `getrusage(RUSAGE_SELF)`, which is process-wide and would fold in whatever CPU work
+    // `cargo test`'s other concurrently-running tests do on other threads during the same
+    // window).
+    let (child, marker, _stdin) = spawn_marker_holder("exec cat >/dev/null");
+    let deadline = Duration::from_millis(300);
+    let cpu_before = self_thread_cpu_time();
+    let wall_before = Instant::now();
+    let verdict = block_until_drained(marker.as_fd(), Some(Instant::now().checked_add(deadline)))
+        .expect("bounded wait against a quiet holder");
+    let wall_elapsed = wall_before.elapsed();
+    let cpu_elapsed = self_thread_cpu_time() - cpu_before;
+
+    assert_eq!(verdict, TreeDrain::MembersRemain);
+    // Generous (5%): proving "genuinely blocked, not spinning," not chasing a tight bound
+    // that would make this test sensitive to normal scheduling/syscall noise.
+    assert!(
+        cpu_elapsed < wall_elapsed / 20,
+        "CPU time ({cpu_elapsed:?}) too high relative to wall time ({wall_elapsed:?}) for a holder \
+         that never writes — looks like a busy-poll, not a genuine kernel block"
+    );
+
+    child.kill().expect("kill");
+    child.wait().expect("reap");
+}
+
+#[test]
+fn a_sustained_writer_never_exceeds_the_deadline() {
+    // Distinct from the quiet-holder test above, deliberately NOT claiming low CPU usage
+    // here: `yes` refills the pipe to the NOTE_LOWAT clamp about as fast as `drain_pending`
+    // can empty it, so this case genuinely IS CPU-proportional to the writer's throughput for
+    // the wait's duration — the module doc's own honest accounting, not a defect. What this
+    // test pins is the property that must ALWAYS hold regardless: the wait terminates at (not
+    // past) the deadline with the correct verdict, whatever it cost to get there —
+    // `block_until_drained` checks the deadline explicitly before every `kevent` call
+    // specifically so this holds even against a descriptor that stays continuously ready. The
+    // slack below is deliberately tight (not the >100ms scheduling margin the sync
+    // death-watch tests use elsewhere) because a regression of that fix should show up as a
+    // large, easy-to-see overrun, not something a generous slack would quietly absorb.
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh").args(["sh", "-c", "exec yes >&3"]);
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    let mut child = cmd.spawn().expect("spawn yes");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+
+    let deadline = Duration::from_millis(300);
+    let wall_before = Instant::now();
+    let verdict = block_until_drained(marker.as_fd(), Some(Instant::now().checked_add(deadline)))
+        .expect("bounded wait against a sustained writer");
+    let wall_elapsed = wall_before.elapsed();
+
+    assert_eq!(
+        verdict,
+        TreeDrain::MembersRemain,
+        "a sustained writer must still report MembersRemain"
+    );
+    assert!(
+        wall_elapsed <= deadline + Duration::from_millis(50),
+        "must not exceed the deadline by more than one round's drain work: {wall_elapsed:?}"
+    );
+
+    child.kill().expect("kill the sustained writer");
+    child.wait().expect("reap");
+}
+
+/// This CALLING THREAD's own CPU time, via `clock_gettime(CLOCK_THREAD_CPUTIME_ID)` — NOT
+/// `getrusage(RUSAGE_SELF)`, which is process-wide and would be contaminated by whatever other
+/// tests `cargo test`'s concurrent thread pool happens to be running during the same
+/// measurement window. Used only to distinguish "blocked" from "busy-polled" in the
+/// quiet-holder test above — no production code depends on it.
+fn self_thread_cpu_time() -> Duration {
+    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
+    // SAFETY: clock_gettime writes a fixed-size struct; pointer matches.
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+    assert_eq!(
+        rc,
+        0,
+        "clock_gettime(CLOCK_THREAD_CPUTIME_ID) failed: {}",
+        std::io::Error::last_os_error()
+    );
+    Duration::from_secs(ts.tv_sec.max(0) as u64) + Duration::from_nanos(ts.tv_nsec.max(0) as u64)
 }

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -535,3 +535,113 @@ fn self_thread_cpu_time() -> Duration {
     );
     Duration::from_secs(ts.tv_sec.max(0) as u64) + Duration::from_nanos(ts.tv_nsec.max(0) as u64)
 }
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_wait_resolves_when_the_last_member_exits() {
+    // `join!` polling `watch` before `end` is an implementation detail, not a contract — so
+    // ordering is enforced with a real, per-call channel, not assumed from poll order.
+    // `armed_rx.recv()` (blocking, moved to a blocking-pool thread) only returns once
+    // `wait_tree_drained_for_test` has actually armed its kqueue; `drop(stdin)` happens
+    // strictly after that.
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    let fd = marker.as_fd();
+    let (armed_tx, armed_rx) = std::sync::mpsc::channel();
+    let watch = crate::tokio::wait::wait_tree_drained_for_test(fd, armed_tx);
+    let end = async move {
+        ::tokio::task::spawn_blocking(move || armed_rx.recv().expect("watch armed"))
+            .await
+            .unwrap();
+        drop(stdin);
+    };
+    let (watched, ()) = ::tokio::join!(watch, end);
+    watched.expect("async drain watch");
+    child.wait().expect("reap");
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn two_concurrent_async_waiters_both_observe_the_drain() {
+    // Each waiter owns a private kqueue, so their knotes cannot displace each other.
+    // Registering the same raw descriptor twice on the reactor instead would park one waiter
+    // forever — but that only manifests across a LIVE-to-DRAINED transition (stickiness means
+    // an already-drained descriptor resolves both registrations on the spot even with the
+    // collision bug present, silently duplicating
+    // `async_wait_resolves_immediately_for_an_already_drained_tree` instead of catching
+    // anything). So both waiters get their own armed handshake, and `drop(stdin)` is provably
+    // AFTER both have armed — not left to `tokio::join!`'s poll order, the same reasoning the
+    // sibling test above this one already applies.
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    let fd = marker.as_fd();
+    let (a_armed_tx, a_armed_rx) = std::sync::mpsc::channel();
+    let (b_armed_tx, b_armed_rx) = std::sync::mpsc::channel();
+    let a = crate::tokio::wait::wait_tree_drained_for_test(fd, a_armed_tx);
+    let b = crate::tokio::wait::wait_tree_drained_for_test(fd, b_armed_tx);
+    let end = async move {
+        ::tokio::task::spawn_blocking(move || {
+            a_armed_rx.recv().expect("waiter a armed");
+            b_armed_rx.recv().expect("waiter b armed");
+        })
+        .await
+        .unwrap();
+        drop(stdin);
+    };
+    let (ra, rb, ()) = ::tokio::join!(a, b, end);
+    ra.expect("waiter a");
+    rb.expect("waiter b");
+    child.wait().expect("reap");
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_wait_resolves_immediately_for_an_already_drained_tree() {
+    let (child, marker, stdin) = spawn_marker_holder("exec cat >/dev/null");
+    drop(stdin);
+    child.wait().expect("reap");
+    crate::tokio::wait::wait_tree_drained(marker.as_fd())
+        .await
+        .expect("already-drained watch");
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_wait_discards_small_bytes_written_by_a_member() {
+    // The async counterpart to the sync `small_bytes_from_a_member_are_not_a_drain`: the
+    // integration between `drain_kqueue` and `watch_readable`'s clear_ready discipline is new
+    // code. (A few bytes stay below the NOTE_LOWAT clamp, so this resolves via the real EOF
+    // from `drop(stdin)`, not via the discard branch — that branch's async coverage would
+    // need a >64 KiB write, which is deliberately left to the sync suite (Task 3), since
+    // proving the SAME bounded-drain mechanics twice adds little once the sync path already
+    // pins it directly.)
+    let mut cmd = crate::Command::new();
+    cmd.executable("/bin/sh")
+        .args(["sh", "-c", "echo noise >&3; echo ready >&4; exec cat >/dev/null"]);
+    cmd.fd(0, crate::Stdio::pipe_in()).expect("stdin pipe");
+    cmd.fd(3, crate::Stdio::pipe_out()).expect("marker pipe");
+    cmd.fd(4, crate::Stdio::pipe_out()).expect("report pipe");
+    let mut child = cmd.spawn().expect("spawn /bin/sh");
+    let marker = child.fd_read_end(3.into()).expect("marker read end");
+    let report = child.fd_read_end(4.into()).expect("report read end");
+    let stdin = child.fd_write_end(crate::Fd::STDIN).expect("stdin write end");
+
+    let fd = marker.as_fd();
+    let watch = crate::tokio::wait::wait_tree_drained(fd);
+    let end = async move {
+        // Blocking read on the report pipe: real synchronization for "the bytes are on the
+        // marker now", off the async executor thread so it can't stall the reactor.
+        ::tokio::task::spawn_blocking(move || {
+            use std::io::Read;
+            let mut byte = [0u8; 1];
+            let mut report = report;
+            report
+                .read_exact(&mut byte)
+                .expect("child wrote to fd 3 before this returns");
+        })
+        .await
+        .unwrap();
+        drop(stdin);
+    };
+    let (watched, ()) = ::tokio::join!(watch, end);
+    watched.expect("async drain watch after discarding bytes");
+    child.wait().expect("reap");
+}

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -215,6 +215,17 @@ impl std::os::fd::AsRawFd for KqueueFd {
 /// against the REAL `AsyncFd` (see `wait_tests`). Exit is concluded only on a drained event;
 /// `clear_ready` only after an EMPTY drain — mio's edge-triggered (`EV_CLEAR`) would-block
 /// contract.
+///
+/// `drain` returning `Ok(None)` is what `clear_ready` treats as "empty" — this loop has no way
+/// to verify that itself, since the closure's return type carries no more than "done" or "not
+/// done". The invariant holds for both current callers because NEITHER `Ok(None)` case ever
+/// consumes bytes: `drain_proc_exit`'s only non-`None` outcome is `NOTE_EXIT`, with no draining
+/// concept at all, and `marker_eof::drain_kqueue`'s caller here (`wait_tree_drained_inner`)
+/// always arms with `unbounded_wait: true`, under which `interpret_read_event` itself never
+/// drains (see `marker_eof`'s module doc — an unbounded wait cannot drain on a sustained
+/// writer's behalf without spinning). A future `drain` closure that DOES consume bytes on a
+/// non-`None`-but-also-non-terminal path would violate this silently; `watch_readable` cannot
+/// detect that on its own, so any such closure owns re-verifying this invariant itself.
 #[cfg(target_os = "macos")]
 async fn watch_readable<F>(afd: &::tokio::io::unix::AsyncFd<KqueueFd>, mut drain: F) -> Result<(), Error>
 where
@@ -229,19 +240,22 @@ where
     }
 }
 
-/// Resolve when every holder of the containment marker's write end has exited — UNBOUNDED IN
-/// BOTH TIME AND CPU, poll-free below `NOTE_LOWAT`'s clamp, reactor-native.
+/// Resolve when every holder of the containment marker's write end has exited — genuinely
+/// poll-free, reactor-native, and with no internal deadline at all.
 ///
-/// **Unlike `block_until_drained`, this future has no deadline parameter and no internal
-/// bound at all.** Below the clamp it genuinely never wakes except on `EV_EOF` (poll-free,
-/// same as the sync form). At or past the clamp (a member sustaining writes ≥ the pipe's
-/// buffer capacity), `watch_readable`'s drain-then-re-await loop has no deadline to check
-/// against, so it keeps draining and re-awaiting for as long as the writer keeps writing —
-/// CPU-proportional to the writer's throughput, for as long as the future is polled, with
-/// nothing here to end it. A caller that wants a bound MUST supply one externally (e.g.
-/// `tokio::time::timeout`, the same pattern `grace_wait` already uses over `wait_exit` in
-/// this file) — that is a caller obligation this doc states explicitly, not a property this
-/// function has.
+/// **Unlike `block_until_drained`, this future has no deadline parameter.** Below `NOTE_LOWAT`'s
+/// clamp it never wakes except on `EV_EOF`. At or past the clamp (a member sustaining writes ≥
+/// the pipe's buffer capacity) this primitive does NOT drain on the writer's behalf, unlike the
+/// sync form's bounded case — see `marker_eof`'s module doc for why an unbounded wait cannot
+/// honestly offer both zero CPU and forward progress for a sustained writer, and why this
+/// primitive, having no deadline to bound the alternative, chooses zero CPU: the writer's own
+/// `write()` call blocks against the full pipe (the marker fd's documented misuse contract —
+/// `fdmarker`'s module doc), and this future stays genuinely asleep until that descriptor
+/// closes. A caller that wants such a writer to make forward progress toward closing the
+/// descriptor cannot get that from this primitive; a caller that merely wants a time bound on
+/// the wait itself can still layer one externally (e.g. `tokio::time::timeout`, the same
+/// pattern `grace_wait` already uses over `wait_exit` in this file) — that bounds the CALLER's
+/// patience, not the writer's blocked state.
 ///
 /// Exited is not reaped: this says nothing about statuses. A caller wanting a status waits on
 /// the root as well.
@@ -285,7 +299,7 @@ async fn wait_tree_drained_inner(
     }
     let afd = AsyncFd::with_interest(KqueueFd(kq), Interest::READABLE).map_err(Error::Io)?;
     watch_readable(&afd, move |kq| {
-        crate::containment::marker_eof::drain_kqueue(kq, read_end).map(|d| d.map(|_| ()))
+        crate::containment::marker_eof::drain_kqueue(kq, read_end, true).map(|d| d.map(|_| ()))
     })
     .await
 }

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -229,6 +229,67 @@ where
     }
 }
 
+/// Resolve when every holder of the containment marker's write end has exited — UNBOUNDED IN
+/// BOTH TIME AND CPU, poll-free below `NOTE_LOWAT`'s clamp, reactor-native.
+///
+/// **Unlike `block_until_drained`, this future has no deadline parameter and no internal
+/// bound at all.** Below the clamp it genuinely never wakes except on `EV_EOF` (poll-free,
+/// same as the sync form). At or past the clamp (a member sustaining writes ≥ the pipe's
+/// buffer capacity), `watch_readable`'s drain-then-re-await loop has no deadline to check
+/// against, so it keeps draining and re-awaiting for as long as the writer keeps writing —
+/// CPU-proportional to the writer's throughput, for as long as the future is polled, with
+/// nothing here to end it. A caller that wants a bound MUST supply one externally (e.g.
+/// `tokio::time::timeout`, the same pattern `grace_wait` already uses over `wait_exit` in
+/// this file) — that is a caller obligation this doc states explicitly, not a property this
+/// function has.
+///
+/// Exited is not reaped: this says nothing about statuses. A caller wanting a status waits on
+/// the root as well.
+///
+/// The marker's own kqueue is what gets registered with the reactor, not the marker
+/// descriptor: a knote is keyed on `(kqueue, fd, filter)`, so a second waiter registering the
+/// same descriptor directly would take over the first's registration and park it forever —
+/// each call arms its OWN private kqueue (`marker_eof::arm`).
+///
+/// No production caller exists yet — Task 6 (`Attached::wait_drained`) wires the SYNC form
+/// only; wiring this async form into `graceful_shutdown_tree` is #62's job. `#[allow(dead_code)]`
+/// reflects that honestly, mirroring `marker_eof::probe`.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub(crate) async fn wait_tree_drained(read_end: std::os::fd::BorrowedFd<'_>) -> Result<(), Error> {
+    wait_tree_drained_inner(read_end, None).await
+}
+
+/// Test-only entry point that reports the instant its kqueue is armed, on a channel the
+/// CALLER owns — no shared/global observer state, so concurrently-running tests (this file
+/// has four) cannot steal each other's notification.
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) async fn wait_tree_drained_for_test(
+    read_end: std::os::fd::BorrowedFd<'_>,
+    armed: std::sync::mpsc::Sender<()>,
+) -> Result<(), Error> {
+    wait_tree_drained_inner(read_end, Some(armed)).await
+}
+
+#[cfg(target_os = "macos")]
+async fn wait_tree_drained_inner(
+    read_end: std::os::fd::BorrowedFd<'_>,
+    armed: Option<std::sync::mpsc::Sender<()>>,
+) -> Result<(), Error> {
+    use ::tokio::io::unix::AsyncFd;
+    use ::tokio::io::Interest;
+    // Unbounded: this future has no deadline parameter at all (see the doc comment above).
+    let kq = crate::containment::marker_eof::arm(read_end, true)?;
+    if let Some(tx) = armed {
+        let _ = tx.send(());
+    }
+    let afd = AsyncFd::with_interest(KqueueFd(kq), Interest::READABLE).map_err(Error::Io)?;
+    watch_readable(&afd, move |kq| {
+        crate::containment::marker_eof::drain_kqueue(kq, read_end).map(|d| d.map(|_| ()))
+    })
+    .await
+}
+
 #[cfg(test)]
 #[path = "wait_tests.rs"]
 mod wait_tests;

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -251,9 +251,9 @@ where
 /// same descriptor directly would take over the first's registration and park it forever —
 /// each call arms its OWN private kqueue (`marker_eof::arm`).
 ///
-/// No production caller exists yet — Task 6 (`Attached::wait_drained`) wires the SYNC form
-/// only; wiring this async form into `graceful_shutdown_tree` is #62's job. `#[allow(dead_code)]`
-/// reflects that honestly, mirroring `marker_eof::probe`.
+/// No production caller exists yet — `Attached::wait_drained` wires the SYNC form only;
+/// wiring this async form into `graceful_shutdown_tree` is a later change's job.
+/// `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
 #[cfg(target_os = "macos")]
 #[allow(dead_code)]
 pub(crate) async fn wait_tree_drained(read_end: std::os::fd::BorrowedFd<'_>) -> Result<(), Error> {

--- a/src/wait/macos.rs
+++ b/src/wait/macos.rs
@@ -2,7 +2,7 @@
 //! reaps) and identity-verified `kill(2)` (no pidfd on Darwin, so a residual pid-reuse
 //! window between re-verify and signal is irreducible — documented at the call site).
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use nix::sys::event::{EvFlags, EventFilter, FilterFlag, KEvent, Kqueue};
 
@@ -108,20 +108,54 @@ pub(crate) fn block_until_exit(id: ProcessId, deadline: Option<Option<Instant>>)
     let Some(kq) = arm_proc_exit(id)? else {
         return Ok(true);
     };
+    block_on_kqueue(&kq, deadline, false, |event| {
+        if event.flags().contains(EvFlags::EV_ERROR) {
+            return Err(Error::Io(std::io::Error::from_raw_os_error(event.data() as i32)));
+        }
+        Ok(Some(true)) // NOTE_EXIT
+    })
+}
+
+/// Block on an armed kqueue until `interpret` concludes, or until `deadline`. `interpret` maps
+/// ONE pending `KEvent` to `Ok(Some(verdict))` (conclusive — stop) or `Ok(None)` (nothing
+/// conclusive yet, e.g. bytes drained below a filter's own terminal condition — keep waiting).
+/// `on_timeout` is the verdict for a genuine timeout.
+///
+/// The deadline is checked explicitly at the top of every round, not inferred from `kevent`
+/// returning 0: a continuously-ready descriptor (e.g. a sustained pipe writer) keeps `kevent`
+/// returning real events even with an already-expired timeout, so relying on "0 events, timed
+/// out" alone would let the wait overrun the deadline by an unbounded number of rounds.
+/// Checking `remaining(deadline)` before each `kevent` call bounds the overrun to at most one
+/// in-flight round: once a round starts with the deadline already elapsed, an inconclusive
+/// event in THAT round returns `on_timeout` immediately rather than looping back.
+///
+/// Shared by every blocking kqueue wait this crate arms — `EVFILT_PROC` here, `EVFILT_READ` in
+/// `containment::marker_eof` — so a hazard found against one filter (an already-past deadline
+/// against a sticky, already-satisfied event) is fixed once, not rediscovered per filter.
+pub(crate) fn block_on_kqueue<T: Copy>(
+    kq: &Kqueue,
+    deadline: Option<Option<Instant>>,
+    on_timeout: T,
+    mut interpret: impl FnMut(&KEvent) -> Result<Option<T>, Error>,
+) -> Result<T, Error> {
     let mut events = [placeholder()];
     loop {
+        let remaining = crate::wait::remaining(deadline);
+        let already_elapsed = remaining == Some(Duration::ZERO);
         // nix Kqueue::kevent takes Option<libc::timespec> (None = block forever).
-        let timeout = crate::wait::remaining(deadline).map(|d| libc::timespec {
+        let timeout = remaining.map(|d| libc::timespec {
             tv_sec: d.as_secs().min(i64::MAX as u64) as libc::time_t,
             tv_nsec: d.subsec_nanos() as libc::c_long,
         });
         match kq.kevent(&[], &mut events, timeout) {
-            Ok(0) => return Ok(false), // timed out, still alive
+            Ok(0) => return Ok(on_timeout), // genuinely timed out, no events
             Ok(_) => {
-                if events[0].flags().contains(EvFlags::EV_ERROR) {
-                    return Err(Error::Io(std::io::Error::from_raw_os_error(events[0].data() as i32)));
+                if let Some(verdict) = interpret(&events[0])? {
+                    return Ok(verdict);
                 }
-                return Ok(true); // NOTE_EXIT
+                if already_elapsed {
+                    return Ok(on_timeout);
+                }
             }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(e) => return Err(Error::Io(e.into())),

--- a/src/wait/macos.rs
+++ b/src/wait/macos.rs
@@ -13,21 +13,13 @@ fn placeholder() -> KEvent {
     KEvent::new(0, EventFilter::EVFILT_PROC, EvFlags::empty(), FilterFlag::empty(), 0, 0)
 }
 
-/// Arm an `EVFILT_PROC | NOTE_EXIT` filter for `pid` on an EXISTING kqueue (`EV_RECEIPT`:
-/// synchronous, receipt-checked). `Ok(None)` => the pid is already gone. The single
-/// definition of the receipt dance — `arm_proc_exit` consumes it, and the decoy composition
-/// test arms its second filter through it (no hand-rolled twin to drift).
-pub(crate) fn arm_note_exit_on(kq: &Kqueue, pid: u32) -> Result<Option<()>, Error> {
-    let change = KEvent::new(
-        pid as usize,
-        EventFilter::EVFILT_PROC,
-        EvFlags::EV_ADD | EvFlags::EV_RECEIPT,
-        FilterFlag::NOTE_EXIT,
-        0,
-        0,
-    );
+/// Apply one change to an EXISTING kqueue with `EV_RECEIPT` (synchronous, receipt-checked)
+/// and return the add result: 0 = armed, otherwise an errno. The single definition of the
+/// receipt dance, shared by every filter this crate arms via `EV_ADD | EV_RECEIPT` — no
+/// hand-rolled twin to drift.
+pub(crate) fn add_with_receipt(kq: &Kqueue, change: KEvent) -> Result<i64, Error> {
     // EV_RECEIPT makes EV_ADD synchronous: kevent returns exactly one receipt event
-    // whose `data` is the add result (0 = armed, ESRCH = pid gone, other = errno).
+    // whose `data` is the add result (0 = armed, an errno otherwise).
     let mut receipt = [placeholder()];
     let n = kq
         .kevent(&[change], &mut receipt, None)
@@ -37,7 +29,21 @@ pub(crate) fn arm_note_exit_on(kq: &Kqueue, pid: u32) -> Result<Option<()>, Erro
             "kqueue EV_RECEIPT returned no receipt event",
         )));
     }
-    let add_result = receipt[0].data() as i64;
+    Ok(receipt[0].data() as i64)
+}
+
+/// Arm an `EVFILT_PROC | NOTE_EXIT` filter for `pid` on an EXISTING kqueue. `Ok(None)` => the
+/// pid is already gone.
+pub(crate) fn arm_note_exit_on(kq: &Kqueue, pid: u32) -> Result<Option<()>, Error> {
+    let change = KEvent::new(
+        pid as usize,
+        EventFilter::EVFILT_PROC,
+        EvFlags::EV_ADD | EvFlags::EV_RECEIPT,
+        FilterFlag::NOTE_EXIT,
+        0,
+        0,
+    );
+    let add_result = add_with_receipt(kq, change)?;
     if add_result == libc::ESRCH as i64 {
         return Ok(None); // pid already gone
     }


### PR DESCRIPTION
#59 gives a contained macOS root an inherited pipe: the supervisor holds the read end, every member holds a write end. When the last member exits, the last write end closes and the read end sees EOF — a kernel-backed "the tree is empty" event that is crash-safe, orphan-inclusive and needs no polling. Nothing consumed it.

This exposes it as a waitable edge, registered via kqueue `EVFILT_READ` with no interval anywhere in the path.

## What it reports

`TreeDrain::{AllMembersExited, MembersRemain}` rather than a bool, because the edge fires on **exit**, not on reaping — an unreaped zombie holds no write end and is not a member. A bool at the call site loses exactly that distinction.

EOF on a pipe is sticky and non-consuming: `read()` returns 0 and keeps returning 0. So repeated and concurrent waiters are safe, and re-waiting after a read is safe.

## What it does and does not guarantee

Below the pipe's low-water clamp — the realistic case, since nothing in the crate ever writes to the marker — the wait is genuinely poll-free, pinned by a thread-scoped CPU-accounting test rather than by wall-clock behaviour, which a busy poll would satisfy identically. XNU clamps a knote's low-water mark to the pipe's actual buffer capacity (~64 KiB here), so a member writing at or above that makes the wait degrade to bounded, CPU-proportional draining. At that point the only claim is that it never exceeds the deadline, checked explicitly at the top of every round: a continuously-ready descriptor makes `kevent` return a real event every time, including with an already-expired timeout, so a loop that infers expiry from a zero-event return never notices it.

An inconclusive write-end scan refuses only when the deadline is unbounded. Under a bounded one the wait simply times out; under an unbounded one an inconclusive scan is precisely when it could hang forever with no way for the caller to find out why.

## Scope

The primitive plus a crate-internal `Attached::wait_drained` accessor. Wiring `graceful_shutdown_tree` to escalate only when the deadline beats the drain is #62's, which both issues' text already assigns there — so the new entry points carry `#[allow(dead_code)]` honestly until then rather than being given a speculative caller.