### PR TITLE
feat: wait for a contained tree to drain, escalating only when the deadline beats it (closes #62)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,25 +144,35 @@ jobs:
       # its `cgroup.subtree_control` is empty, so the v2 "no internal processes"
       # rule does not apply and a cgroup may hold BOTH the test process and a child
       # leaf. We move our shell into it and run only the cgroup-named tests there
-      # (as root, single-threaded). With the marker set the tests assert CgroupV2
-      # and FAIL LOUDLY if the leaf is unusable — never a silent skip.
+      # (as root, single-threaded) — both the `spawn_io` integration binary and the
+      # `--lib` unit-test binary (which carries the white-box CgroupLeaf::wait_drained
+      # coverage in src/containment/cgroup_tests.rs). With the marker set the tests
+      # assert CgroupV2/build a real leaf and FAIL LOUDLY if it is unusable — never a
+      # silent skip.
       - name: Run cgroup v2 containment tests (Linux)
         if: matrix.os == 'linux'
         run: |
           set -euxo pipefail
           cargo test --locked --features pty --target ${{ matrix.target }} --no-run
-          BIN=$(cargo test --locked --features pty --target ${{ matrix.target }} --no-run --message-format=json \
+          JSON=$(cargo test --locked --features pty --target ${{ matrix.target }} --no-run --message-format=json)
+          BIN=$(echo "$JSON" \
             | jq -r 'select(.profile.test == true and .target.name == "spawn_io") | .executable' \
             | grep -v '^null$' | grep . | head -n1)
           test -n "$BIN"
           echo "cgroup test binary: $BIN"
+          LIB_BIN=$(echo "$JSON" \
+            | jq -r 'select(.profile.test == true and .target.name == "cosca" and (.target.kind | contains(["lib"]))) | .executable' \
+            | grep -v '^null$' | grep . | head -n1)
+          test -n "$LIB_BIN"
+          echo "cgroup lib unit test binary: $LIB_BIN"
           sudo bash -euxc '
             CG=/sys/fs/cgroup/cosca-ci
             mkdir -p "$CG"
             echo $$ > "$CG/cgroup.procs"
             export COSCA_TEST_CGROUP=1
-            exec "$0" cgroup --nocapture --test-threads=1
-          ' "$BIN"
+            "$0" cgroup --nocapture --test-threads=1
+            exec "$1" cgroup --nocapture --test-threads=1
+          ' "$BIN" "$LIB_BIN"
 
       # Live setuid-root process-group teardown test (issue #61) is `#[ignore]`d by default
       # (see tests/group_teardown_setuid.rs's module docs) — an ordinary `cargo test`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_Threading",
     "Win32_System_JobObjects",
+    "Win32_System_IO",
     "Win32_System_Console",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Security",

--- a/src/child.rs
+++ b/src/child.rs
@@ -123,6 +123,11 @@ impl Child {
         crate::containment::require_contained(self.containment, &self.attached)
     }
 
+    /// Guard for `wait_tree`/`wait_tree_timeout` (single-sourced with the async `Child`).
+    fn require_drainable(&self) -> Result<(), Error> {
+        crate::containment::require_drainable(self.containment, &self.attached)
+    }
+
     /// This child's stable identity (see [`crate::identity::ProcessId`]).
     pub fn id(&self) -> ProcessId {
         self.id

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -160,30 +160,33 @@ impl Child {
 
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
         //
-        // `drained`: whether the sweep below is skippable. On a drain-observable mechanism
-        // this is positive kernel-confirmed proof the WHOLE tree exited, so the sweep would be
-        // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
-        // stays `false` unconditionally and the sweep always runs, exactly as before this
-        // distinction existed. `root_exited`: whether the root specifically was observed to
-        // have exited. A drained tree implies it. On the root-only-watch mechanism (the `else`
-        // arm below) it is that watch's own result. On a drain-observable mechanism whose tree
-        // did NOT fully drain (`MembersRemain`) it comes from a fresh, non-blocking,
-        // zero-duration probe of the root alone, immediately below — a tree-wide `MembersRemain`
-        // verdict says nothing about the root specifically (only some OTHER member may still be
-        // alive), and the probe costs nothing extra since `grace` was already fully spent by
-        // the tree-drain watch that just returned it. Used only below, to decide whether a
-        // best-effort reap is safe after a sweep failure.
+        // `drained`: whether the sweep below is skippable. Only `TreeDrain::AllMembersExited`
+        // (`permits_skipping_sweep`) makes it true — positive kernel-confirmed proof the WHOLE
+        // tree exited, from a mechanism a live process cannot leave without exiting, so the
+        // sweep would be pure overhead. `AllMarkersClosed` (the macOS marker's advisory pipe
+        // EOF — see `TreeDrain`'s own doc) is NOT that proof: a live process can close its own
+        // copy of the marker descriptor and remain alive, undetectable by this edge alone, so
+        // it falls into the same "always sweep" bucket as `MembersRemain` and every mechanism
+        // with no drain edge at all. `root_exited`: whether the root specifically was observed
+        // to have exited. A skipped-sweep tree implies it. On the root-only-watch mechanism
+        // (the `else` arm below) it is that watch's own result. Everywhere else it comes from a
+        // fresh, non-blocking, zero-duration probe of the root alone, immediately below — a
+        // tree-wide verdict that isn't sufficient to skip the sweep says nothing about the root
+        // specifically (only some OTHER member may still be alive), and the probe costs nothing
+        // extra since `grace` was already fully spent by the tree-drain watch that just
+        // returned it. Used only below, to decide whether a best-effort reap is safe after a
+        // sweep failure.
         let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
             (false, false, Some(e))
         } else if self.containment().can_observe_drain() {
             match self.attached.wait_drained(crate::wait::deadline_from(grace)) {
-                Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
-                Ok(crate::containment::TreeDrain::MembersRemain) => {
-                    match crate::wait::block_until_exit(self.id, Some(Duration::ZERO)) {
-                        Ok(exited) => (false, exited, None),
-                        Err(e) => (false, false, Some(e)),
-                    }
-                }
+                Ok(verdict) if verdict.permits_skipping_sweep() => (true, true, None),
+                // Not sufficient proof alone to skip the sweep (see the doc above) — fall back
+                // to the fresh, non-blocking, zero-duration root probe described there.
+                Ok(_) => match crate::wait::block_until_exit(self.id, Some(Duration::ZERO)) {
+                    Ok(exited) => (false, exited, None),
+                    Err(e) => (false, false, Some(e)),
+                },
                 Err(e) => (false, false, Some(e)),
             }
         } else {
@@ -304,6 +307,27 @@ pub(crate) mod fault {
     }
     pub(crate) fn forced_kill_tree_error() -> crate::error::Error {
         crate::error::Error::Io(std::io::Error::other("forced kill_tree failure (test seam)"))
+    }
+
+    /// RAII disarm for `FORCE_KILL_TREE_ERROR`: a test that arms this seam expecting the sweep
+    /// to skip (so the seam is never consumed by `take_force_kill_tree_error`) must still clear
+    /// it before the thread is reused by a later test — a bare last-line
+    /// `set_force_kill_tree_error(false)` would be skipped by an early return via a failed
+    /// assertion (panic unwinds through this guard's `Drop` regardless). Consuming the seam
+    /// normally (the sweep runs and calls `take_force_kill_tree_error`) already leaves it
+    /// disarmed, so this guard's own `drop` is then a harmless no-op.
+    #[must_use]
+    pub(crate) struct ArmedKillTreeError;
+    impl ArmedKillTreeError {
+        pub(crate) fn arm() -> Self {
+            set_force_kill_tree_error(true);
+            Self
+        }
+    }
+    impl Drop for ArmedKillTreeError {
+        fn drop(&mut self) {
+            set_force_kill_tree_error(false);
+        }
     }
     // No `armed()` here, unlike `crate::wait::fault`'s seam: `take_force_terminate` runs
     // unconditionally at the very top of `graceful_shutdown_tree`, so by the time any test

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -7,6 +7,20 @@ use std::time::Duration;
 use super::Child;
 use crate::error::Error;
 
+/// The `crate::wait::fault` grace-watch seam, consumed HERE rather than inside a specific
+/// backend so it applies uniformly to whichever watch `graceful_shutdown_tree` actually
+/// performs — root-only ([`crate::wait::block_until_exit`]) or whole-tree
+/// ([`crate::containment::Attached::wait_drained`]). Outside test builds the seam module does
+/// not exist at all, so this compiles to a constant `None`.
+#[cfg(test)]
+fn take_forced_watch_error() -> Option<Error> {
+    crate::wait::fault::take_force_watch_error().then(crate::wait::fault::forced_watch_error)
+}
+#[cfg(not(test))]
+fn take_forced_watch_error() -> Option<Error> {
+    None
+}
+
 impl Child {
     /// Send `SIGTERM` to the (lone) child — a cooperative request to exit. Signal-only: does
     /// not wait or reap. Identity-bound, so it cannot race a concurrent reap onto a recycled
@@ -48,18 +62,28 @@ impl Child {
 
     /// Cooperative-then-forced shutdown of the contained tree: send the group its graceful
     /// signal (`SIGTERM` via `killpg`/cgroup, or `CTRL_BREAK` to the job/console group), wait
-    /// up to `grace` for the **root** to exit, then hard-sweep any survivors and reap the root.
-    /// Returns the root's `ExitStatus`. Requires an actionable containment mechanism (errors
-    /// `Unsupported` otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone
-    /// child). Works on all platforms.
+    /// up to `grace`, then hard-sweep any survivors and reap the root. Returns the root's
+    /// `ExitStatus`. Requires an actionable containment mechanism (errors `Unsupported`
+    /// otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone child).
+    /// Works on all platforms.
+    ///
+    /// **What the grace-wait watches depends on the mechanism.** On one with a real kernel
+    /// drain edge ([`Containment::can_observe_drain`](crate::containment::Containment::can_observe_drain)
+    /// — cgroup v2, a Windows job object, the macOS fd marker), the whole `grace` is spent
+    /// watching the *entire tree* drain, and the hard sweep below runs only if `grace` elapses
+    /// before the tree does — never on a tree that already cleared on its own. On every other
+    /// mechanism (`ProcessGroup`, `Session`, `TreeWalk`) there is no kernel edge to observe
+    /// descendants draining, so the wait watches the **root only** and the sweep always runs
+    /// afterward regardless of what it saw, exactly as before this distinction existed.
     ///
     /// **Windows: what this actually signals, and what the grace costs.** `CTRL_BREAK` goes
     /// to the root's **process group** only. A nested contained descendant leads its own
     /// group and never receives it — so it does not exit during the grace, idles through the
-    /// whole window, and is then killed by the sweep. The call reports no error either way:
-    /// on Windows the grace is spent regardless of how much of the tree the signal reached.
-    /// Size it accordingly, and treat [`kill_tree`](Child::kill_tree) as the only op that
-    /// reaches every member.
+    /// whole window, and is then killed by the sweep (a job object *is* drain-observable, so
+    /// this shows up as `grace` fully elapsing rather than draining early, not as a skipped
+    /// wait). The call reports no error either way: on Windows the grace is spent regardless
+    /// of how much of the tree the signal reached. Size it accordingly, and treat
+    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned
@@ -69,11 +93,10 @@ impl Child {
     /// but a raw `Error::Io` when the crate cannot confirm it — so treat **any** error here
     /// as "not delivered, tree still running".
     ///
-    /// The grace-wait is **non-reaping** (watches the root's exit without collecting it), so the
-    /// subsequent hard sweep runs while the root's pid — and thus the `killpg` group id — is
-    /// still valid; reaping first could let `killpg` hit a recycled group. The sweep is
-    /// unconditional but a no-op once the tree has drained, so a graceful exit's status is
-    /// preserved (the lone backstop no-ops on the already-dead root).
+    /// The grace-wait is **non-reaping** (watches exit without collecting it), so a subsequent
+    /// hard sweep runs while the root's pid — and thus the `killpg` group id — is still valid;
+    /// reaping first could let `killpg` hit a recycled group. A skipped or no-op sweep alike
+    /// preserve a graceful exit's status (the lone backstop no-ops on an already-dead root).
     ///
     /// A watch failure never skips the sweep and reap; a sweep error wins over it — and over
     /// a graceful root exit (survivors may remain; the root is still reaped first when its
@@ -136,41 +159,80 @@ impl Child {
         };
 
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
-        let watch = crate::wait::block_until_exit(self.id, Some(grace)); // NON-reaping grace-wait on root
-
-        // The sweep is unconditional — a gracefully-exited root does NOT mean the descendants
-        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch or terminate Err;
-        // it must propagate before the reap on a LIVE root (waiting unswept would hang), but once
-        // the root's exit was observed, the reap runs first so no zombie is stranded.
-        if let Err(e) = &watch {
+        //
+        // `drained`: whether the sweep below is skippable. On a drain-observable mechanism
+        // this is positive kernel-confirmed proof the WHOLE tree exited, so the sweep would be
+        // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
+        // stays `false` unconditionally and the sweep always runs, exactly as before this
+        // distinction existed. `root_exited`: whether the root specifically was observed to
+        // have exited (a drained tree implies it; otherwise it is the root-only watch's own
+        // result) — used only below, to decide whether a best-effort reap is safe after a
+        // sweep failure.
+        let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
+            (false, false, Some(e))
+        } else if self.containment().can_observe_drain() {
+            match self.attached.wait_drained(crate::wait::deadline_from(grace)) {
+                Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
+                Ok(crate::containment::TreeDrain::MembersRemain) => (false, false, None),
+                Err(e) => (false, false, Some(e)),
+            }
+        } else {
+            match crate::wait::block_until_exit(self.id, Some(grace)) {
+                // NON-reaping grace-wait on the root only.
+                Ok(exited) => (false, exited, None),
+                Err(e) => (false, false, Some(e)),
+            }
+        };
+        if let Some(e) = &watch_err {
             log::debug!(
                 "graceful_shutdown_tree({id}): watch error before escalation (subsumed if it also fails): {e}",
                 id = self.id.pid()
             );
         }
-        if let Err(sweep) = self.kill_tree() {
-            if matches!(watch, Ok(true)) {
-                // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
-                // (below) is already the error this call reports, so a failure here is
-                // secondary — but every other discarded error in this module is still logged,
-                // and a silent one here would obscure a second, independent failure mode.
-                if let Err(e) = self.wait() {
-                    log::debug!(
-                        "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
-                        id = self.id.pid()
-                    );
+        // A sweep Err subsumes any watch or terminate Err; it must propagate before the reap on
+        // a LIVE root (waiting unswept would hang), but once the root's exit was observed, the
+        // reap runs first so no zombie is stranded.
+        if !drained {
+            // The `#[cfg(test)]` arm lets a test PROVE the sweep is skipped when `drained`,
+            // not merely that it would have no-op'd: forcing this call to fail and then
+            // observing `Ok` from the whole function is only possible if this branch was
+            // never entered at all.
+            #[cfg(test)]
+            let sweep_result = if fault::take_force_kill_tree_error() {
+                Err(fault::forced_kill_tree_error())
+            } else {
+                self.kill_tree()
+            };
+            #[cfg(not(test))]
+            let sweep_result = self.kill_tree();
+            if let Err(sweep) = sweep_result {
+                if root_exited {
+                    // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
+                    // (below) is already the error this call reports, so a failure here is
+                    // secondary — but every other discarded error in this module is still logged,
+                    // and a silent one here would obscure a second, independent failure mode.
+                    if let Err(e) = self.wait() {
+                        log::debug!(
+                            "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
+                            id = self.id.pid()
+                        );
+                    }
                 }
+                return Err(sweep);
             }
-            return Err(sweep);
         }
         let status = self.wait()?;
-        watch?;
-        // The sweep just returned `Ok`: positive, freshly-measured proof the group cleared,
-        // superseding whatever `term` held. Discard it here rather than returning it — an
-        // already-disproved refusal must never outrank the evidence that disproved it.
+        if let Some(e) = watch_err {
+            return Err(e);
+        }
+        // The tree is confirmed clear here — either the drain watch observed the whole tree
+        // directly (`drained`), or the sweep just returned `Ok`: either way, positive,
+        // freshly-measured proof superseding whatever `term` held. Discard it here rather than
+        // returning it — an already-disproved refusal must never outrank the evidence that
+        // disproved it.
         if let Err(e) = &term {
             log::debug!(
-                "graceful_shutdown_tree({id}): sweep succeeded; discarding the superseded terminate_tree refusal: {e}",
+                "graceful_shutdown_tree({id}): tree confirmed clear; discarding the superseded terminate_tree refusal: {e}",
                 id = self.id.pid()
             );
         }
@@ -209,12 +271,29 @@ pub(crate) mod fault {
     }
     thread_local! {
         static FORCE_TERMINATE: Cell<Forced> = const { Cell::new(Forced::None) };
+        static FORCE_KILL_TREE_ERROR: Cell<bool> = const { Cell::new(false) };
     }
     pub(crate) fn set_force_terminate(kind: Forced) {
         FORCE_TERMINATE.with(|f| f.set(kind));
     }
     pub(crate) fn take_force_terminate() -> Forced {
         FORCE_TERMINATE.with(|f| f.replace(Forced::None))
+    }
+
+    /// Force the next `kill_tree` call inside `graceful_shutdown_tree` on THIS thread — the
+    /// sweep, not `terminate_tree` — to fail, so a test can prove it was skipped (`drained`)
+    /// rather than merely no-op'd on an already-empty group.
+    pub(crate) fn set_force_kill_tree_error(on: bool) {
+        FORCE_KILL_TREE_ERROR.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_kill_tree_error() -> bool {
+        FORCE_KILL_TREE_ERROR.with(|f| f.replace(false))
+    }
+    pub(crate) fn kill_tree_armed() -> bool {
+        FORCE_KILL_TREE_ERROR.with(|f| f.get())
+    }
+    pub(crate) fn forced_kill_tree_error() -> crate::error::Error {
+        crate::error::Error::Io(std::io::Error::other("forced kill_tree failure (test seam)"))
     }
     // No `armed()` here, unlike `crate::wait::fault`'s seam: `take_force_terminate` runs
     // unconditionally at the very top of `graceful_shutdown_tree`, so by the time any test

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -165,15 +165,25 @@ impl Child {
         // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
         // stays `false` unconditionally and the sweep always runs, exactly as before this
         // distinction existed. `root_exited`: whether the root specifically was observed to
-        // have exited (a drained tree implies it; otherwise it is the root-only watch's own
-        // result) — used only below, to decide whether a best-effort reap is safe after a
-        // sweep failure.
+        // have exited. A drained tree implies it. On the root-only-watch mechanism (the `else`
+        // arm below) it is that watch's own result. On a drain-observable mechanism whose tree
+        // did NOT fully drain (`MembersRemain`) it comes from a fresh, non-blocking,
+        // zero-duration probe of the root alone, immediately below — a tree-wide `MembersRemain`
+        // verdict says nothing about the root specifically (only some OTHER member may still be
+        // alive), and the probe costs nothing extra since `grace` was already fully spent by
+        // the tree-drain watch that just returned it. Used only below, to decide whether a
+        // best-effort reap is safe after a sweep failure.
         let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
             (false, false, Some(e))
         } else if self.containment().can_observe_drain() {
             match self.attached.wait_drained(crate::wait::deadline_from(grace)) {
                 Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
-                Ok(crate::containment::TreeDrain::MembersRemain) => (false, false, None),
+                Ok(crate::containment::TreeDrain::MembersRemain) => {
+                    match crate::wait::block_until_exit(self.id, Some(Duration::ZERO)) {
+                        Ok(exited) => (false, exited, None),
+                        Err(e) => (false, false, Some(e)),
+                    }
+                }
                 Err(e) => (false, false, Some(e)),
             }
         } else {

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -132,7 +132,7 @@ fn graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
         crate::log_capture::contains_since(
             mark,
             &format!(
-                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                "graceful_shutdown_tree({pid}): tree confirmed clear; discarding the superseded terminate_tree refusal",
                 pid = id.pid()
             )
         ),
@@ -183,7 +183,7 @@ fn graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
         crate::log_capture::contains_since(
             mark,
             &format!(
-                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                "graceful_shutdown_tree({pid}): tree confirmed clear; discarding the superseded terminate_tree refusal",
                 pid = id.pid()
             )
         ),
@@ -233,6 +233,57 @@ fn graceful_tree_unassessable_mechanism_failure_fails_fast() {
     // Clean up: the child is still running by design (no sweep happened above).
     let _ = child.kill_tree();
     let _ = child.wait();
+}
+
+// The core #62 property: on a drain-observable mechanism, a tree that drains on its own within
+// `grace` must skip the hard sweep entirely — not merely run a sweep that no-ops on an empty
+// group. Proven by forcing `kill_tree` to fail: the call only comes back `Ok` if that branch
+// was never entered. On a mechanism with no kernel drain edge (no `ProcessGroup`/`Session`
+// fallback host in CI, but asserted either way rather than assumed), the sweep stays
+// unconditional by design, so the forced failure must surface instead — both arms are real,
+// exercised assertions, not a skip.
+#[test]
+fn graceful_tree_drained_skips_sweep_when_mechanism_allows() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]); // dies to the default-disposition SIGTERM well within grace
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let result = child.graceful_shutdown_tree(Duration::from_secs(30));
+    if drainable {
+        let status = result.expect("a fully-drained tree must not invoke the sweep at all");
+        assert!(
+            term_fault::kill_tree_armed(),
+            "the forced kill_tree failure must still be armed — the sweep was never entered"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            assert_eq!(
+                status.signal(),
+                Some(libc::SIGTERM),
+                "graceful root exit, got {status:?}"
+            );
+        }
+        #[cfg(windows)]
+        let _ = status;
+    } else {
+        // No kernel drain edge on this mechanism: the sweep is unconditional by design (see
+        // graceful_shutdown_tree's own doc), so the forced failure must surface — proving the
+        // sweep WAS entered, the opposite of the branch above.
+        let err = result.expect_err("a non-drainable mechanism must always run the sweep");
+        assert!(
+            !term_fault::kill_tree_armed(),
+            "the sweep must have consumed the forced-failure seam"
+        );
+        assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+        let _ = child.kill_tree(); // cleanup: the forced failure means the real sweep never ran
+        let _ = child.wait();
+    }
 }
 
 // A NON-containment terminate_tree error (modelling NoConsole/Unsupported) must NOT be held

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -356,27 +356,34 @@ fn graceful_tree_members_remain_still_reaps_an_already_exited_root() {
 // of cgroup/process-group. Fixture: `test_child::fixture_survives_group_signal` (see its own
 // doc) plays the Unix root shell's role — it spawns a `CREATE_NEW_PROCESS_GROUP` grandchild the
 // group `CTRL_BREAK` can never reach (forcing `MembersRemain` on the drain-observable job
-// object, exactly like the Unix fixture's backgrounded, TERM-immune `sleep`), writes a
-// readiness byte to its own stdout, and exits immediately on its own — leaving an unreaped root
-// by the time `graceful_shutdown_tree` runs, exactly like the Unix twin's own `exit 0`.
+// object, exactly like the Unix fixture's backgrounded, TERM-immune `sleep`), THEN connects back
+// and tags over the TCP listener below, proving the grandchild already exists in its own group
+// before this test proceeds — the same happens-before edge the Unix fixture's readiness-byte
+// read supplies, over the same control-channel shape `tests/common::spawn_tree` uses (a stdout
+// byte would not work here: libtest captures a passing test's own `print!` output and discards
+// it, so it would never reach a piped reader — see the fixture's own doc). The fixture then
+// exits immediately on its own, leaving an unreaped root by the time `graceful_shutdown_tree`
+// runs, exactly like the Unix twin's own `exit 0`.
 #[cfg(windows)]
 #[test]
 fn windows_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
     use std::io::Read;
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind readiness listener");
+    let addr = listener.local_addr().expect("local_addr").to_string();
 
     let mut cmd = crate::Command::new();
     cmd.executable(std::env::current_exe().expect("current_exe"))
         .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
-    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ENV, "1");
-    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV, addr);
     cmd.contain();
-    let mut child = cmd.spawn().expect("spawn");
-    let mut readiness = [0u8; 1];
-    child
-        .stdout()
-        .expect("piped stdout")
-        .read_exact(&mut readiness)
-        .expect("readiness byte");
+    let child = cmd.spawn().expect("spawn");
+    // Blocks until the fixture has connected — which it does only after the grandchild survivor
+    // already exists in its own process group (see the fixture's own doc).
+    let (mut sock, _) = listener.accept().expect("accept readiness connection");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("readiness tag");
     let id = child.id();
     let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -351,22 +351,37 @@ fn graceful_tree_members_remain_still_reaps_an_already_exited_root() {
     let _ = child.kill_tree();
 }
 
-// Windows twin of `graceful_tree_members_remain_still_reaps_an_already_exited_root` above — see
-// its doc for the invariant under test; identical here, just reached via a job object instead
-// of cgroup/process-group. Fixture: `test_child::fixture_survives_group_signal` (see its own
-// doc) plays the Unix root shell's role — it spawns a `CREATE_NEW_PROCESS_GROUP` grandchild the
-// group `CTRL_BREAK` can never reach (forcing `MembersRemain` on the drain-observable job
-// object, exactly like the Unix fixture's backgrounded, TERM-immune `sleep`), THEN connects back
-// and tags over the TCP listener below, proving the grandchild already exists in its own group
-// before this test proceeds — the same happens-before edge the Unix fixture's readiness-byte
-// read supplies, over the same control-channel shape `tests/common::spawn_tree` uses (a stdout
-// byte would not work here: libtest captures a passing test's own `print!` output and discards
-// it, so it would never reach a piped reader — see the fixture's own doc). The fixture then
-// exits immediately on its own, leaving an unreaped root by the time `graceful_shutdown_tree`
-// runs, exactly like the Unix twin's own `exit 0`.
+// Windows twin of `graceful_tree_members_remain_still_reaps_an_already_exited_root` above,
+// reached via a job object instead of cgroup/process-group — but NOT a check on the same
+// postcondition, because that postcondition does not translate. The Unix test proves an
+// already-exited root is best-effort REAPED (`waitpid`-collected) even when the sweep also
+// fails, so it never strands a zombie. Windows has no reap concept to strand: per the
+// `shared_child` crate's own comment on its Windows backend, "there's no such thing as reaping
+// child processes on Windows — instead, you close the child handle when you're done with it,
+// like a file", and `Child::wait()` never closes that handle on any Windows backend (raw or
+// std) — only `Child`'s own `Drop` does. A Windows process object stays resolvable exactly as
+// long as ANY handle referencing it is open, including this very `Child`'s own handle, held for
+// this whole test — so `id.exists()` reports `Present` here whether or not the best-effort
+// `self.wait()` call inside `graceful_shutdown_tree` ran, on both the fixed code and the bug it
+// was meant to catch. There is no Windows-observable difference to assert here; asserting `Gone`
+// would be tautologically false regardless of correctness (as CI's `left: Present, right: Gone`
+// failure demonstrated) rather than evidence of anything. What IS Windows-observable, and
+// exercised below, is that a drain-observable-but-not-fully-drained mechanism (`MembersRemain`)
+// still runs the hard sweep and surfaces its failure — the same control flow this branch is
+// otherwise built to protect.
+//
+// Fixture: `test_child::fixture_survives_group_signal` (see its own doc) plays the Unix root
+// shell's role — it spawns a `CREATE_NEW_PROCESS_GROUP` grandchild the group `CTRL_BREAK` can
+// never reach (forcing `MembersRemain` on the drain-observable job object, exactly like the Unix
+// fixture's backgrounded, TERM-immune `sleep`), THEN connects back and tags over the TCP
+// listener below, proving the grandchild already exists in its own group before this test
+// proceeds — the same happens-before edge the Unix fixture's readiness-byte read supplies, over
+// the same control-channel shape `tests/common::spawn_tree` uses (a stdout byte would not work
+// here: libtest captures a passing test's own `print!` output and discards it, so it would never
+// reach a piped reader — see the fixture's own doc).
 #[cfg(windows)]
 #[test]
-fn windows_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+fn windows_graceful_tree_members_remain_surfaces_the_forced_sweep_failure() {
     use std::io::Read;
     use std::net::TcpListener;
 
@@ -384,8 +399,6 @@ fn windows_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
     let (mut sock, _) = listener.accept().expect("accept readiness connection");
     let mut tag = [0u8; 1];
     sock.read_exact(&mut tag).expect("readiness tag");
-    let id = child.id();
-    let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);
     let err = child
         .graceful_shutdown_tree(Duration::from_secs(2))
@@ -394,16 +407,6 @@ fn windows_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
     assert!(
         !term_fault::kill_tree_armed(),
         "the sweep must have consumed the forced-failure seam"
-    );
-    assert_eq!(
-        id.exists(),
-        crate::identity::Existence::Gone,
-        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
-        if drainable {
-            "MembersRemain branch"
-        } else {
-            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
-        }
     );
     // Cleanup: the forced sweep failure was a stub, so the group-signal-immune descendant is
     // still alive — a real sweep now (the seam is already consumed) actually kills it.

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -235,15 +235,16 @@ fn graceful_tree_unassessable_mechanism_failure_fails_fast() {
     let _ = child.wait();
 }
 
-// The core #62 property: on a drain-observable mechanism, a tree that drains on its own within
-// `grace` must skip the hard sweep entirely — not merely run a sweep that no-ops on an empty
-// group. Proven by forcing `kill_tree` to fail: the call only comes back `Ok` if that branch
-// was never entered. On a mechanism with no kernel drain edge (no `ProcessGroup`/`Session`
-// fallback host in CI, but asserted either way rather than assumed), the sweep stays
-// unconditional by design, so the forced failure must surface instead — both arms are real,
-// exercised assertions, not a skip.
+// The invariant under test: only an AUTHORITATIVE drain-observable mechanism (cgroup v2, Windows
+// job object — kernel-owned membership a live process cannot leave without exiting) may skip
+// the hard sweep when a tree drains on its own within `grace`. macOS's fd marker IS
+// drain-observable (`can_observe_drain()` is true) but its EOF is advisory — see `TreeDrain`'s
+// own doc — so it must land in the same "sweep always runs" bucket as a mechanism with no drain
+// edge at all, not the "skip the sweep" bucket. Proven by forcing `kill_tree` to fail: the call
+// only comes back `Ok` if that branch was never entered. Both arms are real, exercised
+// assertions on every platform, not a skip.
 #[test]
-fn graceful_tree_drained_skips_sweep_when_mechanism_allows() {
+fn graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() {
     let mut cmd = crate::Command::new();
     #[cfg(unix)]
     cmd.args(["sleep", "30"]); // dies to the default-disposition SIGTERM well within grace
@@ -251,15 +252,19 @@ fn graceful_tree_drained_skips_sweep_when_mechanism_allows() {
     cmd.args(["ping", "-n", "30", "127.0.0.1"]);
     cmd.contain();
     let child = cmd.spawn().expect("spawn");
-    let drainable = child.containment().can_observe_drain();
-    term_fault::set_force_kill_tree_error(true);
+    let authoritative = matches!(
+        child.containment(),
+        crate::containment::Containment::CgroupV2 | crate::containment::Containment::JobObject
+    );
+    let armed = term_fault::ArmedKillTreeError::arm();
     let result = child.graceful_shutdown_tree(Duration::from_secs(30));
-    if drainable {
-        let status = result.expect("a fully-drained tree must not invoke the sweep at all");
+    if authoritative {
+        let status = result.expect("an authoritatively-drained tree must not invoke the sweep at all");
         assert!(
             term_fault::kill_tree_armed(),
             "the forced kill_tree failure must still be armed — the sweep was never entered"
         );
+        drop(armed); // disarm now that this branch's own assertion above has run
         #[cfg(unix)]
         {
             use std::os::unix::process::ExitStatusExt;
@@ -272,46 +277,54 @@ fn graceful_tree_drained_skips_sweep_when_mechanism_allows() {
         #[cfg(windows)]
         let _ = status;
     } else {
-        // No kernel drain edge on this mechanism: the sweep is unconditional by design (see
-        // graceful_shutdown_tree's own doc), so the forced failure must surface — proving the
-        // sweep WAS entered, the opposite of the branch above.
-        let err = result.expect_err("a non-drainable mechanism must always run the sweep");
+        // Either the marker is advisory (macOS, drain-observable but not authoritative) or
+        // there is no kernel drain edge at all: either way the sweep is unconditional by design
+        // (see graceful_shutdown_tree's own doc), so the forced failure must surface — proving
+        // the sweep WAS entered, the opposite of the branch above.
+        let err = result.expect_err("a non-authoritative mechanism must always run the sweep");
         assert!(
             !term_fault::kill_tree_armed(),
             "the sweep must have consumed the forced-failure seam"
         );
+        drop(armed); // already disarmed by the sweep above; this is a no-op, kept for symmetry
         assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
         let _ = child.kill_tree(); // cleanup: the forced failure means the real sweep never ran
         let _ = child.wait();
     }
 }
 
-// Regression test (#62 round-2 review): on the `MembersRemain` branch — a drain-observable
+// Regression test: on the `MembersRemain` branch — a drain-observable
 // mechanism whose tree does NOT fully drain within `grace` — `root_exited` must be freshly
 // computed by its own zero-duration probe of the root, not hardcoded `false`. Otherwise an
 // already-exited-but-unreaped root is stranded as a zombie when the subsequent hard sweep
 // also fails, because the best-effort reap below is gated on `root_exited`.
 //
-// Fixture: the root shell first ignores `SIGTERM` for itself (`trap '' TERM`), THEN
-// backgrounds `sleep 30` (which vastly outlives `grace`) and exits on its own immediately
-// after — a deterministic ordering, not a race against `grace` OR against the terminate
-// signal: `sleep 30` is forked (inheriting the already-installed ignore disposition
-// atomically, no window where it could still be killed) only after the trap is in effect, and
-// an ignored disposition survives `sleep`'s own exec (POSIX). A version of this fixture where
-// the descendant installs its OWN trap after being forked/exec'd instead would race the
-// terminate signal against that installation and was rejected during development. The
-// descendant keeps a drain-observable tree from fully draining within `grace`, forcing
-// `MembersRemain` specifically — the branch this fix touches. On a mechanism with no kernel
-// drain edge, this same fixture still exercises the pre-existing (unaffected-by-this-bug)
-// root-only watch, which already computed `root_exited` correctly — asserted separately below
+// Fixture: the root shell installs `trap '' TERM`, backgrounds `sleep 30` (which vastly
+// outlives `grace`, keeping the tree from fully draining and forcing `MembersRemain`
+// specifically), writes a single readiness byte, then exits on its own. The test blocks on
+// that byte before ever calling `graceful_shutdown_tree` — a genuine happens-before edge from a
+// real pipe event, not a sleep or a bet that the runner is fast: the root's own `trap`
+// installation has nothing else synchronizing it against `spawn()` returning, and the byte
+// cannot be written until both the trap and the background job are already in place.
+// On a mechanism with no kernel drain edge, this same fixture still exercises the pre-existing
+// root-only watch, which already computes `root_exited` correctly — asserted separately below
 // rather than skipped, per this crate's "never silently skip" testing convention.
 #[cfg(unix)]
 #[test]
 fn graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    use std::io::Read;
+
     let mut cmd = crate::Command::new();
-    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & exit 0"]);
+    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & echo r; exit 0"]);
+    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
     cmd.contain();
-    let child = cmd.spawn().expect("spawn");
+    let mut child = cmd.spawn().expect("spawn");
+    let mut readiness = [0u8; 1];
+    child
+        .stdout()
+        .expect("piped stdout")
+        .read_exact(&mut readiness)
+        .expect("readiness byte");
     let id = child.id();
     let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);
@@ -328,12 +341,64 @@ fn graceful_tree_members_remain_still_reaps_an_already_exited_root() {
         crate::identity::Existence::Gone,
         "an already-exited root must be best-effort reaped even when the sweep fails ({})",
         if drainable {
-            "MembersRemain branch — the #62 round-2 fix"
+            "MembersRemain branch"
         } else {
             "non-drain-observable fallback branch — pre-existing, unaffected behavior"
         }
     );
     // Cleanup: the forced sweep failure was a stub, so the SIGTERM-ignoring descendant is
+    // still alive — a real sweep now (the seam is already consumed) actually kills it.
+    let _ = child.kill_tree();
+}
+
+// Windows twin of `graceful_tree_members_remain_still_reaps_an_already_exited_root` above — see
+// its doc for the invariant under test; identical here, just reached via a job object instead
+// of cgroup/process-group. Fixture: `test_child::fixture_survives_group_signal` (see its own
+// doc) plays the Unix root shell's role — it spawns a `CREATE_NEW_PROCESS_GROUP` grandchild the
+// group `CTRL_BREAK` can never reach (forcing `MembersRemain` on the drain-observable job
+// object, exactly like the Unix fixture's backgrounded, TERM-immune `sleep`), writes a
+// readiness byte to its own stdout, and exits immediately on its own — leaving an unreaped root
+// by the time `graceful_shutdown_tree` runs, exactly like the Unix twin's own `exit 0`.
+#[cfg(windows)]
+#[test]
+fn windows_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    use std::io::Read;
+
+    let mut cmd = crate::Command::new();
+    cmd.executable(std::env::current_exe().expect("current_exe"))
+        .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
+    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ENV, "1");
+    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let mut readiness = [0u8; 1];
+    child
+        .stdout()
+        .expect("piped stdout")
+        .read_exact(&mut readiness)
+        .expect("readiness byte");
+    let id = child.id();
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let err = child
+        .graceful_shutdown_tree(Duration::from_secs(2))
+        .expect_err("the forced sweep failure must surface");
+    assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+    assert!(
+        !term_fault::kill_tree_armed(),
+        "the sweep must have consumed the forced-failure seam"
+    );
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
+        if drainable {
+            "MembersRemain branch"
+        } else {
+            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
+        }
+    );
+    // Cleanup: the forced sweep failure was a stub, so the group-signal-immune descendant is
     // still alive — a real sweep now (the seam is already consumed) actually kills it.
     let _ = child.kill_tree();
 }

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -286,6 +286,58 @@ fn graceful_tree_drained_skips_sweep_when_mechanism_allows() {
     }
 }
 
+// Regression test (#62 round-2 review): on the `MembersRemain` branch — a drain-observable
+// mechanism whose tree does NOT fully drain within `grace` — `root_exited` must be freshly
+// computed by its own zero-duration probe of the root, not hardcoded `false`. Otherwise an
+// already-exited-but-unreaped root is stranded as a zombie when the subsequent hard sweep
+// also fails, because the best-effort reap below is gated on `root_exited`.
+//
+// Fixture: the root shell first ignores `SIGTERM` for itself (`trap '' TERM`), THEN
+// backgrounds `sleep 30` (which vastly outlives `grace`) and exits on its own immediately
+// after — a deterministic ordering, not a race against `grace` OR against the terminate
+// signal: `sleep 30` is forked (inheriting the already-installed ignore disposition
+// atomically, no window where it could still be killed) only after the trap is in effect, and
+// an ignored disposition survives `sleep`'s own exec (POSIX). A version of this fixture where
+// the descendant installs its OWN trap after being forked/exec'd instead would race the
+// terminate signal against that installation and was rejected during development. The
+// descendant keeps a drain-observable tree from fully draining within `grace`, forcing
+// `MembersRemain` specifically — the branch this fix touches. On a mechanism with no kernel
+// drain edge, this same fixture still exercises the pre-existing (unaffected-by-this-bug)
+// root-only watch, which already computed `root_exited` correctly — asserted separately below
+// rather than skipped, per this crate's "never silently skip" testing convention.
+#[cfg(unix)]
+#[test]
+fn graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    let mut cmd = crate::Command::new();
+    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & exit 0"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let err = child
+        .graceful_shutdown_tree(Duration::from_secs(2))
+        .expect_err("the forced sweep failure must surface");
+    assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+    assert!(
+        !term_fault::kill_tree_armed(),
+        "the sweep must have consumed the forced-failure seam"
+    );
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
+        if drainable {
+            "MembersRemain branch — the #62 round-2 fix"
+        } else {
+            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
+        }
+    );
+    // Cleanup: the forced sweep failure was a stub, so the SIGTERM-ignoring descendant is
+    // still alive — a real sweep now (the seam is already consumed) actually kills it.
+    let _ = child.kill_tree();
+}
+
 // A NON-containment terminate_tree error (modelling NoConsole/Unsupported) must NOT be held
 // -- this is the pre-existing, still-documented "no signal sent, no grace waited, tree left
 // running" contract from #46, unrelated to #61, and this task's scoping must not silently

--- a/src/child/lifecycle.rs
+++ b/src/child/lifecycle.rs
@@ -36,4 +36,23 @@ impl Child {
     pub fn wait_deadline(&self, deadline: Instant) -> Result<Option<ExitStatus>, Error> {
         self.proc.wait_deadline(deadline).map_err(Error::Io)
     }
+
+    /// Block until every member of the contained tree has EXITED — not reaped; a status is
+    /// never collected by this call, only the root's own `wait`/`wait_timeout` does that.
+    /// Requires a mechanism with a real kernel drain edge (`Unsupported` otherwise — cgroup v2,
+    /// a Windows job object, and the macOS fd marker have one; `ProcessGroup`/`Session`/
+    /// `TreeWalk` and an uncontained or nested-`Delegated` child do not). Event-driven: no
+    /// interval is chosen internally anywhere in this call's path.
+    pub fn wait_tree(&self) -> Result<crate::containment::TreeDrain, Error> {
+        self.require_drainable()?;
+        self.attached.wait_drained(None)
+    }
+
+    /// Like [`wait_tree`](Child::wait_tree) but bounded by `timeout`. `TreeDrain::MembersRemain`
+    /// at expiry is not an error. A `timeout` so large it would overflow `Instant` is treated as
+    /// unbounded, matching [`wait_timeout`](Child::wait_timeout).
+    pub fn wait_tree_timeout(&self, timeout: Duration) -> Result<crate::containment::TreeDrain, Error> {
+        self.require_drainable()?;
+        self.attached.wait_drained(crate::wait::deadline_from(timeout))
+    }
 }

--- a/src/child/lifecycle.rs
+++ b/src/child/lifecycle.rs
@@ -56,3 +56,7 @@ impl Child {
         self.attached.wait_drained(crate::wait::deadline_from(timeout))
     }
 }
+
+#[cfg(test)]
+#[path = "lifecycle_tests.rs"]
+mod lifecycle_tests;

--- a/src/child/lifecycle_tests.rs
+++ b/src/child/lifecycle_tests.rs
@@ -1,9 +1,20 @@
-//! Unit tests for the public `Child::wait_tree`/`wait_tree_timeout` (`#62` round-2 review,
-//! item 4 — previously zero coverage). Every test branches on
+//! Unit tests for the public `Child::wait_tree`/`wait_tree_timeout`. Every test branches on
 //! `Containment::can_observe_drain()` and asserts a real, non-trivial outcome on BOTH sides
 //! rather than skipping either — this crate's "never silently skip" testing convention.
 
 use std::time::Duration;
+
+/// The `TreeDrain` variant a fully-drained tree reports on `containment`'s mechanism:
+/// `AllMembersExited` everywhere authoritative (cgroup v2, Windows job object), but
+/// `AllMarkersClosed` on macOS's advisory fd marker — see `TreeDrain`'s own doc for why the two
+/// are not interchangeable. Centralized here so every test below asserts the SAME real,
+/// mechanism-correct verdict rather than assuming the authoritative one everywhere.
+fn expected_drained_verdict(containment: crate::containment::Containment) -> crate::containment::TreeDrain {
+    match containment {
+        crate::containment::Containment::FdMarker => crate::containment::TreeDrain::AllMarkersClosed,
+        _ => crate::containment::TreeDrain::AllMembersExited,
+    }
+}
 
 /// A quick, self-terminating contained child: the drain edge (when the mechanism has one)
 /// fires almost immediately, so an UNBOUNDED `wait_tree()` call below is safe — it is a real
@@ -30,17 +41,19 @@ fn long_lived_contained_child() -> crate::Child {
 }
 
 /// Drained case: on a drain-observable mechanism, an unbounded `wait_tree()` against a tree
-/// that fully exits on its own reports `AllMembersExited`. On a mechanism with no kernel drain
-/// edge, the SAME call must fail `Unsupported` instead — both are real, exercised assertions.
+/// that fully exits on its own reports the mechanism-correct drained verdict
+/// (`expected_drained_verdict`). On a mechanism with no kernel drain edge, the SAME call must
+/// fail `Unsupported` instead — both are real, exercised assertions.
 #[test]
-fn wait_tree_reports_all_members_exited_when_the_tree_drains() {
+fn wait_tree_reports_the_drained_verdict_when_the_tree_drains() {
     let child = quick_contained_child();
-    let drainable = child.containment().can_observe_drain();
+    let containment = child.containment();
+    let drainable = containment.can_observe_drain();
     let result = child.wait_tree();
     if drainable {
         assert_eq!(
-            result.expect("a fully-exited tree must report AllMembersExited"),
-            crate::containment::TreeDrain::AllMembersExited
+            result.expect("a fully-exited tree must report a drained verdict"),
+            expected_drained_verdict(containment)
         );
     } else {
         let err = result.expect_err("a non-drainable mechanism must refuse wait_tree");
@@ -71,6 +84,61 @@ fn wait_tree_timeout_reports_members_remain_before_the_deadline() {
     let _ = child.wait();
 }
 
+/// `Duration::ZERO` against a still-alive tree: a one-shot, non-blocking probe (see
+/// `crate::wait::deadline_from`/`remaining`'s own docs) — `MembersRemain`, not an error, and
+/// returned without ever entering the backend's blocking wait (every `wait_drained`
+/// implementation checks `remaining == Duration::ZERO` before its first blocking syscall).
+#[test]
+fn wait_tree_timeout_zero_reports_members_remain_on_a_live_tree() {
+    let child = long_lived_contained_child();
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree_timeout(Duration::ZERO);
+    if drainable {
+        assert_eq!(
+            result.expect("a ZERO probe against a live tree must not be an error"),
+            crate::containment::TreeDrain::MembersRemain
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree_timeout");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    let _ = child.kill_tree();
+    let _ = child.wait();
+}
+
+/// `Duration::ZERO` against an ALREADY-drained tree: the one-shot probe must still observe and
+/// report the real, mechanism-correct drained verdict — not `MembersRemain` by default, and not
+/// blocked on by the deadline being in the past (see `marker_eof::block_until_drained`'s own doc
+/// on why a past deadline still performs exactly one check). The unbounded `wait_tree()` call
+/// first is the genuine happens-before edge that the tree has fully drained before the ZERO
+/// probe below ever runs.
+#[test]
+fn wait_tree_timeout_zero_reports_the_drained_verdict_after_the_tree_has_already_drained() {
+    let child = quick_contained_child();
+    let containment = child.containment();
+    let drainable = containment.can_observe_drain();
+    let first = child.wait_tree();
+    if drainable {
+        first.expect("a fully-exited tree must report a drained verdict");
+        assert_eq!(
+            child
+                .wait_tree_timeout(Duration::ZERO)
+                .expect("a ZERO probe against an already-drained tree must not be an error"),
+            expected_drained_verdict(containment),
+            "a ZERO probe must observe the SAME drained state an unbounded wait already found, \
+             not report MembersRemain just because the deadline is already past"
+        );
+    } else {
+        first.expect_err("a non-drainable mechanism must refuse wait_tree");
+        let err = child.wait_tree_timeout(Duration::ZERO);
+        assert!(
+            matches!(err, Err(crate::error::Error::Unsupported { .. })),
+            "got {err:?}"
+        );
+    }
+    let _ = child.wait();
+}
+
 /// `Unsupported` on a non-drainable mechanism — explicitly REQUESTING `ContainMode::TreeWalk`,
 /// the one mode with no kernel drain edge on every platform where it is actually honored as
 /// requested (`Attached::TreeWalk` carries no `#[cfg]` gate reserving it to one OS, unlike the
@@ -92,12 +160,13 @@ fn wait_tree_is_unsupported_on_a_non_drainable_mechanism() {
     cmd.args(["cmd", "/C", "exit 0"]);
     cmd.contain_with(crate::ContainMode::TreeWalk);
     let treewalk_child = cmd.spawn().expect("spawn");
-    let drainable = treewalk_child.containment().can_observe_drain();
+    let containment = treewalk_child.containment();
+    let drainable = containment.can_observe_drain();
     let err = treewalk_child.wait_tree_timeout(Duration::from_millis(200));
     if drainable {
         assert_eq!(
             err.expect("macOS promotes an explicit TreeWalk request to the drainable fd marker"),
-            crate::containment::TreeDrain::AllMembersExited,
+            expected_drained_verdict(containment),
             "a quick-exiting tree must still be observed as drained through the promoted mechanism"
         );
     } else {

--- a/src/child/lifecycle_tests.rs
+++ b/src/child/lifecycle_tests.rs
@@ -1,0 +1,112 @@
+//! Unit tests for the public `Child::wait_tree`/`wait_tree_timeout` (`#62` round-2 review,
+//! item 4 — previously zero coverage). Every test branches on
+//! `Containment::can_observe_drain()` and asserts a real, non-trivial outcome on BOTH sides
+//! rather than skipping either — this crate's "never silently skip" testing convention.
+
+use std::time::Duration;
+
+/// A quick, self-terminating contained child: the drain edge (when the mechanism has one)
+/// fires almost immediately, so an UNBOUNDED `wait_tree()` call below is safe — it is a real
+/// blocking wait on a genuinely-terminating event, not an indefinite one.
+fn quick_contained_child() -> crate::Child {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["true"]);
+    #[cfg(windows)]
+    cmd.args(["cmd", "/C", "exit 0"]);
+    cmd.contain();
+    cmd.spawn().expect("spawn")
+}
+
+/// A long-lived contained child, for the deadline-not-met case.
+fn long_lived_contained_child() -> crate::Child {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    cmd.spawn().expect("spawn")
+}
+
+/// Drained case: on a drain-observable mechanism, an unbounded `wait_tree()` against a tree
+/// that fully exits on its own reports `AllMembersExited`. On a mechanism with no kernel drain
+/// edge, the SAME call must fail `Unsupported` instead — both are real, exercised assertions.
+#[test]
+fn wait_tree_reports_all_members_exited_when_the_tree_drains() {
+    let child = quick_contained_child();
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree();
+    if drainable {
+        assert_eq!(
+            result.expect("a fully-exited tree must report AllMembersExited"),
+            crate::containment::TreeDrain::AllMembersExited
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    // wait_tree never reaps — the root's exit still needs collecting either way.
+    let _ = child.wait();
+}
+
+/// Deadline-not-met case: on a drain-observable mechanism, `wait_tree_timeout` against a tree
+/// that is still alive at expiry reports `MembersRemain` — NOT an error, per its own doc. On a
+/// non-drainable mechanism the same call must still fail `Unsupported`.
+#[test]
+fn wait_tree_timeout_reports_members_remain_before_the_deadline() {
+    let child = long_lived_contained_child();
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree_timeout(Duration::from_millis(200));
+    if drainable {
+        assert_eq!(
+            result.expect("an unmet deadline on a live tree must not be an error"),
+            crate::containment::TreeDrain::MembersRemain
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree_timeout");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    let _ = child.kill_tree();
+    let _ = child.wait();
+}
+
+/// `Unsupported` on a non-drainable mechanism — explicitly REQUESTING `ContainMode::TreeWalk`,
+/// the one mode with no kernel drain edge on every platform where it is actually honored as
+/// requested (`Attached::TreeWalk` carries no `#[cfg]` gate reserving it to one OS, unlike the
+/// per-OS drainable variants). **Not** portable to a single unconditional assertion, though:
+/// on macOS the fd marker is installed for every contained root regardless of the requested
+/// mode (`dispatch.rs`'s `attach()`, macOS branch — it is what survives `setsid`/reparenting/
+/// `exec` that a mode-specific mechanism does not), so a macOS `TreeWalk` request still comes
+/// back `Containment::FdMarker`, which IS drainable. Branches on the actual reported
+/// `can_observe_drain()` like the two tests above, rather than assuming a platform from the
+/// requested mode, so this asserts something real and non-tautological on every platform: the
+/// `Unsupported` refusal where `TreeWalk` is honored as non-drainable, and — on macOS — that
+/// an explicit `TreeWalk` request still drains correctly through the marker it was promoted to.
+#[test]
+fn wait_tree_is_unsupported_on_a_non_drainable_mechanism() {
+    let mut cmd = crate::Command::new();
+    #[cfg(unix)]
+    cmd.args(["true"]);
+    #[cfg(windows)]
+    cmd.args(["cmd", "/C", "exit 0"]);
+    cmd.contain_with(crate::ContainMode::TreeWalk);
+    let treewalk_child = cmd.spawn().expect("spawn");
+    let drainable = treewalk_child.containment().can_observe_drain();
+    let err = treewalk_child.wait_tree_timeout(Duration::from_millis(200));
+    if drainable {
+        assert_eq!(
+            err.expect("macOS promotes an explicit TreeWalk request to the drainable fd marker"),
+            crate::containment::TreeDrain::AllMembersExited,
+            "a quick-exiting tree must still be observed as drained through the promoted mechanism"
+        );
+    } else {
+        let err = err.expect_err("TreeWalk, honored as requested, has no kernel drain edge");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+        let err2 = treewalk_child
+            .wait_tree()
+            .expect_err("TreeWalk, honored as requested, has no kernel drain edge");
+        assert!(matches!(err2, crate::error::Error::Unsupported { .. }), "got {err2:?}");
+    }
+    let _ = treewalk_child.wait();
+}

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -102,12 +102,44 @@ impl Containment {
 
 /// Whether every member of the contained tree has exited (not reaped — a descriptor/kernel-state
 /// change, never a collected zombie; a caller wanting a status still waits on the root).
+///
+/// `AllMembersExited` and `AllMarkersClosed` are NOT interchangeable evidence, despite both
+/// meaning "nothing more to wait for from this channel". [`Containment::CgroupV2`]'s
+/// `cgroup.events` `populated` field and [`Containment::JobObject`]'s job membership count are
+/// KERNEL-OWNED: a live process cannot leave either set without exiting, so `AllMembersExited`
+/// from either is positive, sufficient proof the whole tree is gone — safe to skip a hard sweep
+/// on. [`Containment::FdMarker`]'s pipe EOF is ADVISORY, not membership-owning: a live process
+/// can leave the marker's holder set early by closing its own copy of the inherited descriptor
+/// (deliberately, or as a side effect of something else it does) while remaining alive —
+/// undetectable by this edge alone. Treat `AllMarkersClosed` as "no more evidence of survivors
+/// from this channel", never as proof no survivor exists; in particular, never use it alone to
+/// skip a hard sweep.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TreeDrain {
-    /// Every member of the tree has exited. Statuses have NOT been collected.
+    /// Every member of the tree has exited, confirmed by a kernel-owned membership count a live
+    /// process cannot leave without exiting. Statuses have NOT been collected.
     AllMembersExited,
+    /// The macOS fd marker's last held copy of the marker descriptor closed. Advisory, not
+    /// authoritative — see this type's own doc.
+    AllMarkersClosed,
     /// At least one member was still running at the deadline.
     MembersRemain,
+}
+
+impl TreeDrain {
+    /// Whether this verdict is, on its own with no corroboration, positive kernel-confirmed
+    /// proof the whole tree exited — strong enough that a hard sweep afterward would be pure
+    /// overhead and can be skipped. Only `AllMembersExited` qualifies; see this type's own doc
+    /// for why `AllMarkersClosed` does not. Named for the decision, not the mechanism, and
+    /// matched exhaustively (no wildcard) so adding a future variant is a compile error HERE —
+    /// the one place this decision is made — rather than a silent default at every call site
+    /// that would otherwise need its own copy of this match.
+    pub(crate) fn permits_skipping_sweep(&self) -> bool {
+        match self {
+            TreeDrain::AllMembersExited => true,
+            TreeDrain::AllMarkersClosed | TreeDrain::MembersRemain => false,
+        }
+    }
 }
 
 /// Guard for the `_tree` operations, shared by the sync and async `Child`: they act on the

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -83,6 +83,31 @@ impl Containment {
             Containment::None | Containment::Delegated => false,
         }
     }
+
+    /// Whether this handle can observe the whole tree's exit via a real kernel edge
+    /// (`wait_tree`/`wait_tree_timeout` act rather than returning `Unsupported`).
+    ///
+    /// A strict subset of [`can_teardown`](Self::can_teardown): `ProcessGroup`/`Session`
+    /// (`killpg`-based) and `TreeWalk` (identity re-enumeration) can tear a tree down but
+    /// expose no single kernel object whose state says "every member has exited" — only
+    /// `CgroupV2` (`cgroup.events`'s `populated` key), `JobObject` (the job's completion-port
+    /// process-count edge) and `FdMarker` (the marker pipe's EOF) do.
+    pub fn can_observe_drain(&self) -> bool {
+        matches!(
+            self,
+            Containment::CgroupV2 | Containment::JobObject | Containment::FdMarker
+        )
+    }
+}
+
+/// Whether every member of the contained tree has exited (not reaped — a descriptor/kernel-state
+/// change, never a collected zombie; a caller wanting a status still waits on the root).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeDrain {
+    /// Every member of the tree has exited. Statuses have NOT been collected.
+    AllMembersExited,
+    /// At least one member was still running at the deadline.
+    MembersRemain,
 }
 
 /// Guard for the `_tree` operations, shared by the sync and async `Child`: they act on the
@@ -102,6 +127,31 @@ pub(crate) fn require_contained(containment: Containment, attached: &Attached) -
                      or a nested member of an ancestor's containment group). Use kill() for a \
                      lone process, or tear down the tree via the outermost .contain()ed handle."
                 .into(),
+        });
+    }
+    Ok(())
+}
+
+/// Guard for `wait_tree`/`wait_tree_timeout`, shared by the sync and async `Child`: only a
+/// mechanism with a real kernel drain edge ([`Containment::can_observe_drain`]) can answer
+/// "has the whole tree exited" without polling — everything else (an uncontained child, a
+/// nested `Delegated` member, or a teardown-only mechanism like `ProcessGroup`/`TreeWalk`)
+/// returns `Unsupported`.
+pub(crate) fn require_drainable(containment: Containment, attached: &Attached) -> Result<(), crate::error::Error> {
+    debug_assert_eq!(
+        containment.can_observe_drain(),
+        attached.can_observe_drain(),
+        "Containment/Attached drain-observability diverged"
+    );
+    if !attached.can_observe_drain() {
+        return Err(crate::error::Error::Unsupported {
+            op: "wait for the contained tree to drain (wait_tree / wait_tree_timeout)".into(),
+            platform: std::env::consts::OS,
+            detail: format!(
+                "this child's containment mechanism ({containment}) exposes no kernel edge for \
+                 tree drain — only cgroup v2, a Windows job object, and the macOS fd marker do. \
+                 Use kill_tree()/terminate_tree() for teardown, or wait() to watch the root alone."
+            ),
         });
     }
     Ok(())

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -99,6 +99,21 @@ use nix::sys::signal::{kill, Signal};
 #[cfg(target_os = "linux")]
 use nix::unistd::Pid;
 
+/// Whether `e` is the kernel's proof that this leaf's `cgroup.events` node is already gone —
+/// either because the whole path was already removed (`ENOENT`, on a fresh `open` through the
+/// now-unlinked leaf directory) or because THIS fd was opened before removal and the
+/// underlying kernfs node has since been deactivated (`ENODEV`, on `seek`/`read` through an
+/// already-open fd). `rmdir` on a cgroup v2 leaf — whether `Drop`'s own retry or an external
+/// cgroup manager's cleanup of an empty leaf — succeeds ONLY once `populated` has already read
+/// 0 (see `CgroupLeaf::wait_drained`'s doc); observing the leaf's removal is therefore always
+/// proof every member had already exited, never proof of anything else, so no other errno is
+/// folded in here (a genuine mechanism failure — `EACCES`, `EIO`, ...— must still surface as
+/// `Error::Io`, not be silently reinterpreted as a drain).
+#[cfg(target_os = "linux")]
+pub(crate) fn removed_after_drain(e: &io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::ENODEV) | Some(libc::ENOENT))
+}
+
 /// A live leaf sub-cgroup created for a single spawned process tree.
 ///
 /// The `pre_exec` closure writes `"0"` to `procs_fd` to place the forked
@@ -167,6 +182,16 @@ impl CgroupLeaf {
     /// interval is chosen anywhere in this path: every round blocks in one `poll(2)` call for
     /// exactly the caller's own remaining time, and returns as soon as either the kernel
     /// reports a transition or the deadline is reached.
+    ///
+    /// Leaf-removal race: `rmdir` on this leaf (`Drop`'s own retry, or an external cgroup
+    /// manager cleaning up an empty leaf — either succeeds only once `populated` has already
+    /// read 0) can land at any point after the last member exits, including between this
+    /// call's own `poll` waking on the 1→0 transition and its very next read. Once that
+    /// happens, `open`/`seek`/`read` on this leaf's `cgroup.events` fail (`ENOENT` for a fresh
+    /// `open` through the now-unlinked directory; `ENODEV` for a syscall through an fd that was
+    /// opened before removal, once the kernel deactivates the underlying kernfs node) — proof
+    /// the leaf is gone, which is itself proof every member had already exited (removal can
+    /// never precede full drain), not a failure. See [`removed_after_drain`].
     pub(crate) fn wait_drained(
         &self,
         deadline: Option<Option<std::time::Instant>>,
@@ -178,12 +203,28 @@ impl CgroupLeaf {
         use crate::containment::TreeDrain;
         use crate::error::Error;
 
-        let mut file = File::open(self.events_path()).map_err(Error::Io)?;
+        let mut file = match File::open(self.events_path()) {
+            Ok(f) => f,
+            Err(e) if removed_after_drain(&e) => return Ok(TreeDrain::AllMembersExited),
+            Err(e) => return Err(Error::Io(e)),
+        };
         let mut buf = String::new();
         loop {
             buf.clear();
-            file.seek(SeekFrom::Start(0)).map_err(Error::Io)?;
-            file.read_to_string(&mut buf).map_err(Error::Io)?;
+            if let Err(e) = file.seek(SeekFrom::Start(0)) {
+                return if removed_after_drain(&e) {
+                    Ok(TreeDrain::AllMembersExited)
+                } else {
+                    Err(Error::Io(e))
+                };
+            }
+            if let Err(e) = file.read_to_string(&mut buf) {
+                return if removed_after_drain(&e) {
+                    Ok(TreeDrain::AllMembersExited)
+                } else {
+                    Err(Error::Io(e))
+                };
+            }
             match parse_populated(&buf) {
                 Some(false) => return Ok(TreeDrain::AllMembersExited),
                 Some(true) => {}

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -58,6 +58,24 @@ pub(crate) fn cgroup_procs_contains(contents: &str, pid: u32) -> bool {
     false
 }
 
+/// Parse the `populated` field out of the contents of a cgroup v2 `cgroup.events` file
+/// (`populated 0`/`populated 1`, one `key value` pair per line, order not guaranteed).
+/// `None` means the file had no `populated` line, or an unrecognized value — the caller
+/// must treat this as "could not be assessed", never silently default to either state.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn parse_populated(contents: &str) -> Option<bool> {
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("populated ") {
+            return match rest.trim() {
+                "0" => Some(false),
+                "1" => Some(true),
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
 // Everything below is Linux-only. =====
 
 #[cfg(target_os = "linux")]
@@ -112,6 +130,12 @@ impl CgroupLeaf {
         self.procs_fd
     }
 
+    /// The leaf's `cgroup.events` path — the async death-watch's own edge to poll, since
+    /// `wait_drained`'s `poll(2)` loop is not reusable from a reactor-native async context.
+    pub(crate) fn events_path(&self) -> PathBuf {
+        self.leaf_path.join("cgroup.events")
+    }
+
     /// Returns `true` when `pid` is listed in `cgroup.procs` of this leaf.
     /// Used post-spawn (parent side) to confirm placement succeeded.
     pub(crate) fn contains_pid(&self, pid: u32) -> bool {
@@ -125,6 +149,65 @@ impl CgroupLeaf {
     /// Best-effort: already-empty leaves are silently fine.
     pub(crate) fn hard_kill(&self) {
         let _ = fs::write(self.leaf_path.join("cgroup.kill"), b"1");
+    }
+
+    /// Block until every process in the leaf has EXITED (not reaped), observed via
+    /// `cgroup.events`'s `populated` key — the kernel flips it 1→0 exactly when the leaf's
+    /// last task exits, fork-proof (no cooperation from the tree, no re-enumeration race).
+    ///
+    /// Read-before-arm: `populated` is checked BEFORE every `poll`, not only after — a
+    /// transition that already happened (leaf drained between a caller's previous check and
+    /// this call) must be observed on the read, not require a fresh kernel edge that will
+    /// never fire again. `POLLPRI` fires on every transition (both 1→0 and 0→1), so an
+    /// intervening 0→1 (a leaf that reused-then-repopulated between reads) is also picked up
+    /// by looping back to re-read rather than trusting readiness to imply the value dropped.
+    ///
+    /// `deadline` follows the crate's watch convention (see [`crate::wait::remaining`]). No
+    /// interval is chosen anywhere in this path: every round blocks in one `poll(2)` call for
+    /// exactly the caller's own remaining time, and returns as soon as either the kernel
+    /// reports a transition or the deadline is reached.
+    pub(crate) fn wait_drained(
+        &self,
+        deadline: Option<Option<std::time::Instant>>,
+    ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        use rustix::event::{poll, PollFd, PollFlags};
+
+        use crate::containment::TreeDrain;
+        use crate::error::Error;
+
+        let mut file = File::open(self.leaf_path.join("cgroup.events")).map_err(Error::Io)?;
+        let mut buf = String::new();
+        loop {
+            buf.clear();
+            file.seek(SeekFrom::Start(0)).map_err(Error::Io)?;
+            file.read_to_string(&mut buf).map_err(Error::Io)?;
+            match parse_populated(&buf) {
+                Some(false) => return Ok(TreeDrain::AllMembersExited),
+                Some(true) => {}
+                None => {
+                    return Err(Error::Io(io::Error::other(
+                        "cgroup.events has no 'populated' field — unexpected kernel format",
+                    )))
+                }
+            }
+            let remaining = crate::wait::remaining(deadline);
+            if remaining == Some(std::time::Duration::ZERO) {
+                return Ok(TreeDrain::MembersRemain);
+            }
+            let ts = remaining.map(|d| rustix::event::Timespec {
+                tv_sec: d.as_secs().min(i64::MAX as u64) as i64,
+                tv_nsec: d.subsec_nanos() as _,
+            });
+            let mut fds = [PollFd::new(&file, PollFlags::PRI)];
+            match poll(&mut fds, ts.as_ref()) {
+                Ok(0) => return Ok(TreeDrain::MembersRemain), // genuinely timed out
+                Ok(_) => continue,                            // a transition fired — re-read
+                Err(rustix::io::Errno::INTR) => continue,
+                Err(e) => return Err(Error::Io(io::Error::from(e))),
+            }
+        }
     }
 
     /// SIGTERM every pid currently listed in `cgroup.procs`.

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -130,8 +130,9 @@ impl CgroupLeaf {
         self.procs_fd
     }
 
-    /// The leaf's `cgroup.events` path — the async death-watch's own edge to poll, since
-    /// `wait_drained`'s `poll(2)` loop is not reusable from a reactor-native async context.
+    /// The leaf's `cgroup.events` path — the drain edge. Both watches open it for themselves:
+    /// the sync one polls it directly, while the reactor-native async one cannot reuse that
+    /// `poll(2)` loop and registers the descriptor instead.
     pub(crate) fn events_path(&self) -> PathBuf {
         self.leaf_path.join("cgroup.events")
     }
@@ -177,7 +178,7 @@ impl CgroupLeaf {
         use crate::containment::TreeDrain;
         use crate::error::Error;
 
-        let mut file = File::open(self.leaf_path.join("cgroup.events")).map_err(Error::Io)?;
+        let mut file = File::open(self.events_path()).map_err(Error::Io)?;
         let mut buf = String::new();
         loop {
             buf.clear();

--- a/src/containment/cgroup.rs
+++ b/src/containment/cgroup.rs
@@ -114,6 +114,40 @@ pub(crate) fn removed_after_drain(e: &io::Error) -> bool {
     matches!(e.raw_os_error(), Some(libc::ENODEV) | Some(libc::ENOENT))
 }
 
+/// Seek to the start of `file` (a `cgroup.events` handle) and read its current `populated`
+/// value. Shared verbatim by `CgroupLeaf::wait_drained`'s sync loop and its tokio twin,
+/// `cgroup_wait_tree_drained` — the only difference between the two callers is how each awaits
+/// the next readiness edge, not how either reads or classifies the file.
+///
+/// A leaf removed after every member has exited (see [`removed_after_drain`]) is reported as
+/// `Ok(false)`: the leaf's own removal is itself proof of a full drain, indistinguishable in
+/// meaning from an explicit `populated 0`.
+#[cfg(target_os = "linux")]
+pub(crate) fn read_populated(file: &mut File, buf: &mut String) -> Result<bool, crate::error::Error> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    buf.clear();
+    if let Err(e) = file.seek(SeekFrom::Start(0)) {
+        return if removed_after_drain(&e) {
+            Ok(false)
+        } else {
+            Err(crate::error::Error::Io(e))
+        };
+    }
+    if let Err(e) = file.read_to_string(buf) {
+        return if removed_after_drain(&e) {
+            Ok(false)
+        } else {
+            Err(crate::error::Error::Io(e))
+        };
+    }
+    parse_populated(buf).ok_or_else(|| {
+        crate::error::Error::Io(io::Error::other(
+            "cgroup.events has no 'populated' field — unexpected kernel format",
+        ))
+    })
+}
+
 /// A live leaf sub-cgroup created for a single spawned process tree.
 ///
 /// The `pre_exec` closure writes `"0"` to `procs_fd` to place the forked
@@ -196,8 +230,6 @@ impl CgroupLeaf {
         &self,
         deadline: Option<Option<std::time::Instant>>,
     ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
-        use std::io::{Read, Seek, SeekFrom};
-
         use rustix::event::{poll, PollFd, PollFlags};
 
         use crate::containment::TreeDrain;
@@ -210,29 +242,8 @@ impl CgroupLeaf {
         };
         let mut buf = String::new();
         loop {
-            buf.clear();
-            if let Err(e) = file.seek(SeekFrom::Start(0)) {
-                return if removed_after_drain(&e) {
-                    Ok(TreeDrain::AllMembersExited)
-                } else {
-                    Err(Error::Io(e))
-                };
-            }
-            if let Err(e) = file.read_to_string(&mut buf) {
-                return if removed_after_drain(&e) {
-                    Ok(TreeDrain::AllMembersExited)
-                } else {
-                    Err(Error::Io(e))
-                };
-            }
-            match parse_populated(&buf) {
-                Some(false) => return Ok(TreeDrain::AllMembersExited),
-                Some(true) => {}
-                None => {
-                    return Err(Error::Io(io::Error::other(
-                        "cgroup.events has no 'populated' field — unexpected kernel format",
-                    )))
-                }
+            if !read_populated(&mut file, &mut buf)? {
+                return Ok(TreeDrain::AllMembersExited);
             }
             let remaining = crate::wait::remaining(deadline);
             if remaining == Some(std::time::Duration::ZERO) {

--- a/src/containment/cgroup_tests.rs
+++ b/src/containment/cgroup_tests.rs
@@ -169,3 +169,39 @@ fn populated_garbage_value_returns_none() {
 fn populated_no_trailing_newline() {
     assert_eq!(parse_populated("frozen 0\npopulated 0"), Some(false));
 }
+
+// removed_after_drain tests -----
+// Linux-only: the function itself is `#[cfg(target_os = "linux")]` (it interprets raw kernel
+// errno values that only mean anything against a real cgroupfs).
+
+/// `ENODEV` — a syscall through an fd opened before the leaf was removed, once the kernel
+/// deactivates the underlying kernfs node — is proof of drain.
+#[cfg(target_os = "linux")]
+#[test]
+fn enodev_is_removed_after_drain() {
+    let e = std::io::Error::from_raw_os_error(libc::ENODEV);
+    assert!(super::removed_after_drain(&e));
+}
+
+/// `ENOENT` — a fresh `open` through the now-unlinked leaf directory — is proof of drain too.
+#[cfg(target_os = "linux")]
+#[test]
+fn enoent_is_removed_after_drain() {
+    let e = std::io::Error::from_raw_os_error(libc::ENOENT);
+    assert!(super::removed_after_drain(&e));
+}
+
+/// Every other errno is a genuine failure, not proof of anything — must NOT be folded into a
+/// guessed drain verdict. `EACCES` (permission denied) and `EIO` (real device/backing-store
+/// failure) are both plausible `cgroup.events` failures unrelated to removal.
+#[cfg(target_os = "linux")]
+#[test]
+fn unrelated_errnos_are_not_removed_after_drain() {
+    for errno in [libc::EACCES, libc::EIO, libc::EBUSY, libc::EPERM] {
+        let e = std::io::Error::from_raw_os_error(errno);
+        assert!(
+            !super::removed_after_drain(&e),
+            "errno {errno} must not be classified as proof of drain"
+        );
+    }
+}

--- a/src/containment/cgroup_tests.rs
+++ b/src/containment/cgroup_tests.rs
@@ -205,3 +205,95 @@ fn unrelated_errnos_are_not_removed_after_drain() {
         );
     }
 }
+
+// CgroupLeaf::wait_drained real-mechanism test -----
+// Linux + cgroup-v2 only, and only when CI provisions a delegated leaf (COSCA_TEST_CGROUP=1) —
+// the same gating convention `tests/spawn_io.rs`'s `linux_cgroup_v2_*` tests already use: a true
+// no-op without the marker, but a loud panic (never a silent pass) if the marker is set and no
+// usable delegated cgroup v2 leaf actually exists.
+
+/// Two real, simultaneously live processes placed directly in the same leaf via the crate's own
+/// `place_self_in_cgroup_pre_exec` — not a synthetic membership list — exercising `wait_drained`'s
+/// full mechanism: the read-before-arm check, the `poll(2)` block-then-timeout path (a bounded
+/// deadline, not `Duration::ZERO`, so the call actually reaches `poll`), and the real kernel
+/// `populated` 1→0 transition once both members are gone.
+#[cfg(target_os = "linux")]
+#[test]
+fn cgroup_wait_drained_tracks_two_real_members_through_exit() {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    use crate::containment::TreeDrain;
+
+    if std::env::var_os("COSCA_TEST_CGROUP").is_none() {
+        // Unprovisioned: not a CI-cgroup environment — true no-op, never a false "ok".
+        return;
+    }
+    let leaf = super::try_create_leaf().expect(
+        "COSCA_TEST_CGROUP is set but no usable delegated cgroup v2 leaf could be created — is \
+         this process running inside a writable, delegated cgroup v2 slice with cgroup.kill \
+         support (kernel >= 5.14)?",
+    );
+
+    let spawn_member = |leaf: &super::CgroupLeaf| -> std::process::Child {
+        let procs_fd = leaf.procs_fd();
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30").stdout(Stdio::null()).stderr(Stdio::null());
+        // SAFETY: `Command::pre_exec` runs this closure only between `fork` and `exec` in the
+        // child; `procs_fd` is a valid, open, writable fd owned by `leaf` for the parent's whole
+        // lifetime (fork gives the child its own fd-table entry pointing at the same underlying
+        // open file description, and `place_self_in_cgroup_pre_exec` closes only that child-side
+        // copy) — exactly its own documented contract. `leaf` outlives every member spawned
+        // through it in this test.
+        unsafe {
+            cmd.pre_exec(move || super::place_self_in_cgroup_pre_exec(procs_fd));
+        }
+        cmd.spawn().expect("spawn a real long-lived cgroup leaf member")
+    };
+
+    let mut a = spawn_member(&leaf);
+    let mut b = spawn_member(&leaf);
+
+    // A real bounded wait with both members alive: must report MembersRemain. The 250ms bound
+    // is not a synchronization guess — it is the deadline `wait_drained` itself blocks on via a
+    // real `poll(2)` call (never expiring early, since neither member exits during it), so this
+    // doubles as the settling time for the two `pre_exec` writes above before the membership
+    // checks below.
+    let bounded = || Some(Some(Instant::now() + Duration::from_millis(250)));
+    assert_eq!(
+        leaf.wait_drained(bounded())
+            .expect("wait_drained with two live members"),
+        TreeDrain::MembersRemain,
+        "both members are alive; must report MembersRemain"
+    );
+    assert!(
+        leaf.contains_pid(a.id()),
+        "member a must actually be placed in the leaf"
+    );
+    assert!(
+        leaf.contains_pid(b.id()),
+        "member b must actually be placed in the leaf"
+    );
+
+    // One survivor: `populated` never flips (still nonzero), so the verdict must not change.
+    a.kill().expect("kill member a");
+    a.wait().expect("reap member a");
+    assert_eq!(
+        leaf.wait_drained(bounded()).expect("wait_drained with one live member"),
+        TreeDrain::MembersRemain,
+        "one member is still alive; must still report MembersRemain"
+    );
+
+    // Both gone: an UNBOUNDED wait_drained blocks on the real kernel `populated` 1→0 edge, not a
+    // chosen interval — the "external event that might never happen" case the crate's no-sleep-
+    // sync rule allows a real wait for. A bug here hangs the test, surfaced by the CI job's own
+    // timeout, not a duration this test invented.
+    b.kill().expect("kill member b");
+    b.wait().expect("reap member b");
+    assert_eq!(
+        leaf.wait_drained(None).expect("wait_drained once both are gone"),
+        TreeDrain::AllMembersExited,
+        "both members exited; must report AllMembersExited"
+    );
+}

--- a/src/containment/cgroup_tests.rs
+++ b/src/containment/cgroup_tests.rs
@@ -1,7 +1,7 @@
 // Pure-parser tests for cgroup v2 path detection and cgroup.procs membership.
 // These run on any host (including Windows) with synthetic inputs — no filesystem access.
 
-use super::{cgroup_procs_contains, parse_v2_relative_path};
+use super::{cgroup_procs_contains, parse_populated, parse_v2_relative_path};
 
 // parse_v2_relative_path tests =====
 
@@ -124,4 +124,48 @@ fn procs_trailing_newline() {
 #[test]
 fn procs_whitespace_trimmed() {
     assert!(cgroup_procs_contains("  99  \n", 99));
+}
+
+// parse_populated tests =====
+
+/// The real kernel format: `populated 0\nfrozen 0\n`.
+#[test]
+fn populated_zero_means_drained() {
+    assert_eq!(parse_populated("populated 0\nfrozen 0\n"), Some(false));
+}
+
+/// `populated 1` means at least one process remains.
+#[test]
+fn populated_one_means_members_remain() {
+    assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));
+}
+
+/// Field order is not guaranteed by the kernel doc — `populated` may not be first.
+#[test]
+fn populated_field_not_first_line() {
+    assert_eq!(parse_populated("frozen 0\npopulated 1\n"), Some(true));
+}
+
+/// No `populated` line at all (wrong file / malformed) — must not silently default.
+#[test]
+fn populated_missing_returns_none() {
+    assert_eq!(parse_populated("frozen 0\n"), None);
+}
+
+/// Empty file — must not silently default.
+#[test]
+fn populated_empty_returns_none() {
+    assert_eq!(parse_populated(""), None);
+}
+
+/// An unrecognized value after `populated ` — must not silently default to either state.
+#[test]
+fn populated_garbage_value_returns_none() {
+    assert_eq!(parse_populated("populated 2\n"), None);
+}
+
+/// No trailing newline on the last line — must still parse.
+#[test]
+fn populated_no_trailing_newline() {
+    assert_eq!(parse_populated("frozen 0\npopulated 0"), Some(false));
 }

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -164,25 +164,37 @@ impl Attached {
         }
     }
 
+    /// Whether this handle owns a mechanism with a kernel drain edge — mirrors
+    /// [`Containment::can_observe_drain`](crate::containment::Containment::can_observe_drain),
+    /// checked against the concrete resource rather than the reported enum so the two can
+    /// never drift silently (`require_drainable` asserts them equal in debug).
+    pub(crate) fn can_observe_drain(&self) -> bool {
+        match self {
+            #[cfg(target_os = "linux")]
+            Attached::Cgroup(_) => true,
+            #[cfg(windows)]
+            Attached::JobObject(_) => true,
+            #[cfg(target_os = "macos")]
+            Attached::FdMarker(_) => true,
+            _ => false,
+        }
+    }
+
     /// Block until every member of the contained tree has EXITED (not reaped), or until
-    /// `deadline`. `Unsupported` on every mechanism without a kernel drain edge — presently all
-    /// of them except the macOS fd marker.
-    ///
-    /// No non-test caller exists yet: wiring `graceful_shutdown_tree`'s conditional escalation
-    /// to consult this is a later change's deliverable, not this one's. `#[allow(dead_code)]`
-    /// reflects that honestly, mirroring `marker_eof::probe`.
-    ///
-    /// Delegates to [`Marker::wait_drained`](crate::containment::fdmarker::Marker::wait_drained)
-    /// rather than handing out a bare `BorrowedFd` (as an earlier `marker_read_end` accessor
-    /// did): that method re-checks the read end's identity first, the same way
-    /// `hard_kill`/`terminate` do, before trusting the descriptor at all.
-    #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
+    /// `deadline`. `Unsupported` on every mechanism without a kernel drain edge (checked by the
+    /// caller via `require_drainable`/`can_observe_drain` before this is reached in the public
+    /// API, but this still refuses honestly if ever called directly against a non-drainable
+    /// mechanism).
     pub(crate) fn wait_drained(
         &self,
         deadline: Option<Option<std::time::Instant>>,
-    ) -> Result<crate::containment::marker_eof::TreeDrain, Error> {
+    ) -> Result<crate::containment::TreeDrain, Error> {
         match self {
+            #[cfg(target_os = "linux")]
+            Attached::Cgroup(leaf) => leaf.wait_drained(deadline),
+            #[cfg(windows)]
+            Attached::JobObject(job) => job.wait_drained(deadline, None),
+            #[cfg(target_os = "macos")]
             Attached::FdMarker(m) => m.wait_drained(deadline),
             _ => Err(Error::Unsupported {
                 op: "wait for the contained tree to drain".into(),

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -411,7 +411,7 @@ fn wait_drained_is_unsupported_without_a_marker() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn wait_drained_reports_members_remain_then_all_members_exited() {
+fn wait_drained_reports_members_remain_then_all_markers_closed() {
     use super::Attached;
     use crate::containment::fdmarker::{pipe_handle_of, Marker, PreparedMarker};
     use crate::containment::TreeDrain;
@@ -455,6 +455,6 @@ fn wait_drained_reports_members_remain_then_all_members_exited() {
         attached
             .wait_drained(None)
             .expect("unbounded wait after the holder exits"),
-        TreeDrain::AllMembersExited
+        TreeDrain::AllMarkersClosed
     );
 }

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -414,7 +414,7 @@ fn wait_drained_is_unsupported_without_a_marker() {
 fn wait_drained_reports_members_remain_then_all_members_exited() {
     use super::Attached;
     use crate::containment::fdmarker::{pipe_handle_of, Marker, PreparedMarker};
-    use crate::containment::marker_eof::TreeDrain;
+    use crate::containment::TreeDrain;
     use std::os::fd::{AsFd, OwnedFd};
 
     // A real holder in a separate process, mirroring marker_eof_tests.rs's

--- a/src/containment/fdmarker.rs
+++ b/src/containment/fdmarker.rs
@@ -1021,7 +1021,11 @@ impl Marker {
     /// indication anything was wrong. A single debug-only line is not enough defense for that
     /// severity; it is checked in EVERY build, and a violation refuses to sweep at all rather
     /// than proceeding on a handle that may no longer mean what `self` claims.
-    fn check_read_end_still_valid(&self) -> Result<(), Error> {
+    ///
+    /// `pub(crate)`: also called from the async dispatch path (`crate::tokio::wait`) before it
+    /// reads `self.read`'s raw fd directly, for the same reason — a reissued fd there would
+    /// falsely report `EV_EOF` just as readily as it would here.
+    pub(crate) fn check_read_end_still_valid(&self) -> Result<(), Error> {
         let read_still_valid = matches!(
             fd_pipe_info(std::process::id(), self.read.as_raw_fd()),
             FdPipeInfoQuery::Found(info) if info.pipe_handle == self.read_handle

--- a/src/containment/fdmarker.rs
+++ b/src/containment/fdmarker.rs
@@ -917,11 +917,10 @@ impl Marker {
     /// reissued fd (an unrelated pipe with no open write end) deliver `EV_EOF` immediately and
     /// report `AllMembersExited` for a fully live tree — the same false-edge risk `hard_kill`
     /// refuses on, not merely a discrepancy between two code paths.
-    #[allow(dead_code)] // no non-test caller yet; mirrors marker_eof::probe / Attached::wait_drained
     pub(crate) fn wait_drained(
         &self,
         deadline: Option<Option<Instant>>,
-    ) -> Result<crate::containment::marker_eof::TreeDrain, Error> {
+    ) -> Result<crate::containment::TreeDrain, Error> {
         self.check_read_end_still_valid()?;
         // This process is the supervisor: it must have closed its own copy of the write end at
         // spawn time (`install`'s contract), or the edge could never fire. A deliberately

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -172,7 +172,7 @@ fn interpret_read_event(
         return Err(Error::Io(std::io::Error::from_raw_os_error(event.data() as i32)));
     }
     if event.flags().contains(EvFlags::EV_EOF) {
-        return Ok(Some(TreeDrain::AllMembersExited));
+        return Ok(Some(TreeDrain::AllMarkersClosed));
     }
     // `data` is a byte count for a readable, non-EOF, non-error EVFILT_READ event — never
     // negative per the kqueue contract this module relies on everywhere else. A violation here
@@ -229,18 +229,19 @@ pub(crate) fn drain_kqueue(
 }
 
 /// One-shot drain check: exact, not heuristic — arms a private kqueue and reads its
-/// zero-timeout verdict off `EV_EOF`, the same authoritative signal `block_until_drained`
-/// uses. `Ok(None)` from `drain_kqueue` (nothing pending yet) means a write end is open with
-/// nothing queued: `MembersRemain`, correctly, since `AllMembersExited` is only ever reported
-/// when the kernel itself said `EV_EOF`.
+/// zero-timeout verdict off `EV_EOF`, the same signal `block_until_drained` uses (advisory, per
+/// this module's `TreeDrain::AllMarkersClosed` — see that type's own doc). `Ok(None)` from
+/// `drain_kqueue` (nothing pending yet) means a write end is open with nothing queued:
+/// `MembersRemain`, correctly, since `AllMarkersClosed` is only ever reported when the kernel
+/// itself said `EV_EOF`.
 ///
-/// No production caller exists yet — kept as crate-internal primitive surface for a future
-/// consumer, exercised directly by the unit tests below. `#[allow(dead_code)]` reflects that
-/// honestly instead of leaving the lib target to fail `cargo clippy --all-targets -D
-/// warnings`, which sees no test-cfg code and would otherwise flag this as unused. A one-shot
-/// check never blocks, so it never risks a caller-invisible hang: it always passes `false` for
-/// `arm`'s `unbounded_wait`.
-#[allow(dead_code)]
+/// Called from `wait_tree_deadline`'s zero-duration case (`crate::tokio::wait`) — a one-shot
+/// check never blocks, so it never risks a caller-invisible hang there: it always passes
+/// `false` for `arm`'s `unbounded_wait`. That caller lives behind the crate's `tokio` feature,
+/// so this (and its own callee `drain_kqueue`) really is unreachable without it —
+/// `#[allow(dead_code)]` reflects that honestly for a `tokio`-disabled build instead of leaving
+/// the lib target to fail `cargo clippy --all-targets -D warnings` there.
+#[cfg_attr(not(feature = "tokio"), allow(dead_code))]
 pub(crate) fn probe(read_end: BorrowedFd<'_>) -> Result<TreeDrain, Error> {
     let kq = arm(read_end, false)?;
     match drain_kqueue(&kq, read_end, false)? {

--- a/src/containment/marker_eof.rs
+++ b/src/containment/marker_eof.rs
@@ -56,24 +56,12 @@ use std::time::Instant;
 
 use nix::sys::event::{EvFlags, EventFilter, FilterFlag, KEvent, Kqueue};
 
+use crate::containment::TreeDrain;
 use crate::error::Error;
 
 #[cfg(test)]
 #[path = "marker_eof_tests.rs"]
 mod marker_eof_tests;
-
-/// Whether every holder of the marker's write end has **exited**.
-///
-/// Exited is not reaped: descriptors close before the zombie is collected, so
-/// `AllMembersExited` never implies a status is available. It also means every holder of the
-/// *marker*, which a member that closed the descriptor has stopped being.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TreeDrain {
-    /// Every marker holder has exited. Statuses have NOT been collected.
-    AllMembersExited,
-    /// At least one marker holder was still running at the deadline.
-    MembersRemain,
-}
 
 /// The `NOTE_LOWAT` low-water mark every knote in this module is armed with. Clamped by the
 /// kernel to the pipe's actual buffer capacity — see the module doc for what this does and

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -16,7 +16,8 @@
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::time::{Duration, Instant};
 
-use super::{block_until_drained, probe, TreeDrain};
+use super::{block_until_drained, probe};
+use crate::containment::TreeDrain;
 
 fn test_spawn_lock() -> std::sync::MutexGuard<'static, ()> {
     crate::child::spawn::spawn_lock()

--- a/src/containment/marker_eof_tests.rs
+++ b/src/containment/marker_eof_tests.rs
@@ -71,7 +71,7 @@ fn probe_reports_drained_when_the_last_write_end_is_gone() {
     let _serialize = test_spawn_lock();
     let (r, w) = marker_pipe();
     drop(w); // the last holder's descriptor closed
-    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMarkersClosed);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn probe_reports_drained_even_with_bytes_still_buffered() {
     let (r, w) = marker_pipe();
     nix::unistd::write(&w, b"noise from a member").expect("write");
     drop(w);
-    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMarkersClosed);
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn block_until_drained_with_a_past_deadline_behaves_like_a_one_shot_probe() {
     drop(stdin);
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
-        TreeDrain::AllMembersExited
+        TreeDrain::AllMarkersClosed
     );
     child.wait().expect("reap");
 }
@@ -134,7 +134,7 @@ fn block_until_drained_with_a_past_deadline_still_reports_an_already_drained_tre
     drop(w); // drained before the deadline below is even evaluated
     assert_eq!(
         block_until_drained(r.as_fd(), Some(Some(already_past))).expect("probe"),
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "an already-drained tree must be reported as drained even past a stale deadline"
     );
 }
@@ -171,7 +171,7 @@ fn a_retained_supervisor_write_end_is_refused_not_waited_on() {
     // table is being churned by every other test running at the same moment. The property
     // under test is that a CLEARED write end is never mistaken for a still-held one.
     assert_ne!(super::write_end_check(r.as_fd()), super::WriteEndCheck::HeldByUs);
-    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMembersExited);
+    assert_eq!(probe(r.as_fd()).expect("probe"), TreeDrain::AllMarkersClosed);
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn a_live_member_holds_the_edge_shut_and_releases_it_on_exit() {
     drop(stdin); // cat sees EOF on stdin and exits
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
-        TreeDrain::AllMembersExited
+        TreeDrain::AllMarkersClosed
     );
     child.wait().expect("reap");
 }
@@ -246,7 +246,7 @@ fn the_edge_is_sticky_for_a_waiter_that_arrives_late() {
     child.wait().expect("reap");
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("late wait"),
-        TreeDrain::AllMembersExited
+        TreeDrain::AllMarkersClosed
     );
 }
 
@@ -257,7 +257,7 @@ fn a_member_that_closes_the_marker_leaves_the_set_early() {
     let (child, marker, stdin) = spawn_marker_holder("exec 3>&-; exec cat >/dev/null");
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("wait"),
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "a member that closed the marker must leave the membership set"
     );
     assert_eq!(
@@ -318,15 +318,15 @@ fn an_orphan_reparented_to_launchd_holds_the_edge_shut() {
     drop(stdin); // the orphan's only exit path — no signal, no timer
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "the edge must fire when the orphan exits"
     );
 }
 
 #[test]
-fn all_members_exited_requires_every_simultaneous_holder_to_exit() {
+fn all_markers_closed_requires_every_simultaneous_holder_to_exit() {
     // Every test above this one has exactly ONE write-end holder at a time, so none of them can
-    // tell "some closed" from "all closed" apart — a bug that reported `AllMembersExited` the
+    // tell "some closed" from "all closed" apart — a bug that reported `AllMarkersClosed` the
     // moment ANY single holder's copy closed, ignoring the rest, would still pass every one of
     // them. This test needs two INDEPENDENTLY closable holders alive at once: a single root
     // `/bin/sh` backgrounds two separate `cat` processes, each with its OWN stdin pipe (fd 0
@@ -364,7 +364,7 @@ fn all_members_exited_requires_every_simultaneous_holder_to_exit() {
     drop(stdin_b); // holder B sees EOF and exits; no holder remains
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "the edge must fire only once the LAST simultaneous holder is gone"
     );
     child
@@ -408,7 +408,7 @@ fn small_bytes_from_a_member_are_not_a_drain() {
     drop(stdin);
     assert_eq!(
         block_until_drained(marker.as_fd(), None).expect("unbounded wait"),
-        TreeDrain::AllMembersExited
+        TreeDrain::AllMarkersClosed
     );
     child.wait().expect("reap");
 }
@@ -476,7 +476,7 @@ fn bytes_past_the_low_water_clamp_are_drained_without_a_wrong_verdict() {
             Some(Instant::now().checked_add(Duration::from_secs(10)))
         )
         .expect("wait past the low-water clamp"),
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "closing the marker after writing past the clamp must still report drained, not hang or misfire"
     );
     assert_eq!(
@@ -599,7 +599,7 @@ fn an_unbounded_wait_against_a_sustained_writer_blocks_without_spending_cpu() {
 
     assert_eq!(
         verdict,
-        TreeDrain::AllMembersExited,
+        TreeDrain::AllMarkersClosed,
         "killing the writer closes the marker descriptor, which must still be observed"
     );
     // Generous (5%), matching the quiet-holder test's own margin: proving "genuinely blocked,

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -48,10 +48,19 @@ pub(crate) struct JobHandle {
     raw: AtomicPtr<c_void>,
     /// The I/O completion port associated with this job at creation time, before
     /// `AssignProcessToJobObject` — always, never opt-in (see `assign_to_kill_on_close_job`).
-    /// `wait_drained` deliberately does not read from it (see that method's doc for why); it is
-    /// kept here solely so the association persists for the job's lifetime and the port handle
-    /// is closed exactly once, honestly, on `Drop` rather than leaked.
-    port: HANDLE,
+    ///
+    /// `wait_drained` never reads from this port — it is NOT what the drain waits on. The drain
+    /// instead re-enumerates the job's live members with `QueryInformationJobObject` and blocks
+    /// on real `WaitForMultipleObjects` process-handle waits (see that method's doc for the full
+    /// mechanism and why: ordinary job lifecycle messages are documented by Microsoft as not
+    /// guaranteed to be delivered, so trusting them here could hang forever on one dropped
+    /// packet). The association still matters for a narrower reason: `assign_to_kill_on_close_job`
+    /// creates and associates the port *before* assigning the process, so the job never has a
+    /// live member without one — a self-imposed ordering invariant, not a functional dependency
+    /// of any watch. Kept as an atomic pointer purely so `JobHandle` stays `Sync` (a bare Windows
+    /// handle is otherwise `!Sync`, matching `raw`); never null, never taken — it is only ever
+    /// read once, in `Drop`, to close it exactly once rather than leak it.
+    port: AtomicPtr<c_void>,
 }
 
 // A Windows job-object HANDLE is a process-wide kernel handle; using it
@@ -71,9 +80,10 @@ impl std::fmt::Debug for JobHandle {
 impl JobHandle {
     fn new(handle: HANDLE, port: HANDLE) -> Self {
         debug_assert!(!handle.0.is_null(), "job handle must not be null");
+        debug_assert!(!port.0.is_null(), "job completion port handle must not be null");
         JobHandle {
             raw: AtomicPtr::new(handle.0),
-            port,
+            port: AtomicPtr::new(port.0),
         }
     }
 
@@ -166,7 +176,7 @@ impl Drop for JobHandle {
         // closed anywhere else. Closing it here, unconditionally, whether or not the tree was
         // torn down, releases the last resource this type holds.
         unsafe {
-            let _ = CloseHandle(self.port);
+            let _ = CloseHandle(HANDLE(self.port.load(Ordering::Relaxed)));
         }
     }
 }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -505,26 +505,28 @@ impl JobHandle {
     ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
         let Some(job) = self.as_handle() else {
             // The job was already consumed — `hard_kill()` or `Drop` already ran, nulling `raw`
-            // and closing the underlying handle. `TerminateJobObject`/`CloseHandle` are NOT
-            // documented as synchronous with member process teardown (pending I/O, for one, can
-            // outlive both calls), so "we already told it to die" is not live evidence that
-            // every member has actually finished exiting. Once the handle is gone there is also
-            // no longer any way to ask — `QueryInformationJobObject` needs a live job handle,
-            // and none of `JobHandle`'s fields keep the individual member pids around to fall
-            // back on. Reporting `AllMembersExited` here would be exactly the guess this
-            // function's own doc promises never to make; `Unassessable` says plainly that the
-            // answer can no longer be observed, rather than asserting one nothing here
-            // re-checked. No `source`: nothing was asked of the OS on this path at all — the
-            // handle was already gone before any call could be made.
-            return Err(crate::error::Error::Unassessable {
-                detail: "the job handle was already closed (kill_tree()/hard_kill(), or the \
-                         Child was dropped) before this drain check ran; whether every member \
-                         has actually finished exiting can no longer be observed"
-                    .into(),
-                source: None,
-            });
+            // and closing the underlying handle. See `consumed_job_handle_error`'s own doc for
+            // why that is reported as `Unassessable` rather than a guessed `AllMembersExited`.
+            return Err(consumed_job_handle_error());
         };
         wait_drained_raw(job, deadline, cancel)
+    }
+}
+
+/// The [`Error::Unassessable`](crate::error::Error::Unassessable) reported when a drain check
+/// finds the job handle already closed (`kill_tree()`/`hard_kill()`, or the `Child` was
+/// dropped): `TerminateJobObject`/`CloseHandle` are not documented as synchronous with member
+/// process teardown, so once the handle is gone there is no way left to ask whether every member
+/// has actually finished exiting — reporting `AllMembersExited` here would be a guess, not a
+/// live-checked verdict. Shared verbatim by `JobHandle::wait_drained`'s own early return and its
+/// tokio twin, `job_wait_tree_drained`.
+pub(crate) fn consumed_job_handle_error() -> crate::error::Error {
+    crate::error::Error::Unassessable {
+        detail: "the job handle was already closed (kill_tree()/hard_kill(), or the Child was \
+                 dropped) before this drain check ran; whether every member has actually \
+                 finished exiting can no longer be observed"
+            .into(),
+        source: None,
     }
 }
 
@@ -628,6 +630,16 @@ pub(crate) fn wait_drained_raw(
             idx < wait_set.len(),
             "unexpected WaitForMultipleObjects verdict: {waited:?}"
         );
+        if idx >= wait_set.len() {
+            // Same anomaly the debug_assert above catches in debug builds — surfaced here too
+            // so a release build does not silently fall through to "treat as a member exit and
+            // re-enumerate" without any trace of the OS having returned an unexpected verdict.
+            log::warn!(
+                "wait_tree: unexpected WaitForMultipleObjects verdict {waited:?} (index {idx} \
+                 outside the {} handles waited on) - re-enumerating regardless",
+                wait_set.len()
+            );
+        }
         if cancel.is_some() && idx == handles.len() {
             // The cancel handle was signaled — the caller's future was dropped. The
             // tree's drain state is genuinely unknown at this instant; report it exactly
@@ -701,8 +713,20 @@ fn resume_initial_threads(proc_handle: std::os::windows::io::RawHandle) -> io::R
         let _ = CloseHandle(snap);
     }
 
+    // The doc above promises this unconditionally ("If ResumeThread fails the child is killed
+    // immediately and an error returned") — that must hold even when SOME threads resumed
+    // successfully before another one failed, not only when every one did: a thread left
+    // suspended is exactly the "frozen process" this function exists to rule out, regardless of
+    // how many of its siblings got moving first.
+    if let Some(e) = last_err {
+        log::warn!(
+            "wait_tree: failed to resume one or more of this child's initial threads \
+             ({resumed} resumed successfully before the failure): {e}"
+        );
+        return Err(e);
+    }
     if resumed == 0 {
-        return Err(last_err.unwrap_or_else(|| io::Error::other("no suspended threads resumed")));
+        return Err(io::Error::other("no suspended threads resumed"));
     }
     Ok(())
 }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -451,14 +451,23 @@ impl JobHandle {
     ///
     /// `deadline` follows the crate's watch convention (see [`crate::wait::remaining`]). No
     /// interval is chosen anywhere in this path: every round blocks in one
-    /// `WaitForMultipleObjects` call for exactly the caller's own remaining time.
+    /// `WaitForMultipleObjects` call for exactly the caller's own remaining time. An
+    /// already-elapsed (or `Duration::ZERO`) deadline still gets one real re-enumeration and, if
+    /// any member is still live, one real non-blocking `WaitForMultipleObjects` poll before a
+    /// deadline-based verdict is returned — a stale bound only ever forecloses looping back for
+    /// ANOTHER round, never the current one's own observation. A drained tree is reported
+    /// `AllMembersExited` regardless of how late the caller arrived to look.
     ///
     /// `cancel`, when given, is appended to every round's wait set (one fewer live member
     /// tracked per round) so a live `WaitForMultipleObjects` releases the instant it is
     /// signaled rather than only at the next re-enumeration boundary — the async wrapper's
     /// drop-cancellation primitive (mirrors `block_until_exit_or_cancel`'s cancel event). A
     /// cancellation reports `MembersRemain` (the tree's drain state is simply unknown at that
-    /// point, same as a timeout), never an error.
+    /// point, same as a timeout), never an error. Unlike the deadline, cancellation IS checked
+    /// before that first re-enumeration too: it is a genuine "stop looking" instruction, not a
+    /// stale bound on how long to keep looking, so a caller who cancels before this call ever
+    /// enumerates the job once still gets a prompt `MembersRemain` rather than being forced
+    /// through one more round first.
     pub(crate) fn wait_drained(
         &self,
         deadline: Option<Option<std::time::Instant>>,
@@ -506,35 +515,29 @@ pub(crate) fn wait_drained_raw(
 
     let budget = MAXIMUM_WAIT_OBJECTS - 1 - if cancel.is_some() { 1 } else { 0 };
     loop {
-        // Check the deadline and cancellation BEFORE doing any work this round — not after,
-        // and never skipped by an early `continue`. A round in which every candidate pid has
-        // already exited by the time we try to open it (see the all-exited case below) is
-        // real progress and must re-enumerate, but that re-enumeration is still one loop
-        // iteration, and every iteration owes its caller a bounded-wait probe and a
-        // cancellation check: otherwise `wait_tree_timeout(Duration::ZERO)` — documented and
-        // used as a non-blocking probe — can loop on a churning tree, and a dropped future's
-        // cancel signal (see `SignalOnDrop`) is never observed by a thread that keeps cycling
-        // straight back to `query_job_pid_list` without ever consulting it.
+        // Cancellation is checked BEFORE any work this round, including the very first — a
+        // deliberate asymmetry with the deadline check below. Cancellation is a genuine "stop
+        // looking" instruction (the caller's future was dropped; the tree's drain state is no
+        // longer anyone's to observe), so it is honored even before we have ever enumerated the
+        // job once. A deadline, in contrast, is a stale BOUND on how long to keep looking, not
+        // an instruction to skip looking — see below.
         if let Some(c) = cancel {
             // SAFETY: `cancel` is a valid handle for the duration of this call (caller-owned).
             let cancel_state = unsafe { WaitForSingleObject(c, 0) };
             if cancel_state == WAIT_OBJECT_0 {
-                // The cancel handle was signaled — the caller's future was dropped. The
-                // tree's drain state is genuinely unknown at this instant; report it exactly
-                // like a timeout rather than inventing a verdict.
                 return Ok(TreeDrain::MembersRemain);
             }
         }
-        let ms: u32 = match crate::wait::remaining(deadline) {
-            None => INFINITE,
-            Some(d) => {
-                if d.is_zero() {
-                    return Ok(TreeDrain::MembersRemain);
-                }
-                d.as_millis().min((INFINITE - 1) as u128) as u32
-            }
-        };
 
+        // Re-enumerate BEFORE consulting the deadline for a return. A `Duration::ZERO` (or
+        // already-elapsed) deadline must still observe the tree's ACTUAL current state on the
+        // one round it gets, not conclude `MembersRemain` purely because it arrived too late to
+        // look — a ZERO probe on an already-drained tree must report `AllMembersExited`, the
+        // same verdict an unbounded wait would find. This mirrors `block_on_kqueue`'s
+        // `already_elapsed` handling on the macOS side: the real observation always happens
+        // first; an elapsed deadline only forecloses looping back for ANOTHER round afterward
+        // (see the `handles.is_empty()` branch below, and the `ms` computation for the bounded
+        // wait itself).
         let pids = query_job_pid_list(job).map_err(Error::Io)?;
         if pids.is_empty() {
             return Ok(TreeDrain::AllMembersExited);
@@ -555,6 +558,10 @@ pub(crate) fn wait_drained_raw(
             }
         }
 
+        // Computed once per round and reused below for both the empty-handles decision and the
+        // bounded-wait timeout, so the two agree on what "the deadline" means for this round.
+        let remaining = crate::wait::remaining(deadline);
+
         if handles.is_empty() {
             if let Some(e) = denied {
                 // A persistent, actionable open failure (not a benign exit-race): looping
@@ -568,8 +575,15 @@ pub(crate) fn wait_drained_raw(
                 });
             }
             // Every candidate in this round's batch had already exited by the time we tried
-            // to open it — real progress. Re-enumerate immediately (the deadline and
-            // cancellation checks above already covered this iteration).
+            // to open it — real progress, but this round's `pids` was non-empty (so
+            // `AllMembersExited` isn't supported by what was actually observed) and looping
+            // straight back to `query_job_pid_list` is itself another round, which a bounded
+            // wait must not be allowed to take once its deadline has already elapsed (the
+            // busy-spin/cancellation-starvation hazard this whole restructuring exists to
+            // close). An elapsed deadline concludes `MembersRemain` here instead of continuing.
+            if remaining == Some(std::time::Duration::ZERO) {
+                return Ok(TreeDrain::MembersRemain);
+            }
             continue;
         }
         if let Some(e) = &denied {
@@ -592,6 +606,16 @@ pub(crate) fn wait_drained_raw(
         if let Some(c) = cancel {
             wait_set.push(c);
         }
+
+        // A ZERO (or already-elapsed) deadline yields `ms == 0` here, which
+        // `WaitForMultipleObjects` treats as a genuine non-blocking poll of the handles just
+        // opened above — the ZERO-probe semantics fall out of the real API rather than a
+        // pre-emptive return, so this round's `handles` (real, live members) still get one
+        // real look before `WAIT_TIMEOUT` reports `MembersRemain` below.
+        let ms: u32 = match remaining {
+            None => INFINITE,
+            Some(d) => d.as_millis().min((INFINITE - 1) as u128) as u32,
+        };
 
         // SAFETY: every handle in `handles` was just opened above and stays open for the
         // duration of this call; `cancel`, if present, is kept alive by its caller for the

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -16,21 +16,19 @@ use std::mem::size_of;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 use windows::Win32::Foundation::{
-    CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, WAIT_FAILED,
-    WAIT_OBJECT_0, WAIT_TIMEOUT,
+    CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, WAIT_FAILED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
 };
 use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
 use windows::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectW, JobObjectAssociateCompletionPortInformation,
-    JobObjectBasicProcessIdList, JobObjectExtendedLimitInformation, QueryInformationJobObject, SetInformationJobObject,
-    TerminateJobObject, JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_PROCESS_ID_LIST,
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectBasicProcessIdList, JobObjectExtendedLimitInformation,
+    QueryInformationJobObject, SetInformationJobObject, TerminateJobObject, JOBOBJECT_BASIC_PROCESS_ID_LIST,
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 };
 use windows::Win32::System::Threading::{
-    GetProcessId, OpenProcess, OpenThread, ResumeThread, WaitForMultipleObjects, CREATE_NEW_PROCESS_GROUP,
-    CREATE_SUSPENDED, INFINITE, PROCESS_SYNCHRONIZE, THREAD_SUSPEND_RESUME,
+    GetProcessId, OpenProcess, OpenThread, ResumeThread, WaitForMultipleObjects, WaitForSingleObject,
+    CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, INFINITE, PROCESS_SYNCHRONIZE, THREAD_SUSPEND_RESUME,
 };
-use windows::Win32::System::IO::CreateIoCompletionPort;
 
 /// Sentinel: a null pointer means the handle has been consumed or is invalid.
 fn null_ptr() -> *mut c_void {
@@ -46,21 +44,6 @@ pub(crate) struct JobHandle {
     /// The raw HANDLE value stored as an atomic `*mut c_void`.
     /// Null means the handle has been consumed (taken/killed).
     raw: AtomicPtr<c_void>,
-    /// The I/O completion port associated with this job at creation time, before
-    /// `AssignProcessToJobObject` — always, never opt-in (see `assign_to_kill_on_close_job`).
-    ///
-    /// `wait_drained` never reads from this port — it is NOT what the drain waits on. The drain
-    /// instead re-enumerates the job's live members with `QueryInformationJobObject` and blocks
-    /// on real `WaitForMultipleObjects` process-handle waits (see that method's doc for the full
-    /// mechanism and why: ordinary job lifecycle messages are documented by Microsoft as not
-    /// guaranteed to be delivered, so trusting them here could hang forever on one dropped
-    /// packet). The association still matters for a narrower reason: `assign_to_kill_on_close_job`
-    /// creates and associates the port *before* assigning the process, so the job never has a
-    /// live member without one — a self-imposed ordering invariant, not a functional dependency
-    /// of any watch. Kept as an atomic pointer purely so `JobHandle` stays `Sync` (a bare Windows
-    /// handle is otherwise `!Sync`, matching `raw`); never null, never taken — it is only ever
-    /// read once, in `Drop`, to close it exactly once rather than leak it.
-    port: AtomicPtr<c_void>,
 }
 
 // A Windows job-object HANDLE is a process-wide kernel handle; using it
@@ -78,12 +61,10 @@ impl std::fmt::Debug for JobHandle {
 }
 
 impl JobHandle {
-    fn new(handle: HANDLE, port: HANDLE) -> Self {
+    fn new(handle: HANDLE) -> Self {
         debug_assert!(!handle.0.is_null(), "job handle must not be null");
-        debug_assert!(!port.0.is_null(), "job completion port handle must not be null");
         JobHandle {
             raw: AtomicPtr::new(handle.0),
-            port: AtomicPtr::new(port.0),
         }
     }
 
@@ -153,10 +134,7 @@ impl JobHandle {
         // Safety: CreateJobObjectW with null name/attrs returns an owned job handle.
         let handle = unsafe { CreateJobObjectW(None, windows::core::PCWSTR::null()) }
             .expect("CreateJobObjectW for test placeholder");
-        // SAFETY: creating a fresh, unassociated completion port has no preconditions.
-        let port = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 0) }
-            .expect("CreateIoCompletionPort for test placeholder");
-        JobHandle::new(handle, port)
+        JobHandle::new(handle)
     }
 }
 
@@ -170,13 +148,6 @@ impl Drop for JobHandle {
             unsafe {
                 let _ = CloseHandle(job);
             }
-        }
-        // SAFETY: `port` was created once in `assign_to_kill_on_close_job` (or the test
-        // placeholder) and is owned exclusively by this `JobHandle` — never shared, never
-        // closed anywhere else. Closing it here, unconditionally, whether or not the tree was
-        // torn down, releases the last resource this type holds.
-        unsafe {
-            let _ = CloseHandle(HANDLE(self.port.load(Ordering::Relaxed)));
         }
     }
 }
@@ -350,11 +321,7 @@ pub(crate) mod fault {
     }
 }
 
-/// Create a `KILL_ON_JOB_CLOSE` job, associate a fresh I/O completion port with it — ALWAYS,
-/// before `AssignProcessToJobObject`, never opt-in — and assign the process at `proc_handle` to
-/// it. Associating before assignment (rather than after) means no window exists in which the
-/// job could be assigned but unassociated: nothing racing the assignment can observe a job that
-/// briefly had a member with no completion port at all.
+/// Create a `KILL_ON_JOB_CLOSE` job and assign the process at `proc_handle` to it.
 fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> io::Result<JobHandle> {
     // A Windows `RawHandle` is a `*mut c_void`.
     let raw_handle = HANDLE(proc_handle.cast());
@@ -374,37 +341,12 @@ fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> 
             return Err(io::Error::from(e));
         }
 
-        let port = match CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 0) {
-            Ok(p) => p,
-            Err(e) => {
-                let _ = CloseHandle(job);
-                return Err(io::Error::from(e));
-            }
-        };
-        // The completion key only needs to be unique per port; the job handle's own bit
-        // pattern is a convenient, already-unique value with no bookkeeping of its own.
-        let assoc = JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
-            CompletionKey: job.0,
-            CompletionPort: port,
-        };
-        if let Err(e) = SetInformationJobObject(
-            job,
-            JobObjectAssociateCompletionPortInformation,
-            std::ptr::addr_of!(assoc).cast(),
-            size_of::<JOBOBJECT_ASSOCIATE_COMPLETION_PORT>() as u32,
-        ) {
-            let _ = CloseHandle(port);
-            let _ = CloseHandle(job);
-            return Err(io::Error::from(e));
-        }
-
         if let Err(e) = AssignProcessToJobObject(job, raw_handle) {
-            let _ = CloseHandle(port);
             let _ = CloseHandle(job);
             return Err(io::Error::from(e));
         }
 
-        Ok(JobHandle::new(job, port))
+        Ok(JobHandle::new(job))
     }
 }
 
@@ -417,41 +359,58 @@ fn query_job_pid_list(job: HANDLE) -> io::Result<Vec<u32>> {
     let mut capacity: usize = 64;
     loop {
         let buf_len = size_of::<JOBOBJECT_BASIC_PROCESS_ID_LIST>() + capacity.saturating_sub(1) * size_of::<usize>();
-        let mut buf = vec![0u8; buf_len];
+        // Backed by `Vec<usize>`, not `Vec<u8>`: `JOBOBJECT_BASIC_PROCESS_ID_LIST` is 8-aligned
+        // (it holds `usize` fields), but a `Vec<u8>`'s allocation is only ever requested at
+        // alignment 1. Forming a `&JOBOBJECT_BASIC_PROCESS_ID_LIST` from a `Vec<u8>` buffer is
+        // undefined behaviour regardless of what the allocator happens to return in practice —
+        // the compiler is entitled to assume the reference's target is properly aligned. A
+        // `Vec<usize>` buffer is naturally aligned for this header, and is read through raw
+        // pointers below rather than a reference, so no alignment assumption is ever load-bearing.
+        let mut buf: Vec<usize> = vec![0usize; buf_len.div_ceil(size_of::<usize>())];
         let mut returned = 0u32;
-        // SAFETY: `buf` is exactly `buf_len` bytes, zero-initialized, matching the trailing
-        // `ProcessIdList` array's declared capacity; the call writes at most that many bytes.
+        let header_ptr = buf.as_mut_ptr().cast::<JOBOBJECT_BASIC_PROCESS_ID_LIST>();
+        // SAFETY: `buf` is at least `buf_len` bytes (rounded up to whole `usize`s),
+        // zero-initialized, matching the trailing `ProcessIdList` array's declared capacity; the
+        // call writes at most `buf_len` bytes.
         let result = unsafe {
             QueryInformationJobObject(
                 Some(job),
                 JobObjectBasicProcessIdList,
-                buf.as_mut_ptr().cast(),
+                header_ptr.cast(),
                 buf_len as u32,
                 Some(&mut returned),
             )
         };
-        // SAFETY: the fixed header (`NumberOfAssignedProcesses`/`NumberOfProcessIdsInList`) is
-        // always written even when the call fails with a too-small buffer.
-        let header = unsafe { &*(buf.as_ptr() as *const JOBOBJECT_BASIC_PROCESS_ID_LIST) };
+        // The fixed header (`NumberOfAssignedProcesses`/`NumberOfProcessIdsInList`) is always
+        // written even when the call fails with a too-small buffer. Read both fields via
+        // `addr_of!`/`read_unaligned` on the raw pointer rather than materialising a
+        // `&JOBOBJECT_BASIC_PROCESS_ID_LIST` reference, so this call never depends on forming a
+        // reference into a buffer the kernel writes out-of-band.
+        // SAFETY: `header_ptr` is valid for reads of `size_of::<JOBOBJECT_BASIC_PROCESS_ID_LIST>()`
+        // bytes (`buf_len` is at least that size by construction) and initialized (zeroed above,
+        // then possibly partially overwritten by the call).
+        let assigned = unsafe { std::ptr::addr_of!((*header_ptr).NumberOfAssignedProcesses).read_unaligned() } as usize;
         if result.is_err() {
-            let assigned = header.NumberOfAssignedProcesses as usize;
             if assigned > capacity {
                 capacity = assigned;
                 continue;
             }
             return Err(io::Error::last_os_error());
         }
-        let n = header.NumberOfProcessIdsInList as usize;
+        // SAFETY: same as above.
+        let n = unsafe { std::ptr::addr_of!((*header_ptr).NumberOfProcessIdsInList).read_unaligned() } as usize;
         debug_assert!(
             n <= capacity,
             "kernel reported more pids than the queried buffer could hold"
         );
-        let list_ptr = header.ProcessIdList.as_ptr();
+        // SAFETY: `ProcessIdList` is the header's trailing flexible-array member; `buf` was sized
+        // for `capacity` entries starting right after the two `u32` counters, and
+        // `n.min(capacity) <= capacity`, so every read below is in-bounds and initialized.
+        let list_ptr = unsafe { std::ptr::addr_of!((*header_ptr).ProcessIdList).cast::<usize>() };
         let mut pids = Vec::with_capacity(n.min(capacity));
         for i in 0..n.min(capacity) {
-            // SAFETY: `list_ptr` points at the start of `buf`'s trailing `usize` array, which
-            // has room for `capacity` entries; `i < n.min(capacity) <= capacity`.
-            let raw = unsafe { *list_ptr.add(i) };
+            // SAFETY: see above.
+            let raw = unsafe { list_ptr.add(i).read_unaligned() };
             pids.push(raw as u32);
         }
         return Ok(pids);
@@ -464,13 +423,15 @@ const MAXIMUM_WAIT_OBJECTS: usize = 64;
 impl JobHandle {
     /// Block until every process in this job has EXITED (not reaped), or until `deadline`.
     ///
-    /// Deliberately does NOT read the completion port associated at job-creation time: every
+    /// Deliberately does not associate an I/O completion port with the job at all: every
     /// ordinary job-lifecycle completion-port message (`JOB_OBJECT_MSG_EXIT_PROCESS`,
     /// `JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO`, ...) is documented by Microsoft as **not guaranteed
     /// to be delivered** — only `JobObjectNotificationLimitInformation`-class resource-limit
-    /// messages carry a delivery guarantee, a class unrelated to process lifecycle. Trusting the
+    /// messages carry a delivery guarantee, a class unrelated to process lifecycle. Trusting a
     /// port for this call's own correctness would make an unbounded `wait_tree()` capable of a
-    /// caller-invisible infinite hang on a single dropped packet.
+    /// caller-invisible infinite hang on a single dropped packet — and with the port never read,
+    /// associating one anyway would only cost unbounded kernel nonpaged-pool growth (one queued
+    /// packet per job lifecycle event, for the job handle's whole lifetime) for nothing.
     ///
     /// Instead, each round: (1) re-enumerate the job's LIVE members via
     /// `QueryInformationJobObject(JobObjectBasicProcessIdList)` — the authoritative, always-fresh
@@ -545,6 +506,35 @@ pub(crate) fn wait_drained_raw(
 
     let budget = MAXIMUM_WAIT_OBJECTS - 1 - if cancel.is_some() { 1 } else { 0 };
     loop {
+        // Check the deadline and cancellation BEFORE doing any work this round — not after,
+        // and never skipped by an early `continue`. A round in which every candidate pid has
+        // already exited by the time we try to open it (see the all-exited case below) is
+        // real progress and must re-enumerate, but that re-enumeration is still one loop
+        // iteration, and every iteration owes its caller a bounded-wait probe and a
+        // cancellation check: otherwise `wait_tree_timeout(Duration::ZERO)` — documented and
+        // used as a non-blocking probe — can loop on a churning tree, and a dropped future's
+        // cancel signal (see `SignalOnDrop`) is never observed by a thread that keeps cycling
+        // straight back to `query_job_pid_list` without ever consulting it.
+        if let Some(c) = cancel {
+            // SAFETY: `cancel` is a valid handle for the duration of this call (caller-owned).
+            let cancel_state = unsafe { WaitForSingleObject(c, 0) };
+            if cancel_state == WAIT_OBJECT_0 {
+                // The cancel handle was signaled — the caller's future was dropped. The
+                // tree's drain state is genuinely unknown at this instant; report it exactly
+                // like a timeout rather than inventing a verdict.
+                return Ok(TreeDrain::MembersRemain);
+            }
+        }
+        let ms: u32 = match crate::wait::remaining(deadline) {
+            None => INFINITE,
+            Some(d) => {
+                if d.is_zero() {
+                    return Ok(TreeDrain::MembersRemain);
+                }
+                d.as_millis().min((INFINITE - 1) as u128) as u32
+            }
+        };
+
         let pids = query_job_pid_list(job).map_err(Error::Io)?;
         if pids.is_empty() {
             return Ok(TreeDrain::AllMembersExited);
@@ -578,25 +568,22 @@ pub(crate) fn wait_drained_raw(
                 });
             }
             // Every candidate in this round's batch had already exited by the time we tried
-            // to open it — real progress. Re-enumerate immediately.
+            // to open it — real progress. Re-enumerate immediately (the deadline and
+            // cancellation checks above already covered this iteration).
             continue;
         }
-
-        let ms: u32 = match crate::wait::remaining(deadline) {
-            None => INFINITE,
-            Some(d) => {
-                if d.is_zero() {
-                    for h in &handles {
-                        // SAFETY: each handle was freshly opened above and not yet closed.
-                        unsafe {
-                            let _ = CloseHandle(*h);
-                        }
-                    }
-                    return Ok(TreeDrain::MembersRemain);
-                }
-                d.as_millis().min((INFINITE - 1) as u128) as u32
-            }
-        };
+        if let Some(e) = &denied {
+            // Some sibling in this round was still openable, so the round proceeds — but an
+            // actionable `OpenProcess` failure on a live member (as opposed to the benign
+            // exit-race above) is otherwise invisible for every round in which that holds,
+            // which can be every round for the tree's whole lifetime. Every other known
+            // failure in this function gets a visible disposition; this one should too, even
+            // though it isn't (yet) fatal to this round's wait.
+            log::debug!(
+                "wait_tree: could not open one live job member to watch for its exit, but \
+                 other members are still trackable this round: {e}"
+            );
+        }
 
         // The cancel handle (if any) is appended AFTER the real member handles, never
         // closed here (caller-owned) — only `handles` (the freshly opened member handles)
@@ -713,14 +700,12 @@ fn resume_initial_threads(proc_handle: std::os::windows::io::RawHandle) -> io::R
         let _ = CloseHandle(snap);
     }
 
-    // The doc above promises this unconditionally ("If ResumeThread fails the child is killed
-    // immediately and an error returned") — that must hold even when SOME threads resumed
-    // successfully before another one failed, not only when every one did: a thread left
-    // suspended is exactly the "frozen process" this function exists to rule out, regardless of
-    // how many of its siblings got moving first.
+    // That must hold even when SOME threads resumed successfully before another one failed, not
+    // only when every one did: a thread left suspended is exactly the "frozen process" this
+    // function exists to rule out, regardless of how many of its siblings got moving first.
     if let Some(e) = last_err {
         log::warn!(
-            "wait_tree: failed to resume one or more of this child's initial threads \
+            "resume_initial_threads: failed to resume one or more of this child's initial threads \
              ({resumed} resumed successfully before the failure): {e}"
         );
         return Err(e);

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -479,11 +479,14 @@ impl JobHandle {
     /// pids and block on `WaitForMultipleObjects(bWaitAll = FALSE)`. A process handle becoming
     /// signaled on exit is an unconditional, always-honored OS guarantee — unlike a job message
     /// — so as long as this round's tree is non-empty, at least one tracked handle WILL
-    /// eventually signal, forcing a fresh re-enumeration next round. This can never falsely
-    /// report `AllMembersExited` (that verdict is only ever reached via a live re-count of
-    /// zero); it can only be slow to *notice* full drain when concurrently-live membership
-    /// exceeds `MAXIMUM_WAIT_OBJECTS - 1` in a single round (this round's un-tracked excess is
-    /// picked up on the NEXT re-enumeration, once a tracked handle signals).
+    /// eventually signal, forcing a fresh re-enumeration next round. While the job handle is
+    /// still open, this can never falsely report `AllMembersExited` (that verdict is only ever
+    /// reached via a live re-count of zero); it can only be slow to *notice* full drain when
+    /// concurrently-live membership exceeds `MAXIMUM_WAIT_OBJECTS - 1` in a single round (this
+    /// round's un-tracked excess is picked up on the NEXT re-enumeration, once a tracked handle
+    /// signals). If the job handle has ALREADY been consumed by the time this call runs, there
+    /// is nothing left to re-enumerate at all — see the early return below, which reports
+    /// [`Error::Unassessable`](crate::error::Error::Unassessable) rather than guess.
     ///
     /// `deadline` follows the crate's watch convention (see [`crate::wait::remaining`]). No
     /// interval is chosen anywhere in this path: every round blocks in one
@@ -501,9 +504,25 @@ impl JobHandle {
         cancel: Option<HANDLE>,
     ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
         let Some(job) = self.as_handle() else {
-            // The job was already consumed (killed/dropped) by the time this call runs — the
-            // tree it owned is gone.
-            return Ok(crate::containment::TreeDrain::AllMembersExited);
+            // The job was already consumed — `hard_kill()` or `Drop` already ran, nulling `raw`
+            // and closing the underlying handle. `TerminateJobObject`/`CloseHandle` are NOT
+            // documented as synchronous with member process teardown (pending I/O, for one, can
+            // outlive both calls), so "we already told it to die" is not live evidence that
+            // every member has actually finished exiting. Once the handle is gone there is also
+            // no longer any way to ask — `QueryInformationJobObject` needs a live job handle,
+            // and none of `JobHandle`'s fields keep the individual member pids around to fall
+            // back on. Reporting `AllMembersExited` here would be exactly the guess this
+            // function's own doc promises never to make; `Unassessable` says plainly that the
+            // answer can no longer be observed, rather than asserting one nothing here
+            // re-checked. No `source`: nothing was asked of the OS on this path at all — the
+            // handle was already gone before any call could be made.
+            return Err(crate::error::Error::Unassessable {
+                detail: "the job handle was already closed (kill_tree()/hard_kill(), or the \
+                         Child was dropped) before this drain check ran; whether every member \
+                         has actually finished exiting can no longer be observed"
+                    .into(),
+                source: None,
+            });
         };
         wait_drained_raw(job, deadline, cancel)
     }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -15,15 +15,22 @@ use std::io;
 use std::mem::size_of;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use windows::Win32::Foundation::{CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT};
+use windows::Win32::Foundation::{
+    CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, WAIT_FAILED,
+    WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
 use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
 use windows::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
-    TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectAssociateCompletionPortInformation,
+    JobObjectBasicProcessIdList, JobObjectExtendedLimitInformation, QueryInformationJobObject, SetInformationJobObject,
+    TerminateJobObject, JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_PROCESS_ID_LIST,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 };
 use windows::Win32::System::Threading::{
-    GetProcessId, OpenThread, ResumeThread, CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, THREAD_SUSPEND_RESUME,
+    GetProcessId, OpenProcess, OpenThread, ResumeThread, WaitForMultipleObjects, CREATE_NEW_PROCESS_GROUP,
+    CREATE_SUSPENDED, INFINITE, PROCESS_SYNCHRONIZE, THREAD_SUSPEND_RESUME,
 };
+use windows::Win32::System::IO::CreateIoCompletionPort;
 
 /// Sentinel: a null pointer means the handle has been consumed or is invalid.
 fn null_ptr() -> *mut c_void {
@@ -39,6 +46,12 @@ pub(crate) struct JobHandle {
     /// The raw HANDLE value stored as an atomic `*mut c_void`.
     /// Null means the handle has been consumed (taken/killed).
     raw: AtomicPtr<c_void>,
+    /// The I/O completion port associated with this job at creation time, before
+    /// `AssignProcessToJobObject` — always, never opt-in (see `assign_to_kill_on_close_job`).
+    /// `wait_drained` deliberately does not read from it (see that method's doc for why); it is
+    /// kept here solely so the association persists for the job's lifetime and the port handle
+    /// is closed exactly once, honestly, on `Drop` rather than leaked.
+    port: HANDLE,
 }
 
 // A Windows job-object HANDLE is a process-wide kernel handle; using it
@@ -56,10 +69,11 @@ impl std::fmt::Debug for JobHandle {
 }
 
 impl JobHandle {
-    fn new(handle: HANDLE) -> Self {
+    fn new(handle: HANDLE, port: HANDLE) -> Self {
         debug_assert!(!handle.0.is_null(), "job handle must not be null");
         JobHandle {
             raw: AtomicPtr::new(handle.0),
+            port,
         }
     }
 
@@ -129,7 +143,10 @@ impl JobHandle {
         // Safety: CreateJobObjectW with null name/attrs returns an owned job handle.
         let handle = unsafe { CreateJobObjectW(None, windows::core::PCWSTR::null()) }
             .expect("CreateJobObjectW for test placeholder");
-        JobHandle::new(handle)
+        // SAFETY: creating a fresh, unassociated completion port has no preconditions.
+        let port = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 0) }
+            .expect("CreateIoCompletionPort for test placeholder");
+        JobHandle::new(handle, port)
     }
 }
 
@@ -143,6 +160,13 @@ impl Drop for JobHandle {
             unsafe {
                 let _ = CloseHandle(job);
             }
+        }
+        // SAFETY: `port` was created once in `assign_to_kill_on_close_job` (or the test
+        // placeholder) and is owned exclusively by this `JobHandle` — never shared, never
+        // closed anywhere else. Closing it here, unconditionally, whether or not the tree was
+        // torn down, releases the last resource this type holds.
+        unsafe {
+            let _ = CloseHandle(self.port);
         }
     }
 }
@@ -316,11 +340,15 @@ pub(crate) mod fault {
     }
 }
 
-/// Create a `KILL_ON_JOB_CLOSE` job and assign the process at `proc_handle` to it.
+/// Create a `KILL_ON_JOB_CLOSE` job, associate a fresh I/O completion port with it — ALWAYS,
+/// before `AssignProcessToJobObject`, never opt-in — and assign the process at `proc_handle` to
+/// it. Associating before assignment (rather than after) means no window exists in which the
+/// job could be assigned but unassociated: nothing racing the assignment can observe a job that
+/// briefly had a member with no completion port at all.
 fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> io::Result<JobHandle> {
     // A Windows `RawHandle` is a `*mut c_void`.
     let raw_handle = HANDLE(proc_handle.cast());
-    // SAFETY: all calls are standard Win32; owned handles are closed on error.
+    // SAFETY: all calls are standard Win32; owned handles are closed on every error path.
     unsafe {
         let job = CreateJobObjectW(None, windows::core::PCWSTR::null()).map_err(io::Error::from)?;
 
@@ -336,12 +364,248 @@ fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> 
             return Err(io::Error::from(e));
         }
 
-        if let Err(e) = AssignProcessToJobObject(job, raw_handle) {
+        let port = match CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 0) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = CloseHandle(job);
+                return Err(io::Error::from(e));
+            }
+        };
+        // The completion key only needs to be unique per port; the job handle's own bit
+        // pattern is a convenient, already-unique value with no bookkeeping of its own.
+        let assoc = JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
+            CompletionKey: job.0,
+            CompletionPort: port,
+        };
+        if let Err(e) = SetInformationJobObject(
+            job,
+            JobObjectAssociateCompletionPortInformation,
+            std::ptr::addr_of!(assoc).cast(),
+            size_of::<JOBOBJECT_ASSOCIATE_COMPLETION_PORT>() as u32,
+        ) {
+            let _ = CloseHandle(port);
             let _ = CloseHandle(job);
             return Err(io::Error::from(e));
         }
 
-        Ok(JobHandle::new(job))
+        if let Err(e) = AssignProcessToJobObject(job, raw_handle) {
+            let _ = CloseHandle(port);
+            let _ = CloseHandle(job);
+            return Err(io::Error::from(e));
+        }
+
+        Ok(JobHandle::new(job, port))
+    }
+}
+
+/// Read the job's LIVE member pids via `QueryInformationJobObject(JobObjectBasicProcessIdList)`
+/// — the authoritative, always-fresh source `wait_drained` re-consults every round, independent
+/// of any completion-port message. Grows the buffer and retries (no bound on retries: a job
+/// that keeps growing needs an ever-larger buffer, but capping this would silently under-report
+/// live membership rather than fail loudly).
+fn query_job_pid_list(job: HANDLE) -> io::Result<Vec<u32>> {
+    let mut capacity: usize = 64;
+    loop {
+        let buf_len = size_of::<JOBOBJECT_BASIC_PROCESS_ID_LIST>() + capacity.saturating_sub(1) * size_of::<usize>();
+        let mut buf = vec![0u8; buf_len];
+        let mut returned = 0u32;
+        // SAFETY: `buf` is exactly `buf_len` bytes, zero-initialized, matching the trailing
+        // `ProcessIdList` array's declared capacity; the call writes at most that many bytes.
+        let result = unsafe {
+            QueryInformationJobObject(
+                Some(job),
+                JobObjectBasicProcessIdList,
+                buf.as_mut_ptr().cast(),
+                buf_len as u32,
+                Some(&mut returned),
+            )
+        };
+        // SAFETY: the fixed header (`NumberOfAssignedProcesses`/`NumberOfProcessIdsInList`) is
+        // always written even when the call fails with a too-small buffer.
+        let header = unsafe { &*(buf.as_ptr() as *const JOBOBJECT_BASIC_PROCESS_ID_LIST) };
+        if result.is_err() {
+            let assigned = header.NumberOfAssignedProcesses as usize;
+            if assigned > capacity {
+                capacity = assigned;
+                continue;
+            }
+            return Err(io::Error::last_os_error());
+        }
+        let n = header.NumberOfProcessIdsInList as usize;
+        debug_assert!(
+            n <= capacity,
+            "kernel reported more pids than the queried buffer could hold"
+        );
+        let list_ptr = header.ProcessIdList.as_ptr();
+        let mut pids = Vec::with_capacity(n.min(capacity));
+        for i in 0..n.min(capacity) {
+            // SAFETY: `list_ptr` points at the start of `buf`'s trailing `usize` array, which
+            // has room for `capacity` entries; `i < n.min(capacity) <= capacity`.
+            let raw = unsafe { *list_ptr.add(i) };
+            pids.push(raw as u32);
+        }
+        return Ok(pids);
+    }
+}
+
+/// The largest handle count a single `WaitForMultipleObjects` call accepts (`MAXIMUM_WAIT_OBJECTS`).
+const MAXIMUM_WAIT_OBJECTS: usize = 64;
+
+impl JobHandle {
+    /// Block until every process in this job has EXITED (not reaped), or until `deadline`.
+    ///
+    /// Deliberately does NOT read the completion port associated at job-creation time: every
+    /// ordinary job-lifecycle completion-port message (`JOB_OBJECT_MSG_EXIT_PROCESS`,
+    /// `JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO`, ...) is documented by Microsoft as **not guaranteed
+    /// to be delivered** — only `JobObjectNotificationLimitInformation`-class resource-limit
+    /// messages carry a delivery guarantee, a class unrelated to process lifecycle. Trusting the
+    /// port for this call's own correctness would make an unbounded `wait_tree()` capable of a
+    /// caller-invisible infinite hang on a single dropped packet.
+    ///
+    /// Instead, each round: (1) re-enumerate the job's LIVE members via
+    /// `QueryInformationJobObject(JobObjectBasicProcessIdList)` — the authoritative, always-fresh
+    /// source of truth, independent of any notification; (2) if empty, the tree has drained; (3)
+    /// otherwise open real `SYNCHRONIZE` handles to up to `MAXIMUM_WAIT_OBJECTS - 1` of those
+    /// pids and block on `WaitForMultipleObjects(bWaitAll = FALSE)`. A process handle becoming
+    /// signaled on exit is an unconditional, always-honored OS guarantee — unlike a job message
+    /// — so as long as this round's tree is non-empty, at least one tracked handle WILL
+    /// eventually signal, forcing a fresh re-enumeration next round. This can never falsely
+    /// report `AllMembersExited` (that verdict is only ever reached via a live re-count of
+    /// zero); it can only be slow to *notice* full drain when concurrently-live membership
+    /// exceeds `MAXIMUM_WAIT_OBJECTS - 1` in a single round (this round's un-tracked excess is
+    /// picked up on the NEXT re-enumeration, once a tracked handle signals).
+    ///
+    /// `deadline` follows the crate's watch convention (see [`crate::wait::remaining`]). No
+    /// interval is chosen anywhere in this path: every round blocks in one
+    /// `WaitForMultipleObjects` call for exactly the caller's own remaining time.
+    ///
+    /// `cancel`, when given, is appended to every round's wait set (one fewer live member
+    /// tracked per round) so a live `WaitForMultipleObjects` releases the instant it is
+    /// signaled rather than only at the next re-enumeration boundary — the async wrapper's
+    /// drop-cancellation primitive (mirrors `block_until_exit_or_cancel`'s cancel event). A
+    /// cancellation reports `MembersRemain` (the tree's drain state is simply unknown at that
+    /// point, same as a timeout), never an error.
+    pub(crate) fn wait_drained(
+        &self,
+        deadline: Option<Option<std::time::Instant>>,
+        cancel: Option<HANDLE>,
+    ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
+        let Some(job) = self.as_handle() else {
+            // The job was already consumed (killed/dropped) by the time this call runs — the
+            // tree it owned is gone.
+            return Ok(crate::containment::TreeDrain::AllMembersExited);
+        };
+        wait_drained_raw(job, deadline, cancel)
+    }
+}
+
+/// The loop body of [`JobHandle::wait_drained`], taking the already-resolved raw handle rather
+/// than borrowing `&JobHandle` — the async wrapper (`tokio::wait`) copies the handle value out
+/// before handing it to `spawn_blocking`, since a `'static` blocking closure cannot capture a
+/// borrow. Sound because the async caller holds `&JobHandle` (transitively, `&Child`) across the
+/// whole `spawn_blocking` `.await`, so the job handle cannot be closed while this runs.
+pub(crate) fn wait_drained_raw(
+    job: HANDLE,
+    deadline: Option<Option<std::time::Instant>>,
+    cancel: Option<HANDLE>,
+) -> Result<crate::containment::TreeDrain, crate::error::Error> {
+    use crate::containment::TreeDrain;
+    use crate::error::Error;
+
+    let budget = MAXIMUM_WAIT_OBJECTS - 1 - if cancel.is_some() { 1 } else { 0 };
+    loop {
+        let pids = query_job_pid_list(job).map_err(Error::Io)?;
+        if pids.is_empty() {
+            return Ok(TreeDrain::AllMembersExited);
+        }
+
+        let mut handles: Vec<HANDLE> = Vec::new();
+        let mut denied: Option<io::Error> = None;
+        for pid in pids.iter().take(budget) {
+            // SAFETY: standard Win32 call; the handle is closed below on every path.
+            match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, *pid) } {
+                Ok(h) => handles.push(h),
+                // ERROR_INVALID_PARAMETER: the pid no longer names a process — it exited in
+                // the race between the enumeration above and this open. That is real
+                // progress (this round's tree is shrinking), not a failure: loop back to
+                // re-enumerate rather than treating it as denied.
+                Err(e) if e.code() == windows::Win32::Foundation::ERROR_INVALID_PARAMETER.to_hresult() => {}
+                Err(e) => denied = Some(io::Error::from(e)),
+            }
+        }
+
+        if handles.is_empty() {
+            if let Some(e) = denied {
+                // A persistent, actionable open failure (not a benign exit-race): looping
+                // back here without ever holding a real handle to block on would busy-spin.
+                log::warn!("wait_tree: could not open any live job member to watch for its exit ({e})");
+                return Err(Error::Unassessable {
+                    detail: "could not open a handle to any live member of the contained tree \
+                                 to observe its exit"
+                        .into(),
+                    source: Some(e),
+                });
+            }
+            // Every candidate in this round's batch had already exited by the time we tried
+            // to open it — real progress. Re-enumerate immediately.
+            continue;
+        }
+
+        let ms: u32 = match crate::wait::remaining(deadline) {
+            None => INFINITE,
+            Some(d) => {
+                if d.is_zero() {
+                    for h in &handles {
+                        // SAFETY: each handle was freshly opened above and not yet closed.
+                        unsafe {
+                            let _ = CloseHandle(*h);
+                        }
+                    }
+                    return Ok(TreeDrain::MembersRemain);
+                }
+                d.as_millis().min((INFINITE - 1) as u128) as u32
+            }
+        };
+
+        // The cancel handle (if any) is appended AFTER the real member handles, never
+        // closed here (caller-owned) — only `handles` (the freshly opened member handles)
+        // are closed below.
+        let mut wait_set = handles.clone();
+        if let Some(c) = cancel {
+            wait_set.push(c);
+        }
+
+        // SAFETY: every handle in `handles` was just opened above and stays open for the
+        // duration of this call; `cancel`, if present, is kept alive by its caller for the
+        // same duration.
+        let waited = unsafe { WaitForMultipleObjects(&wait_set, false, ms) };
+        let wait_failed = (waited == WAIT_FAILED).then(io::Error::last_os_error);
+        for h in &handles {
+            // SAFETY: each handle was opened above; closing after the wait releases it
+            // regardless of which handle (if any) was signaled.
+            unsafe {
+                let _ = CloseHandle(*h);
+            }
+        }
+
+        if waited == WAIT_TIMEOUT {
+            return Ok(TreeDrain::MembersRemain);
+        }
+        if let Some(e) = wait_failed {
+            return Err(Error::Io(e));
+        }
+        let idx = waited.0.wrapping_sub(WAIT_OBJECT_0.0) as usize;
+        debug_assert!(
+            idx < wait_set.len(),
+            "unexpected WaitForMultipleObjects verdict: {waited:?}"
+        );
+        if cancel.is_some() && idx == handles.len() {
+            // The cancel handle was signaled — the caller's future was dropped. The
+            // tree's drain state is genuinely unknown at this instant; report it exactly
+            // like a timeout rather than inventing a verdict.
+            return Ok(TreeDrain::MembersRemain);
+        }
+        // A tracked member exited — loop back and re-enumerate the authoritative live set.
     }
 }
 

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -3,14 +3,15 @@
 
 #[test]
 fn job_handle_debug_does_not_panic() {
-    // Verify the Debug impl compiles and runs cleanly for a consumed handle.
+    // Verify the Debug impl compiles and runs cleanly for a consumed (raw == null) handle.
+    // `port` is never a legal null, so there is no struct-literal shortcut to that state: go
+    // through the real constructor (`create_empty_for_test`) and a real consuming path
+    // (`hard_kill`, which both nulls `raw` and closes the underlying job handle — unlike a bare
+    // `take`, it doesn't leak the real handle this constructor opened) instead of hand-building
+    // a `JobHandle`.
     use super::JobHandle;
-    use std::sync::atomic::AtomicPtr;
-    // Construct a consumed (null) JobHandle to verify the Debug impl path.
-    // SAFETY: this is test-only; we do NOT pass this to any Win32 call.
-    let h = JobHandle {
-        raw: AtomicPtr::new(std::ptr::null_mut()),
-    };
+    let h = JobHandle::create_empty_for_test();
+    h.hard_kill();
     let s = format!("{h:?}");
     assert!(s.contains("JobHandle"), "debug output: {s}");
 }

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -16,6 +16,99 @@ fn job_handle_debug_does_not_panic() {
     assert!(s.contains("JobHandle"), "debug output: {s}");
 }
 
+/// A `wait_drained` call against an already-consumed job handle must report `Unassessable`,
+/// never a guessed `AllMembersExited` — the handle is gone, so nothing here re-checked whether
+/// every member actually finished exiting (`TerminateJobObject`/`CloseHandle` are not
+/// documented as synchronous with member process teardown).
+#[test]
+fn wait_drained_on_a_consumed_handle_is_unassessable() {
+    use super::JobHandle;
+    let h = JobHandle::create_empty_for_test();
+    h.hard_kill();
+    let err = h
+        .wait_drained(Some(None), None)
+        .expect_err("a consumed job handle must not report a live drain verdict");
+    let crate::error::Error::Unassessable { source, .. } = err else {
+        panic!("expected Unassessable, got {err:?}");
+    };
+    assert!(
+        source.is_none(),
+        "nothing was asked of the OS on this path — no source is expected"
+    );
+}
+
+/// `query_job_pid_list` on a freshly created, unpopulated job reports no members — the fast
+/// path `wait_drained_raw` relies on to return `AllMembersExited` without ever opening a
+/// process handle.
+#[test]
+fn query_job_pid_list_is_empty_for_an_unpopulated_job() {
+    use super::JobHandle;
+    let job = JobHandle::create_empty_for_test();
+    let job_handle = job.as_handle().expect("freshly created job handle must be live");
+    let pids = super::query_job_pid_list(job_handle).expect("query pid list");
+    assert!(pids.is_empty(), "an empty job must report no members: {pids:?}");
+}
+
+/// `wait_drained_raw`'s empty-job fast path: no member was ever assigned, so the very first
+/// re-enumeration already reports `AllMembersExited`, with no wait and no deadline needed.
+#[test]
+fn wait_drained_raw_reports_drained_for_an_empty_job() {
+    use super::JobHandle;
+    let job = JobHandle::create_empty_for_test();
+    let job_handle = job.as_handle().expect("freshly created job handle must be live");
+    let verdict = super::wait_drained_raw(job_handle, Some(None), None).expect("wait_drained_raw");
+    assert_eq!(verdict, crate::containment::TreeDrain::AllMembersExited);
+}
+
+/// A real, still-running job member reports `MembersRemain` at an already-elapsed deadline —
+/// not a race: the child is blocked reading its own piped stdin, which this test still holds
+/// open at the point of the check, so the member's liveness there is a fact this test itself
+/// holds, not a guess about timing. Also exercises `query_job_pid_list`'s non-empty branch (the
+/// pid must be visible in the job before `wait_drained_raw` can find it to wait on at all), and
+/// — once the child is let go and reaped — the live re-enumeration that turns a real exit into
+/// `AllMembersExited`, synchronized on `Child::wait()` rather than on any elapsed time.
+#[test]
+fn wait_drained_raw_tracks_a_real_member_through_exit() {
+    use std::os::windows::io::AsRawHandle;
+
+    // `cmd /C more`: a binary present on every Windows host, which blocks reading its stdin
+    // until EOF, then exits. No new external dependency — this is the OS shell.
+    let mut child = std::process::Command::new("cmd")
+        .args(["/C", "more"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn cmd /C more");
+    let raw = child.as_raw_handle();
+
+    let job = super::assign_to_kill_on_close_job(raw).expect("assign to job");
+    let job_handle = job.as_handle().expect("freshly created job handle must be live");
+
+    let pids = super::query_job_pid_list(job_handle).expect("query pid list");
+    assert_eq!(
+        pids,
+        vec![child.id()],
+        "the job must report exactly the member just assigned"
+    );
+
+    // An already-elapsed deadline: `crate::wait::remaining` reads it as Duration::ZERO without
+    // blocking at all, so this assertion is instantaneous — the point under test is that a
+    // non-empty live member set reports MembersRemain rather than a guessed drain verdict.
+    let past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+    let verdict = super::wait_drained_raw(job_handle, Some(Some(past)), None).expect("wait_drained_raw");
+    assert_eq!(verdict, crate::containment::TreeDrain::MembersRemain);
+
+    // Let the child exit on its own terms (EOF on stdin), then confirm the job reports drained
+    // once it genuinely has. `Child::wait()` only returns once the OS reports the process gone
+    // — a real synchronization point, not a timing guess.
+    drop(child.stdin.take());
+    child.wait().expect("wait for cmd /C more to exit");
+
+    let verdict = super::wait_drained_raw(job_handle, Some(None), None).expect("wait_drained_raw");
+    assert_eq!(verdict, crate::containment::TreeDrain::AllMembersExited);
+}
+
 /// Live coverage of the `Ok(true)` arm against a real console. `Ok(false)` needs the DETACHED
 /// helper in the integration suite (a different process); `Err` is not provokable live, hence
 /// the fault seam exercised below. This test does NOT guard the integration test against

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -20,3 +20,50 @@ pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
         .spawn()
         .expect("spawn")
 }
+
+/// The fully-qualified libtest path of [`fixture_survives_group_signal`], for callers that
+/// re-exec this binary against it directly (`current_exe() --exact <this>`) rather than through
+/// [`spawn_a_process_that_exits`]'s own filter.
+#[cfg(windows)]
+pub(crate) const FIXTURE_SURVIVES_GROUP_SIGNAL_TEST: &str = "test_child::fixture_survives_group_signal";
+
+/// The env var whose mere presence tells [`fixture_survives_group_signal`] it was re-exec'd as
+/// a fixture rather than picked up by an ordinary, unfiltered suite run.
+#[cfg(windows)]
+pub(crate) const FIXTURE_SURVIVES_GROUP_SIGNAL_ENV: &str = "COSCA_FIXTURE_SURVIVES_GROUP_SIGNAL";
+
+/// Windows-only fixture for the `root_exited`-on-`MembersRemain` regression (sync and async
+/// twins): a no-op when picked up by an ordinary, unfiltered suite run — [`FIXTURE_SURVIVES_GROUP_SIGNAL_ENV`]
+/// is unset there. Re-executed via `current_exe() --exact` [`FIXTURE_SURVIVES_GROUP_SIGNAL_TEST`]
+/// with that var set, it instead spawns a grandchild a group `CTRL_BREAK` can never reach —
+/// `CREATE_NEW_PROCESS_GROUP` puts it in its own process group, the same isolation
+/// `graceful_shutdown_tree`'s own doc describes for a nested contained descendant — then writes
+/// a single readiness byte to its own stdout and exits immediately, regardless of the group
+/// signal. The job object still tracks the grandchild as a tree member despite its own process
+/// group (job membership and process group are independent Win32 concepts), so it shows up as a
+/// `MembersRemain` survivor even though the signal itself never reaches it. Mirrors
+/// [`spawn_a_process_that_exits`]'s filtered-re-exec idiom (see its own doc for why the filter
+/// is mandatory) put to a second use.
+#[cfg(windows)]
+#[test]
+fn fixture_survives_group_signal() {
+    if std::env::var_os(FIXTURE_SURVIVES_GROUP_SIGNAL_ENV).is_none() {
+        return; // picked up by an ordinary suite run — deliberately inert
+    }
+    use std::io::Write;
+    use std::os::windows::process::CommandExt;
+
+    // CREATE_NEW_PROCESS_GROUP (winbase.h). A scalar flag, so a raw constant needs no
+    // `windows`-crate import: `std::os::windows::process::CommandExt::creation_flags` takes it
+    // as a plain `u32`.
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    #[allow(clippy::zombie_processes)] // intentional: the grandchild must outlive us; containment kills it
+    let _survivor = std::process::Command::new("ping")
+        .args(["-n", "30", "127.0.0.1"])
+        .creation_flags(CREATE_NEW_PROCESS_GROUP)
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn a grandchild the group signal cannot reach");
+    print!("r");
+    std::io::stdout().flush().expect("flush readiness byte");
+}

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -27,29 +27,38 @@ pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
 #[cfg(windows)]
 pub(crate) const FIXTURE_SURVIVES_GROUP_SIGNAL_TEST: &str = "test_child::fixture_survives_group_signal";
 
-/// The env var whose mere presence tells [`fixture_survives_group_signal`] it was re-exec'd as
-/// a fixture rather than picked up by an ordinary, unfiltered suite run.
+/// The env var carrying the `127.0.0.1:<port>` address [`fixture_survives_group_signal`] connects
+/// back to and tags once the grandchild survivor exists in its own process group. Its mere
+/// presence also tells the fixture it was re-exec'd deliberately rather than picked up by an
+/// ordinary, unfiltered suite run — one var serves both roles, since the fixture needs the
+/// address either way.
 #[cfg(windows)]
-pub(crate) const FIXTURE_SURVIVES_GROUP_SIGNAL_ENV: &str = "COSCA_FIXTURE_SURVIVES_GROUP_SIGNAL";
+pub(crate) const FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV: &str = "COSCA_FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR";
 
 /// Windows-only fixture for the `root_exited`-on-`MembersRemain` regression (sync and async
-/// twins): a no-op when picked up by an ordinary, unfiltered suite run — [`FIXTURE_SURVIVES_GROUP_SIGNAL_ENV`]
-/// is unset there. Re-executed via `current_exe() --exact` [`FIXTURE_SURVIVES_GROUP_SIGNAL_TEST`]
-/// with that var set, it instead spawns a grandchild a group `CTRL_BREAK` can never reach —
-/// `CREATE_NEW_PROCESS_GROUP` puts it in its own process group, the same isolation
-/// `graceful_shutdown_tree`'s own doc describes for a nested contained descendant — then writes
-/// a single readiness byte to its own stdout and exits immediately, regardless of the group
-/// signal. The job object still tracks the grandchild as a tree member despite its own process
-/// group (job membership and process group are independent Win32 concepts), so it shows up as a
-/// `MembersRemain` survivor even though the signal itself never reaches it. Mirrors
-/// [`spawn_a_process_that_exits`]'s filtered-re-exec idiom (see its own doc for why the filter
-/// is mandatory) put to a second use.
+/// twins): a no-op when picked up by an ordinary, unfiltered suite run —
+/// [`FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV`] is unset there. Re-executed via `current_exe()
+/// --exact` [`FIXTURE_SURVIVES_GROUP_SIGNAL_TEST`] with that var set, it instead spawns a
+/// grandchild a group `CTRL_BREAK` can never reach — `CREATE_NEW_PROCESS_GROUP` puts it in its
+/// own process group, the same isolation `graceful_shutdown_tree`'s own doc describes for a
+/// nested contained descendant — then connects to the caller's listener at that address and
+/// writes a single tag byte, proving the grandchild already exists (and is already in its own
+/// group) before the caller proceeds to call `graceful_shutdown_tree`. The tag goes out over a
+/// real TCP socket, not `print!`/`io::stdout()`: libtest captures the latter per-test and
+/// discards it for a passing test, so a stdout-based readiness byte never reaches the caller's
+/// piped reader at all — this is the same control-channel shape `tests/common`'s
+/// `spawn_tree`/`spawn_tree_async` tag handshake already uses for exactly this reason, not a
+/// Windows-specific mechanism. The job object still tracks the grandchild as a tree member
+/// despite its own process group (job membership and process group are independent Win32
+/// concepts), so it shows up as a `MembersRemain` survivor even though the signal itself never
+/// reaches it. Mirrors [`spawn_a_process_that_exits`]'s filtered-re-exec idiom (see its own doc
+/// for why the filter is mandatory) put to a second use.
 #[cfg(windows)]
 #[test]
 fn fixture_survives_group_signal() {
-    if std::env::var_os(FIXTURE_SURVIVES_GROUP_SIGNAL_ENV).is_none() {
+    let Some(addr) = std::env::var_os(FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV) else {
         return; // picked up by an ordinary suite run — deliberately inert
-    }
+    };
     use std::io::Write;
     use std::os::windows::process::CommandExt;
 
@@ -64,6 +73,6 @@ fn fixture_survives_group_signal() {
         .stdout(std::process::Stdio::null())
         .spawn()
         .expect("spawn a grandchild the group signal cannot reach");
-    print!("r");
-    std::io::stdout().flush().expect("flush readiness byte");
+    let mut sock = std::net::TcpStream::connect(addr.to_str().expect("utf8 addr")).expect("connect readiness socket");
+    sock.write_all(b"R").expect("write readiness tag");
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -519,6 +519,10 @@ impl Child {
 #[path = "child_drop_tests.rs"]
 mod child_drop_tests;
 
+#[cfg(test)]
+#[path = "child_wait_tree_tests.rs"]
+mod child_wait_tree_tests;
+
 #[cfg(all(test, windows))]
 impl Child {
     /// Test-only: install the per-instance raw-wait observer on this child (see the raw backend's

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -475,6 +475,36 @@ impl Child {
     fn require_contained(&self) -> Result<(), Error> {
         crate::containment::require_contained(self.containment, &self.attached)
     }
+
+    /// Guard for `wait_tree`/`wait_tree_timeout` (single-sourced with the sync `Child`).
+    fn require_drainable(&self) -> Result<(), Error> {
+        crate::containment::require_drainable(self.containment, &self.attached)
+    }
+
+    /// Block until every member of the contained tree has EXITED — not reaped; a status is
+    /// never collected by this call, only the root's own `wait`/`try_wait` does that. Requires
+    /// a mechanism with a real kernel drain edge (`Unsupported` otherwise — cgroup v2, a
+    /// Windows job object, and the macOS fd marker have one; `ProcessGroup`/`Session`/
+    /// `TreeWalk` and an uncontained or nested-`Delegated` child do not). Reactor-native on
+    /// Linux and macOS (no polling interval); Windows hands the wait to `spawn_blocking` (job
+    /// objects have no pollable handle) with a cancel event so a dropped future releases the
+    /// blocking watcher promptly instead of parking out the wait.
+    pub async fn wait_tree(&self) -> Result<crate::containment::TreeDrain, Error> {
+        self.require_drainable()?;
+        super::wait::wait_tree_drained_dispatch(&self.attached, None).await
+    }
+
+    /// Like [`wait_tree`](Child::wait_tree) but bounded by `timeout`.
+    /// `TreeDrain::MembersRemain` at expiry is not an error. A `timeout` so large it would
+    /// overflow `Instant` is treated as unbounded, matching [`wait_tree`](Child::wait_tree).
+    pub async fn wait_tree_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<crate::containment::TreeDrain, Error> {
+        self.require_drainable()?;
+        let deadline = crate::wait::deadline_from(timeout);
+        super::wait::wait_tree_drained_dispatch(&self.attached, deadline).await
+    }
 }
 
 impl Child {

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -7,6 +7,22 @@ use std::time::Duration;
 use super::Child;
 use crate::error::Error;
 
+/// The `crate::wait::fault` grace-watch seam, consumed HERE rather than inside a specific
+/// backend so it applies uniformly to whichever watch `graceful_shutdown_tree` actually
+/// performs — root-only ([`crate::tokio::wait::grace_wait`]) or whole-tree
+/// ([`crate::tokio::wait::wait_tree_drained_dispatch`]). Outside test builds the seam module
+/// does not exist at all, so this compiles to a constant `None`. Duplicated (not shared) with
+/// the sync `crate::child::graceful` twin — see this module's own fault-seam doc comment for
+/// why a shared seam is not nameable across the sync/async trees.
+#[cfg(test)]
+fn take_forced_watch_error() -> Option<Error> {
+    crate::wait::fault::take_force_watch_error().then(crate::wait::fault::forced_watch_error)
+}
+#[cfg(not(test))]
+fn take_forced_watch_error() -> Option<Error> {
+    None
+}
+
 impl Child {
     /// Send `SIGTERM` to the (lone) child — a cooperative request to exit. Signal-only: does
     /// not wait or reap. Identity-bound, so it cannot race a concurrent reap onto a recycled
@@ -60,18 +76,28 @@ impl Child {
 
     /// Cooperative-then-forced shutdown of the contained tree: send the group its graceful
     /// signal (`SIGTERM` via `killpg`/cgroup, or `CTRL_BREAK` to the job/console group), wait
-    /// up to `grace` for the **root** to exit, then hard-sweep any survivors and reap the root.
-    /// Returns the root's `ExitStatus`. Requires an actionable containment mechanism (errors
-    /// `Unsupported` otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone
-    /// child). Works on all platforms.
+    /// up to `grace`, then hard-sweep any survivors and reap the root. Returns the root's
+    /// `ExitStatus`. Requires an actionable containment mechanism (errors `Unsupported`
+    /// otherwise — use [`graceful_shutdown`](Child::graceful_shutdown) for a lone child).
+    /// Works on all platforms.
+    ///
+    /// **What the grace-wait watches depends on the mechanism.** On one with a real kernel
+    /// drain edge ([`Containment::can_observe_drain`](crate::containment::Containment::can_observe_drain)
+    /// — cgroup v2, a Windows job object, the macOS fd marker), the whole `grace` is spent
+    /// watching the *entire tree* drain, and the hard sweep below runs only if `grace` elapses
+    /// before the tree does — never on a tree that already cleared on its own. On every other
+    /// mechanism (`ProcessGroup`, `Session`, `TreeWalk`) there is no kernel edge to observe
+    /// descendants draining, so the wait watches the **root only** and the sweep always runs
+    /// afterward regardless of what it saw, exactly as before this distinction existed.
     ///
     /// **Windows: what this actually signals, and what the grace costs.** `CTRL_BREAK` goes
     /// to the root's **process group** only. A nested contained descendant leads its own
     /// group and never receives it — so it does not exit during the grace, idles through the
-    /// whole window, and is then killed by the sweep. The call reports no error either way:
-    /// on Windows the grace is spent regardless of how much of the tree the signal reached.
-    /// Size it accordingly, and treat [`kill_tree`](Child::kill_tree) as the only op that
-    /// reaches every member.
+    /// whole window, and is then killed by the sweep (a job object *is* drain-observable, so
+    /// this shows up as `grace` fully elapsing rather than draining early, not as a skipped
+    /// wait). The call reports no error either way: on Windows the grace is spent regardless
+    /// of how much of the tree the signal reached. Size it accordingly, and treat
+    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned
@@ -81,11 +107,10 @@ impl Child {
     /// but a raw `Error::Io` when the crate cannot confirm it — so treat **any** error here
     /// as "not delivered, tree still running".
     ///
-    /// The grace-wait is **non-reaping** (watches the root's exit without collecting it), so the
-    /// subsequent hard sweep runs while the root's pid — and thus the `killpg` group id — is
-    /// still valid; reaping first could let `killpg` hit a recycled group. The sweep is
-    /// unconditional but a no-op once the tree has drained, so a graceful exit's status is
-    /// preserved (the lone backstop no-ops on the already-dead root).
+    /// The grace-wait is **non-reaping** (watches exit without collecting it), so a subsequent
+    /// hard sweep runs while the root's pid — and thus the `killpg` group id — is still valid;
+    /// reaping first could let `killpg` hit a recycled group. A skipped or no-op sweep alike
+    /// preserve a graceful exit's status (the lone backstop no-ops on an already-dead root).
     ///
     /// Dropping this future mid-grace cancels the exit watch (on all platforms — the Windows
     /// watcher is released via its cancel event) and performs no further signalling — the
@@ -144,40 +169,82 @@ impl Child {
         };
 
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
-        let watch = crate::tokio::wait::grace_wait(self.id(), grace).await;
-        // The sweep is unconditional — a gracefully-exited root does NOT mean the descendants
-        // drained (the survivor-sweep scenario). A sweep Err subsumes any watch or terminate Err;
-        // it must propagate before the reap on a LIVE root (waiting unswept would hang), but once
-        // the root's exit was observed, the reap runs first so no zombie is stranded.
-        if let Err(e) = &watch {
+        //
+        // `drained`: whether the sweep below is skippable. On a drain-observable mechanism
+        // this is positive kernel-confirmed proof the WHOLE tree exited, so the sweep would be
+        // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
+        // stays `false` unconditionally and the sweep always runs, exactly as before this
+        // distinction existed. `root_exited`: whether the root specifically was observed to
+        // have exited (a drained tree implies it; otherwise it is the root-only watch's own
+        // result) — used only below, to decide whether a best-effort reap is safe after a
+        // sweep failure.
+        let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
+            (false, false, Some(e))
+        } else if self.containment().can_observe_drain() {
+            match crate::tokio::wait::wait_tree_drained_dispatch(&self.attached, crate::wait::deadline_from(grace))
+                .await
+            {
+                Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
+                Ok(crate::containment::TreeDrain::MembersRemain) => (false, false, None),
+                Err(e) => (false, false, Some(e)),
+            }
+        } else {
+            // NON-reaping grace-wait on the root only.
+            match crate::tokio::wait::grace_wait(self.id(), grace).await {
+                Ok(exited) => (false, exited, None),
+                Err(e) => (false, false, Some(e)),
+            }
+        };
+        if let Some(e) = &watch_err {
             log::debug!(
                 "graceful_shutdown_tree({id}): watch error before escalation (subsumed if it also fails): {e}",
                 id = self.id().pid()
             );
         }
-        if let Err(sweep) = self.kill_tree() {
-            if matches!(watch, Ok(true)) {
-                // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
-                // (below) is already the error this call reports, so a failure here is
-                // secondary — but every other discarded error in this module is still logged,
-                // and a silent one here would obscure a second, independent failure mode.
-                if let Err(e) = self.wait().await {
-                    log::debug!(
-                        "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
-                        id = self.id().pid()
-                    );
+        // A sweep Err subsumes any watch or terminate Err; it must propagate before the reap on
+        // a LIVE root (waiting unswept would hang), but once the root's exit was observed, the
+        // reap runs first so no zombie is stranded.
+        if !drained {
+            // The `#[cfg(test)]` arm lets a test PROVE the sweep is skipped when `drained`,
+            // not merely that it would have no-op'd: forcing this call to fail and then
+            // observing `Ok` from the whole function is only possible if this branch was
+            // never entered at all.
+            #[cfg(test)]
+            let sweep_result = if fault::take_force_kill_tree_error() {
+                Err(fault::forced_kill_tree_error())
+            } else {
+                self.kill_tree()
+            };
+            #[cfg(not(test))]
+            let sweep_result = self.kill_tree();
+            if let Err(sweep) = sweep_result {
+                if root_exited {
+                    // Best-effort reap so an observed-exited root isn't left a zombie; `sweep`
+                    // (below) is already the error this call reports, so a failure here is
+                    // secondary — but every other discarded error in this module is still logged,
+                    // and a silent one here would obscure a second, independent failure mode.
+                    if let Err(e) = self.wait().await {
+                        log::debug!(
+                            "graceful_shutdown_tree({id}): best-effort reap after a swept, exited root also failed: {e}",
+                            id = self.id().pid()
+                        );
+                    }
                 }
+                return Err(sweep);
             }
-            return Err(sweep);
         }
         let status = self.wait().await?;
-        watch?;
-        // The sweep just returned `Ok`: positive, freshly-measured proof the group cleared,
-        // superseding whatever `term` held. Discard it here rather than returning it — an
-        // already-disproved refusal must never outrank the evidence that disproved it.
+        if let Some(e) = watch_err {
+            return Err(e);
+        }
+        // The tree is confirmed clear here — either the drain watch observed the whole tree
+        // directly (`drained`), or the sweep just returned `Ok`: either way, positive,
+        // freshly-measured proof superseding whatever `term` held. Discard it here rather than
+        // returning it — an already-disproved refusal must never outrank the evidence that
+        // disproved it.
         if let Err(e) = &term {
             log::debug!(
-                "graceful_shutdown_tree({id}): sweep succeeded; discarding the superseded terminate_tree refusal: {e}",
+                "graceful_shutdown_tree({id}): tree confirmed clear; discarding the superseded terminate_tree refusal: {e}",
                 id = self.id().pid()
             );
         }
@@ -216,12 +283,29 @@ pub(crate) mod fault {
     }
     thread_local! {
         static FORCE_TERMINATE: Cell<Forced> = const { Cell::new(Forced::None) };
+        static FORCE_KILL_TREE_ERROR: Cell<bool> = const { Cell::new(false) };
     }
     pub(crate) fn set_force_terminate(kind: Forced) {
         FORCE_TERMINATE.with(|f| f.set(kind));
     }
     pub(crate) fn take_force_terminate() -> Forced {
         FORCE_TERMINATE.with(|f| f.replace(Forced::None))
+    }
+
+    /// Force the next `kill_tree` call inside `graceful_shutdown_tree` on THIS thread — the
+    /// sweep, not `terminate_tree` — to fail, so a test can prove it was skipped (`drained`)
+    /// rather than merely no-op'd on an already-empty group.
+    pub(crate) fn set_force_kill_tree_error(on: bool) {
+        FORCE_KILL_TREE_ERROR.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_kill_tree_error() -> bool {
+        FORCE_KILL_TREE_ERROR.with(|f| f.replace(false))
+    }
+    pub(crate) fn kill_tree_armed() -> bool {
+        FORCE_KILL_TREE_ERROR.with(|f| f.get())
+    }
+    pub(crate) fn forced_kill_tree_error() -> crate::error::Error {
+        crate::error::Error::Io(std::io::Error::other("forced kill_tree failure (test seam)"))
     }
     // No `armed()` here — see the sync twin's identical note.
     pub(crate) fn forced_terminate_error(kind: Forced) -> crate::error::Error {

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -175,9 +175,14 @@ impl Child {
         // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
         // stays `false` unconditionally and the sweep always runs, exactly as before this
         // distinction existed. `root_exited`: whether the root specifically was observed to
-        // have exited (a drained tree implies it; otherwise it is the root-only watch's own
-        // result) — used only below, to decide whether a best-effort reap is safe after a
-        // sweep failure.
+        // have exited. A drained tree implies it. On the root-only-watch mechanism (the `else`
+        // arm below) it is that watch's own result. On a drain-observable mechanism whose tree
+        // did NOT fully drain (`MembersRemain`) it comes from a fresh, non-blocking,
+        // zero-duration probe of the root alone, immediately below — a tree-wide `MembersRemain`
+        // verdict says nothing about the root specifically (only some OTHER member may still be
+        // alive), and the probe costs nothing extra since `grace` was already fully spent by
+        // the tree-drain watch that just returned it. Used only below, to decide whether a
+        // best-effort reap is safe after a sweep failure.
         let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
             (false, false, Some(e))
         } else if self.containment().can_observe_drain() {
@@ -185,7 +190,12 @@ impl Child {
                 .await
             {
                 Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
-                Ok(crate::containment::TreeDrain::MembersRemain) => (false, false, None),
+                Ok(crate::containment::TreeDrain::MembersRemain) => {
+                    match crate::tokio::wait::grace_wait(self.id(), Duration::ZERO).await {
+                        Ok(exited) => (false, exited, None),
+                        Err(e) => (false, false, Some(e)),
+                    }
+                }
                 Err(e) => (false, false, Some(e)),
             }
         } else {

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -170,18 +170,21 @@ impl Child {
 
         // Watch-Err ordering: sweep + reap first, then surface (see graceful_shutdown above).
         //
-        // `drained`: whether the sweep below is skippable. On a drain-observable mechanism
-        // this is positive kernel-confirmed proof the WHOLE tree exited, so the sweep would be
-        // pure overhead — skip it. On every other mechanism there is no such edge, so `drained`
-        // stays `false` unconditionally and the sweep always runs, exactly as before this
-        // distinction existed. `root_exited`: whether the root specifically was observed to
-        // have exited. A drained tree implies it. On the root-only-watch mechanism (the `else`
-        // arm below) it is that watch's own result. On a drain-observable mechanism whose tree
-        // did NOT fully drain (`MembersRemain`) it comes from a fresh, non-blocking,
-        // zero-duration probe of the root alone, immediately below — a tree-wide `MembersRemain`
-        // verdict says nothing about the root specifically (only some OTHER member may still be
-        // alive), and the probe costs nothing extra since `grace` was already fully spent by
-        // the tree-drain watch that just returned it. Used only below, to decide whether a
+        // `drained`: whether the sweep below is skippable. Only `TreeDrain::AllMembersExited`
+        // (`permits_skipping_sweep`) makes it true — positive kernel-confirmed proof the WHOLE
+        // tree exited, from a mechanism a live process cannot leave without exiting, so the
+        // sweep would be pure overhead. `AllMarkersClosed` (the macOS marker's advisory pipe
+        // EOF — see `TreeDrain`'s own doc) is NOT that proof: a live process can close its own
+        // copy of the marker descriptor and remain alive, undetectable by this edge alone, so
+        // it falls into the same "always sweep" bucket as `MembersRemain` and every mechanism
+        // with no drain edge at all. `root_exited`: whether the root specifically was observed
+        // to have exited. A skipped-sweep tree implies it. On the root-only-watch mechanism
+        // (the `else` arm below) it is that watch's own result. Everywhere else it comes from a
+        // fresh, non-blocking, zero-duration probe of the root alone, immediately below — a
+        // tree-wide verdict that isn't sufficient to skip the sweep says nothing about the root
+        // specifically (only some OTHER member may still be alive), and the probe costs nothing
+        // extra since `grace` was already fully spent by the tree-drain watch that just
+        // returned it. Used only below, to decide whether a
         // best-effort reap is safe after a sweep failure.
         let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
             (false, false, Some(e))
@@ -189,13 +192,13 @@ impl Child {
             match crate::tokio::wait::wait_tree_drained_dispatch(&self.attached, crate::wait::deadline_from(grace))
                 .await
             {
-                Ok(crate::containment::TreeDrain::AllMembersExited) => (true, true, None),
-                Ok(crate::containment::TreeDrain::MembersRemain) => {
-                    match crate::tokio::wait::grace_wait(self.id(), Duration::ZERO).await {
-                        Ok(exited) => (false, exited, None),
-                        Err(e) => (false, false, Some(e)),
-                    }
-                }
+                Ok(verdict) if verdict.permits_skipping_sweep() => (true, true, None),
+                // Not sufficient proof alone to skip the sweep (see the doc above) — fall back
+                // to the fresh, non-blocking, zero-duration root probe described there.
+                Ok(_) => match crate::tokio::wait::grace_wait(self.id(), Duration::ZERO).await {
+                    Ok(exited) => (false, exited, None),
+                    Err(e) => (false, false, Some(e)),
+                },
                 Err(e) => (false, false, Some(e)),
             }
         } else {
@@ -316,6 +319,23 @@ pub(crate) mod fault {
     }
     pub(crate) fn forced_kill_tree_error() -> crate::error::Error {
         crate::error::Error::Io(std::io::Error::other("forced kill_tree failure (test seam)"))
+    }
+
+    /// RAII disarm for `FORCE_KILL_TREE_ERROR` — see the sync twin's identical guard for the
+    /// full rationale (a test harness thread is reused across test functions, so a seam armed
+    /// but never consumed must still be cleared even if this test's own assertions panic first).
+    #[must_use]
+    pub(crate) struct ArmedKillTreeError;
+    impl ArmedKillTreeError {
+        pub(crate) fn arm() -> Self {
+            set_force_kill_tree_error(true);
+            Self
+        }
+    }
+    impl Drop for ArmedKillTreeError {
+        fn drop(&mut self) {
+            set_force_kill_tree_error(false);
+        }
     }
     // No `armed()` here — see the sync twin's identical note.
     pub(crate) fn forced_terminate_error(kind: Forced) -> crate::error::Error {

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -311,26 +311,28 @@ async fn async_graceful_tree_members_remain_still_reaps_an_already_exited_root()
 
 // Async twin of `windows_graceful_tree_members_remain_still_reaps_an_already_exited_root` — see
 // there for the full rationale, including the `test_child::fixture_survives_group_signal`
-// fixture that plays the Unix root shell's role.
+// fixture that plays the Unix root shell's role and why the readiness tag travels over a raw
+// TCP socket rather than stdout. Blocking `std::net::TcpListener` (not an async socket), exactly
+// like `tests/common::spawn_tree_async`'s own synchronous accept — a short, bounded wait for a
+// real connection, not a poll loop, and the same shape already accepted for an async test.
 #[cfg(windows)]
 #[tokio::test]
 async fn windows_async_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
-    use tokio::io::AsyncReadExt;
+    use std::io::Read;
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind readiness listener");
+    let addr = listener.local_addr().expect("local_addr").to_string();
 
     let mut cmd = crate::tokio::Command::new();
     cmd.executable(std::env::current_exe().expect("current_exe"))
         .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
-    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ENV, "1");
-    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV, addr);
     cmd.contain();
     let mut child = cmd.spawn().expect("spawn");
-    let mut readiness = [0u8; 1];
-    child
-        .stdout()
-        .expect("piped stdout")
-        .read_exact(&mut readiness)
-        .await
-        .expect("readiness byte");
+    let (mut sock, _) = listener.accept().expect("accept readiness connection");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("readiness tag");
     let id = child.id();
     let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -214,10 +214,10 @@ async fn async_graceful_tree_unassessable_mechanism_failure_fails_fast() {
     let _ = child.wait().await;
 }
 
-// Async twin of `graceful_tree_drained_skips_sweep_when_mechanism_allows` — see there for the
-// full rationale.
+// Async twin of `graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative` —
+// see there for the full rationale.
 #[tokio::test]
-async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
+async fn async_graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() {
     let mut cmd = crate::tokio::Command::new();
     #[cfg(unix)]
     cmd.args(["sleep", "30"]);
@@ -225,15 +225,19 @@ async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
     cmd.args(["ping", "-n", "30", "127.0.0.1"]);
     cmd.contain();
     let mut child = cmd.spawn().expect("spawn");
-    let drainable = child.containment().can_observe_drain();
-    term_fault::set_force_kill_tree_error(true);
+    let authoritative = matches!(
+        child.containment(),
+        crate::containment::Containment::CgroupV2 | crate::containment::Containment::JobObject
+    );
+    let armed = term_fault::ArmedKillTreeError::arm();
     let result = child.graceful_shutdown_tree(Duration::from_secs(30)).await;
-    if drainable {
-        let status = result.expect("a fully-drained tree must not invoke the sweep at all");
+    if authoritative {
+        let status = result.expect("an authoritatively-drained tree must not invoke the sweep at all");
         assert!(
             term_fault::kill_tree_armed(),
             "the forced kill_tree failure must still be armed — the sweep was never entered"
         );
+        drop(armed); // disarm now that this branch's own assertion above has run
         #[cfg(unix)]
         {
             use std::os::unix::process::ExitStatusExt;
@@ -246,11 +250,12 @@ async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
         #[cfg(windows)]
         let _ = status;
     } else {
-        let err = result.expect_err("a non-drainable mechanism must always run the sweep");
+        let err = result.expect_err("a non-authoritative mechanism must always run the sweep");
         assert!(
             !term_fault::kill_tree_armed(),
             "the sweep must have consumed the forced-failure seam"
         );
+        drop(armed); // already disarmed by the sweep above; this is a no-op, kept for symmetry
         assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
         let _ = child.kill_tree(); // cleanup: the forced failure means the real sweep never ran
         let _ = child.wait().await;
@@ -258,14 +263,25 @@ async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
 }
 
 // Async twin of `graceful_tree_members_remain_still_reaps_an_already_exited_root` — see there
-// for the full rationale.
+// for the full rationale, including the readiness handshake that closes the root's own
+// trap-installation race.
 #[cfg(unix)]
 #[tokio::test]
 async fn async_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    use tokio::io::AsyncReadExt;
+
     let mut cmd = crate::tokio::Command::new();
-    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & exit 0"]);
+    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & echo r; exit 0"]);
+    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
     cmd.contain();
     let mut child = cmd.spawn().expect("spawn");
+    let mut readiness = [0u8; 1];
+    child
+        .stdout()
+        .expect("piped stdout")
+        .read_exact(&mut readiness)
+        .await
+        .expect("readiness byte");
     let id = child.id();
     let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);
@@ -283,12 +299,61 @@ async fn async_graceful_tree_members_remain_still_reaps_an_already_exited_root()
         crate::identity::Existence::Gone,
         "an already-exited root must be best-effort reaped even when the sweep fails ({})",
         if drainable {
-            "MembersRemain branch — the #62 round-2 fix"
+            "MembersRemain branch"
         } else {
             "non-drain-observable fallback branch — pre-existing, unaffected behavior"
         }
     );
     // Cleanup: the forced sweep failure was a stub, so the SIGTERM-ignoring descendant is
+    // still alive — a real sweep now (the seam is already consumed) actually kills it.
+    let _ = child.kill_tree();
+}
+
+// Async twin of `windows_graceful_tree_members_remain_still_reaps_an_already_exited_root` — see
+// there for the full rationale, including the `test_child::fixture_survives_group_signal`
+// fixture that plays the Unix root shell's role.
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_async_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    use tokio::io::AsyncReadExt;
+
+    let mut cmd = crate::tokio::Command::new();
+    cmd.executable(std::env::current_exe().expect("current_exe"))
+        .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
+    cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ENV, "1");
+    cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let mut readiness = [0u8; 1];
+    child
+        .stdout()
+        .expect("piped stdout")
+        .read_exact(&mut readiness)
+        .await
+        .expect("readiness byte");
+    let id = child.id();
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let err = child
+        .graceful_shutdown_tree(Duration::from_secs(2))
+        .await
+        .expect_err("the forced sweep failure must surface");
+    assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+    assert!(
+        !term_fault::kill_tree_armed(),
+        "the sweep must have consumed the forced-failure seam"
+    );
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
+        if drainable {
+            "MembersRemain branch"
+        } else {
+            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
+        }
+    );
+    // Cleanup: the forced sweep failure was a stub, so the group-signal-immune descendant is
     // still alive — a real sweep now (the seam is already consumed) actually kills it.
     let _ = child.kill_tree();
 }

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -257,6 +257,42 @@ async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
     }
 }
 
+// Async twin of `graceful_tree_members_remain_still_reaps_an_already_exited_root` — see there
+// for the full rationale.
+#[cfg(unix)]
+#[tokio::test]
+async fn async_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+    let mut cmd = crate::tokio::Command::new();
+    cmd.args(["sh", "-c", "trap '' TERM; sleep 30 & exit 0"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let err = child
+        .graceful_shutdown_tree(Duration::from_secs(2))
+        .await
+        .expect_err("the forced sweep failure must surface");
+    assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+    assert!(
+        !term_fault::kill_tree_armed(),
+        "the sweep must have consumed the forced-failure seam"
+    );
+    assert_eq!(
+        id.exists(),
+        crate::identity::Existence::Gone,
+        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
+        if drainable {
+            "MembersRemain branch — the #62 round-2 fix"
+        } else {
+            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
+        }
+    );
+    // Cleanup: the forced sweep failure was a stub, so the SIGTERM-ignoring descendant is
+    // still alive — a real sweep now (the seam is already consumed) actually kills it.
+    let _ = child.kill_tree();
+}
+
 // Async twin of `graceful_tree_non_containment_terminate_error_fails_fast`.
 #[tokio::test]
 async fn async_graceful_tree_non_containment_terminate_error_fails_fast() {

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -120,7 +120,7 @@ async fn async_graceful_tree_terminate_refusal_still_sweeps_and_reaps() {
         crate::log_capture::contains_since(
             mark,
             &format!(
-                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                "graceful_shutdown_tree({pid}): tree confirmed clear; discarding the superseded terminate_tree refusal",
                 pid = id.pid()
             )
         ),
@@ -168,7 +168,7 @@ async fn async_graceful_tree_unassessable_per_member_still_sweeps_and_reaps() {
         crate::log_capture::contains_since(
             mark,
             &format!(
-                "graceful_shutdown_tree({pid}): sweep succeeded; discarding the superseded terminate_tree refusal",
+                "graceful_shutdown_tree({pid}): tree confirmed clear; discarding the superseded terminate_tree refusal",
                 pid = id.pid()
             )
         ),
@@ -212,6 +212,49 @@ async fn async_graceful_tree_unassessable_mechanism_failure_fails_fast() {
     // Clean up: the child is still running by design (no sweep happened above).
     let _ = child.kill_tree();
     let _ = child.wait().await;
+}
+
+// Async twin of `graceful_tree_drained_skips_sweep_when_mechanism_allows` — see there for the
+// full rationale.
+#[tokio::test]
+async fn async_graceful_tree_drained_skips_sweep_when_mechanism_allows() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let drainable = child.containment().can_observe_drain();
+    term_fault::set_force_kill_tree_error(true);
+    let result = child.graceful_shutdown_tree(Duration::from_secs(30)).await;
+    if drainable {
+        let status = result.expect("a fully-drained tree must not invoke the sweep at all");
+        assert!(
+            term_fault::kill_tree_armed(),
+            "the forced kill_tree failure must still be armed — the sweep was never entered"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            assert_eq!(
+                status.signal(),
+                Some(libc::SIGTERM),
+                "graceful root exit, got {status:?}"
+            );
+        }
+        #[cfg(windows)]
+        let _ = status;
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must always run the sweep");
+        assert!(
+            !term_fault::kill_tree_armed(),
+            "the sweep must have consumed the forced-failure seam"
+        );
+        assert!(matches!(err, crate::error::Error::Io(_)), "got {err:?}");
+        let _ = child.kill_tree(); // cleanup: the forced failure means the real sweep never ran
+        let _ = child.wait().await;
+    }
 }
 
 // Async twin of `graceful_tree_non_containment_terminate_error_fails_fast`.

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -309,15 +309,17 @@ async fn async_graceful_tree_members_remain_still_reaps_an_already_exited_root()
     let _ = child.kill_tree();
 }
 
-// Async twin of `windows_graceful_tree_members_remain_still_reaps_an_already_exited_root` — see
-// there for the full rationale, including the `test_child::fixture_survives_group_signal`
-// fixture that plays the Unix root shell's role and why the readiness tag travels over a raw
+// Async twin of `windows_graceful_tree_members_remain_surfaces_the_forced_sweep_failure` — see
+// there for the full rationale, including why the Unix twin's reap postcondition does not
+// translate to Windows (no Windows-observable difference between the fixed code and the bug it
+// was meant to catch, so none is asserted here), the `test_child::fixture_survives_group_signal`
+// fixture that plays the Unix root shell's role, and why the readiness tag travels over a raw
 // TCP socket rather than stdout. Blocking `std::net::TcpListener` (not an async socket), exactly
 // like `tests/common::spawn_tree_async`'s own synchronous accept — a short, bounded wait for a
 // real connection, not a poll loop, and the same shape already accepted for an async test.
 #[cfg(windows)]
 #[tokio::test]
-async fn windows_async_graceful_tree_members_remain_still_reaps_an_already_exited_root() {
+async fn windows_async_graceful_tree_members_remain_surfaces_the_forced_sweep_failure() {
     use std::io::Read;
     use std::net::TcpListener;
 
@@ -333,8 +335,6 @@ async fn windows_async_graceful_tree_members_remain_still_reaps_an_already_exite
     let (mut sock, _) = listener.accept().expect("accept readiness connection");
     let mut tag = [0u8; 1];
     sock.read_exact(&mut tag).expect("readiness tag");
-    let id = child.id();
-    let drainable = child.containment().can_observe_drain();
     term_fault::set_force_kill_tree_error(true);
     let err = child
         .graceful_shutdown_tree(Duration::from_secs(2))
@@ -344,16 +344,6 @@ async fn windows_async_graceful_tree_members_remain_still_reaps_an_already_exite
     assert!(
         !term_fault::kill_tree_armed(),
         "the sweep must have consumed the forced-failure seam"
-    );
-    assert_eq!(
-        id.exists(),
-        crate::identity::Existence::Gone,
-        "an already-exited root must be best-effort reaped even when the sweep fails ({})",
-        if drainable {
-            "MembersRemain branch"
-        } else {
-            "non-drain-observable fallback branch — pre-existing, unaffected behavior"
-        }
     );
     // Cleanup: the forced sweep failure was a stub, so the group-signal-immune descendant is
     // still alive — a real sweep now (the seam is already consumed) actually kills it.

--- a/src/tokio/child_wait_tree_tests.rs
+++ b/src/tokio/child_wait_tree_tests.rs
@@ -1,8 +1,19 @@
 //! Async twin of `src/child/lifecycle_tests.rs` — unit tests for the public async
-//! `Child::wait_tree`/`wait_tree_timeout` (`#62` round-2 review, item 4 — previously zero
-//! coverage). See the sync twin for the full per-test rationale.
+//! `Child::wait_tree`/`wait_tree_timeout`. See the sync twin for the full per-test rationale.
 
 use std::time::Duration;
+
+/// The `TreeDrain` variant a fully-drained tree reports on `containment`'s mechanism:
+/// `AllMembersExited` everywhere authoritative (cgroup v2, Windows job object), but
+/// `AllMarkersClosed` on macOS's advisory fd marker — see `TreeDrain`'s own doc for why the two
+/// are not interchangeable. Centralized here so every test below asserts the SAME real,
+/// mechanism-correct verdict rather than assuming the authoritative one everywhere.
+fn expected_drained_verdict(containment: crate::containment::Containment) -> crate::containment::TreeDrain {
+    match containment {
+        crate::containment::Containment::FdMarker => crate::containment::TreeDrain::AllMarkersClosed,
+        _ => crate::containment::TreeDrain::AllMembersExited,
+    }
+}
 
 fn quick_contained_cmd() -> crate::tokio::Command {
     let mut cmd = crate::tokio::Command::new();
@@ -25,15 +36,16 @@ fn long_lived_contained_cmd() -> crate::tokio::Command {
 }
 
 #[tokio::test]
-async fn async_wait_tree_reports_all_members_exited_when_the_tree_drains() {
+async fn async_wait_tree_reports_the_drained_verdict_when_the_tree_drains() {
     let mut cmd = quick_contained_cmd();
     let mut child = cmd.spawn().expect("spawn");
-    let drainable = child.containment().can_observe_drain();
+    let containment = child.containment();
+    let drainable = containment.can_observe_drain();
     let result = child.wait_tree().await;
     if drainable {
         assert_eq!(
-            result.expect("a fully-exited tree must report AllMembersExited"),
-            crate::containment::TreeDrain::AllMembersExited
+            result.expect("a fully-exited tree must report a drained verdict"),
+            expected_drained_verdict(containment)
         );
     } else {
         let err = result.expect_err("a non-drainable mechanism must refuse wait_tree");
@@ -61,6 +73,58 @@ async fn async_wait_tree_timeout_reports_members_remain_before_the_deadline() {
     let _ = child.wait().await;
 }
 
+/// Async twin of `wait_tree_timeout_zero_reports_members_remain_on_a_live_tree` — see there for
+/// the full rationale.
+#[tokio::test]
+async fn async_wait_tree_timeout_zero_reports_members_remain_on_a_live_tree() {
+    let mut cmd = long_lived_contained_cmd();
+    let mut child = cmd.spawn().expect("spawn");
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree_timeout(Duration::ZERO).await;
+    if drainable {
+        assert_eq!(
+            result.expect("a ZERO probe against a live tree must not be an error"),
+            crate::containment::TreeDrain::MembersRemain
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree_timeout");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    let _ = child.kill_tree();
+    let _ = child.wait().await;
+}
+
+/// Async twin of `wait_tree_timeout_zero_reports_the_drained_verdict_after_the_tree_has_already_drained`
+/// — see there for the full rationale.
+#[tokio::test]
+async fn async_wait_tree_timeout_zero_reports_the_drained_verdict_after_the_tree_has_already_drained() {
+    let mut cmd = quick_contained_cmd();
+    let mut child = cmd.spawn().expect("spawn");
+    let containment = child.containment();
+    let drainable = containment.can_observe_drain();
+    let first = child.wait_tree().await;
+    if drainable {
+        first.expect("a fully-exited tree must report a drained verdict");
+        assert_eq!(
+            child
+                .wait_tree_timeout(Duration::ZERO)
+                .await
+                .expect("a ZERO probe against an already-drained tree must not be an error"),
+            expected_drained_verdict(containment),
+            "a ZERO probe must observe the SAME drained state an unbounded wait already found, \
+             not report MembersRemain just because the deadline is already past"
+        );
+    } else {
+        first.expect_err("a non-drainable mechanism must refuse wait_tree");
+        let err = child.wait_tree_timeout(Duration::ZERO).await;
+        assert!(
+            matches!(err, Err(crate::error::Error::Unsupported { .. })),
+            "got {err:?}"
+        );
+    }
+    let _ = child.wait().await;
+}
+
 /// See the sync twin's identical test for the full rationale, including why this cannot be a
 /// single unconditional assertion (macOS promotes every contained root's mechanism to the
 /// drainable fd marker regardless of the requested mode).
@@ -73,12 +137,13 @@ async fn async_wait_tree_is_unsupported_on_a_non_drainable_mechanism() {
     cmd.args(["cmd", "/C", "exit 0"]);
     cmd.contain_with(crate::ContainMode::TreeWalk);
     let mut treewalk_child = cmd.spawn().expect("spawn");
-    let drainable = treewalk_child.containment().can_observe_drain();
+    let containment = treewalk_child.containment();
+    let drainable = containment.can_observe_drain();
     let result = treewalk_child.wait_tree_timeout(Duration::from_millis(200)).await;
     if drainable {
         assert_eq!(
             result.expect("macOS promotes an explicit TreeWalk request to the drainable fd marker"),
-            crate::containment::TreeDrain::AllMembersExited,
+            expected_drained_verdict(containment),
             "a quick-exiting tree must still be observed as drained through the promoted mechanism"
         );
     } else {

--- a/src/tokio/child_wait_tree_tests.rs
+++ b/src/tokio/child_wait_tree_tests.rs
@@ -1,0 +1,94 @@
+//! Async twin of `src/child/lifecycle_tests.rs` — unit tests for the public async
+//! `Child::wait_tree`/`wait_tree_timeout` (`#62` round-2 review, item 4 — previously zero
+//! coverage). See the sync twin for the full per-test rationale.
+
+use std::time::Duration;
+
+fn quick_contained_cmd() -> crate::tokio::Command {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["true"]);
+    #[cfg(windows)]
+    cmd.args(["cmd", "/C", "exit 0"]);
+    cmd.contain();
+    cmd
+}
+
+fn long_lived_contained_cmd() -> crate::tokio::Command {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["sleep", "30"]);
+    #[cfg(windows)]
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    cmd
+}
+
+#[tokio::test]
+async fn async_wait_tree_reports_all_members_exited_when_the_tree_drains() {
+    let mut cmd = quick_contained_cmd();
+    let mut child = cmd.spawn().expect("spawn");
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree().await;
+    if drainable {
+        assert_eq!(
+            result.expect("a fully-exited tree must report AllMembersExited"),
+            crate::containment::TreeDrain::AllMembersExited
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    let _ = child.wait().await;
+}
+
+#[tokio::test]
+async fn async_wait_tree_timeout_reports_members_remain_before_the_deadline() {
+    let mut cmd = long_lived_contained_cmd();
+    let mut child = cmd.spawn().expect("spawn");
+    let drainable = child.containment().can_observe_drain();
+    let result = child.wait_tree_timeout(Duration::from_millis(200)).await;
+    if drainable {
+        assert_eq!(
+            result.expect("an unmet deadline on a live tree must not be an error"),
+            crate::containment::TreeDrain::MembersRemain
+        );
+    } else {
+        let err = result.expect_err("a non-drainable mechanism must refuse wait_tree_timeout");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+    }
+    let _ = child.kill_tree();
+    let _ = child.wait().await;
+}
+
+/// See the sync twin's identical test for the full rationale, including why this cannot be a
+/// single unconditional assertion (macOS promotes every contained root's mechanism to the
+/// drainable fd marker regardless of the requested mode).
+#[tokio::test]
+async fn async_wait_tree_is_unsupported_on_a_non_drainable_mechanism() {
+    let mut cmd = crate::tokio::Command::new();
+    #[cfg(unix)]
+    cmd.args(["true"]);
+    #[cfg(windows)]
+    cmd.args(["cmd", "/C", "exit 0"]);
+    cmd.contain_with(crate::ContainMode::TreeWalk);
+    let mut treewalk_child = cmd.spawn().expect("spawn");
+    let drainable = treewalk_child.containment().can_observe_drain();
+    let result = treewalk_child.wait_tree_timeout(Duration::from_millis(200)).await;
+    if drainable {
+        assert_eq!(
+            result.expect("macOS promotes an explicit TreeWalk request to the drainable fd marker"),
+            crate::containment::TreeDrain::AllMembersExited,
+            "a quick-exiting tree must still be observed as drained through the promoted mechanism"
+        );
+    } else {
+        let err = result.expect_err("TreeWalk, honored as requested, has no kernel drain edge");
+        assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+        let err2 = treewalk_child
+            .wait_tree()
+            .await
+            .expect_err("TreeWalk, honored as requested, has no kernel drain edge");
+        assert!(matches!(err2, crate::error::Error::Unsupported { .. }), "got {err2:?}");
+    }
+    let _ = treewalk_child.wait().await;
+}

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -284,11 +284,11 @@ pub(crate) async fn wait_tree_deadline(
     match crate::wait::remaining(deadline) {
         None => {
             wait_tree_drained(read_end).await?;
-            Ok(TreeDrain::AllMembersExited)
+            Ok(TreeDrain::AllMarkersClosed)
         }
         Some(d) if d.is_zero() => crate::containment::marker_eof::probe(read_end),
         Some(d) => match ::tokio::time::timeout(d, wait_tree_drained(read_end)).await {
-            Ok(res) => res.map(|()| TreeDrain::AllMembersExited),
+            Ok(res) => res.map(|()| TreeDrain::AllMarkersClosed),
             Err(_elapsed) => Ok(TreeDrain::MembersRemain),
         },
     }
@@ -338,14 +338,12 @@ async fn cgroup_wait_tree_drained(
     leaf: &crate::containment::cgroup::CgroupLeaf,
     deadline: Option<Option<std::time::Instant>>,
 ) -> Result<crate::containment::TreeDrain, Error> {
-    use std::io::{Read, Seek, SeekFrom};
-
     use ::tokio::io::unix::AsyncFd;
     use ::tokio::io::Interest;
 
     use crate::containment::TreeDrain;
 
-    use crate::containment::cgroup::removed_after_drain;
+    use crate::containment::cgroup::{read_populated, removed_after_drain};
 
     let file = match std::fs::File::open(leaf.events_path()) {
         Ok(f) => f,
@@ -355,37 +353,14 @@ async fn cgroup_wait_tree_drained(
     let mut afd = AsyncFd::with_interest(file, Interest::PRIORITY).map_err(Error::Io)?;
     let mut buf = String::new();
     loop {
-        buf.clear();
         // Mirrors `CgroupLeaf::wait_drained`'s own leaf-removal race handling exactly (see its
-        // doc): `rmdir` on this leaf — `Drop`'s own retry, or an external cgroup manager's
-        // cleanup of an already-empty leaf — can land between this loop's own `ready()` wakeup
-        // and its next read, and observing that removal is itself proof every member had
-        // already exited (rmdir cannot precede full drain), not a failure.
-        {
-            let f = afd.get_mut();
-            if let Err(e) = f.seek(SeekFrom::Start(0)) {
-                return if removed_after_drain(&e) {
-                    Ok(TreeDrain::AllMembersExited)
-                } else {
-                    Err(Error::Io(e))
-                };
-            }
-            if let Err(e) = f.read_to_string(&mut buf) {
-                return if removed_after_drain(&e) {
-                    Ok(TreeDrain::AllMembersExited)
-                } else {
-                    Err(Error::Io(e))
-                };
-            }
-        }
-        match crate::containment::cgroup::parse_populated(&buf) {
-            Some(false) => return Ok(TreeDrain::AllMembersExited),
-            Some(true) => {}
-            None => {
-                return Err(Error::Io(std::io::Error::other(
-                    "cgroup.events has no 'populated' field — unexpected kernel format",
-                )))
-            }
+        // doc, and `read_populated`'s own): `rmdir` on this leaf — `Drop`'s own retry, or an
+        // external cgroup manager's cleanup of an already-empty leaf — can land between this
+        // loop's own `ready()` wakeup and its next read, and observing that removal is itself
+        // proof every member had already exited (rmdir cannot precede full drain), not a
+        // failure.
+        if !read_populated(afd.get_mut(), &mut buf)? {
+            return Ok(TreeDrain::AllMembersExited);
         }
         let remaining = crate::wait::remaining(deadline);
         if remaining == Some(std::time::Duration::ZERO) {
@@ -409,18 +384,29 @@ async fn cgroup_wait_tree_drained(
 /// Job objects expose no pollable handle, so — unlike the Linux/macOS arms in this file — this
 /// is NOT reactor-native: it hands the sync `JobHandle::wait_drained` loop to `spawn_blocking`,
 /// releasing the blocking thread promptly on drop via the same cancel-event idiom
-/// `blocking_watch` uses for `grace_wait`. Only the raw `HANDLE` value (`Copy`, `Send`) crosses
-/// into the blocking closure — `JobHandle` itself is never moved there — because the closure
-/// must be `'static` while `JobHandle` is only borrowed. This is sound because the caller
-/// (`wait_tree_drained`, transitively `tokio::Child::wait_tree`/`wait_tree_timeout`) holds
-/// `&Child` — and so `&JobHandle` — across this entire `.await`, so the job handle cannot be
-/// closed while the blocking task runs.
+/// `blocking_watch` uses for `grace_wait`.
+///
+/// **Handle ownership across cancellation.** `blocking_watch` gets away with borrowing nothing
+/// at all — it re-derives a process handle from a `ProcessId` inside the closure. A job object
+/// has no such re-openable identity, so this function instead duplicates the live job `HANDLE`
+/// into one the spawned task owns outright (`DuplicateHandle`, closed by the closure itself on
+/// every exit path, panic included) before ever spawning. This matters because dropping THIS
+/// future only cancels the `.await` — it does not join the blocking task, which keeps running
+/// detached. A caller cancelling the `wait_tree`/`wait_tree_timeout` future (via `select!`, an
+/// outer `timeout()`, or simply not polling it again) can therefore race `JobHandle::hard_kill`/
+/// `Drop` closing the ORIGINAL handle while the detached task is still mid-syscall on it. A
+/// borrowed raw `HANDLE` would then alias a handle value the kernel is free to recycle onto an
+/// unrelated object the moment it is closed; the duplicate has its own independent lifetime,
+/// closed only by the task that owns it, and is never touched by `JobHandle` at all — so no
+/// such aliasing is possible regardless of what the caller does with the `Child` after
+/// cancelling.
 #[cfg(windows)]
 async fn job_wait_tree_drained(
     job: &crate::containment::windows::JobHandle,
     deadline: Option<Option<std::time::Instant>>,
 ) -> Result<crate::containment::TreeDrain, Error> {
-    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Foundation::{CloseHandle, DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
+    use windows::Win32::System::Threading::GetCurrentProcess;
 
     // Duration::ZERO delegates to the sync one-shot probe — no thread-pool hop needed for a
     // call that cannot block (mirrors grace_wait's identical delegation).
@@ -430,19 +416,43 @@ async fn job_wait_tree_drained(
     let Some(raw_job) = job.as_handle() else {
         // Mirrors `JobHandle::wait_drained`'s own early return exactly (this function only
         // reaches here once that method's Duration::ZERO delegation above has already been
-        // ruled out): the job handle was already consumed, so there is no live handle left to
-        // re-enumerate or open member handles from, and `TerminateJobObject`/`CloseHandle` are
-        // not documented as synchronous with member process teardown. Reporting
-        // `AllMembersExited` here would be a guess, not a live-checked verdict — see that
-        // method's doc and inline comment for the full justification.
-        return Err(Error::Unassessable {
-            detail: "the job handle was already closed (kill_tree()/hard_kill(), or the Child \
-                     was dropped) before this drain check ran; whether every member has \
-                     actually finished exiting can no longer be observed"
-                .into(),
-            source: None,
-        });
+        // ruled out) — see `consumed_job_handle_error`'s own doc for the full justification.
+        return Err(crate::containment::windows::consumed_job_handle_error());
     };
+
+    /// An independently-owned duplicate of the job handle, held only by the spawned blocking
+    /// task and closed by it on every exit path, panic included — see this function's own doc
+    /// for why a borrowed handle is not safe to hand across the cancellation boundary here.
+    /// Closing a job handle only fires `KILL_ON_JOB_CLOSE` if it is the LAST open handle to
+    /// that job (Win32 semantics); `JobHandle`'s own, separate handle is unaffected either way.
+    struct OwnedJobDup(HANDLE);
+    impl Drop for OwnedJobDup {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is this struct's own `DuplicateHandle`-created handle, never
+            // shared or aliased anywhere else.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+    let mut dup = HANDLE::default();
+    // SAFETY: `raw_job` was just confirmed live via `job.as_handle()` above. Duplicating
+    // within our own process with `DUPLICATE_SAME_ACCESS` produces an independent handle to
+    // the same job object, valid for the spawned task's full lifetime regardless of what
+    // happens to `job`/`JobHandle` afterward.
+    unsafe {
+        DuplicateHandle(
+            GetCurrentProcess(),
+            raw_job,
+            GetCurrentProcess(),
+            &mut dup,
+            0,
+            false,
+            DUPLICATE_SAME_ACCESS,
+        )
+    }
+    .map_err(|e| Error::Io(std::io::Error::from(e)))?;
+    let job_dup = OwnedJobDup(dup);
 
     /// Signals the cancel event on drop (harmless after completion) so the blocking watcher
     /// releases promptly instead of parking out the deadline, and `Runtime::drop` — which
@@ -460,24 +470,27 @@ async fn job_wait_tree_drained(
     let cancel_raw = HANDLE(std::os::windows::io::AsRawHandle::as_raw_handle(&*cancel));
     let cancel_for_blocking = cancel.clone();
 
-    /// `HANDLE`'s raw pointer is `!Send` by default; a job or event handle is sound to use
-    /// from another thread (the kernel serialises handle operations) — the same justification
-    /// as `JobHandle`'s own `unsafe impl Send`.
+    /// `HANDLE`'s raw pointer is `!Send` by default; a job or event handle (owned or borrowed
+    /// for the task's own full lifetime) is sound to use and close from another thread — the
+    /// kernel serialises handle operations — the same justification as `JobHandle`'s own
+    /// `unsafe impl Send`.
     struct SendHandles {
-        job: HANDLE,
+        job: OwnedJobDup,
         cancel: HANDLE,
     }
     unsafe impl Send for SendHandles {}
     let handles = SendHandles {
-        job: raw_job,
+        job: job_dup,
         cancel: cancel_raw,
     };
 
     let joined = ::tokio::task::spawn_blocking(move || {
         let handles = handles;
-        let result = crate::containment::windows::wait_drained_raw(handles.job, deadline, Some(handles.cancel));
+        let result = crate::containment::windows::wait_drained_raw(handles.job.0, deadline, Some(handles.cancel));
         drop(cancel_for_blocking); // keep the handle alive for the full blocking call, explicitly
         result
+        // `handles.job` (`OwnedJobDup`) drops here on every path, including an early return
+        // from `wait_drained_raw` above, closing our duplicate independently of `JobHandle`.
     })
     .await;
     match joined {
@@ -510,7 +523,19 @@ pub(crate) async fn wait_tree_drained_dispatch(
         #[cfg(windows)]
         crate::containment::Attached::JobObject(job) => job_wait_tree_drained(job, deadline).await,
         #[cfg(target_os = "macos")]
-        crate::containment::Attached::FdMarker(m) => wait_tree_deadline(m.read_end(), deadline).await,
+        crate::containment::Attached::FdMarker(m) => {
+            // Mirrors `Marker::wait_drained`'s own preamble exactly: a reissued read-end fd
+            // would falsely deliver `EV_EOF` instantly here just as readily as it would there,
+            // so this path must not skip the check just because it reads the raw fd directly
+            // instead of going through `Marker::wait_drained`.
+            m.check_read_end_still_valid()?;
+            debug_assert_ne!(
+                crate::containment::marker_eof::write_end_check(m.read_end()),
+                crate::containment::marker_eof::WriteEndCheck::HeldByUs,
+                "the supervisor still holds a copy of the marker write end - the tree-drain edge can never fire"
+            );
+            wait_tree_deadline(m.read_end(), deadline).await
+        }
         other => other.wait_drained(deadline),
     }
 }

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -345,15 +345,38 @@ async fn cgroup_wait_tree_drained(
 
     use crate::containment::TreeDrain;
 
-    let file = std::fs::File::open(leaf.events_path()).map_err(Error::Io)?;
+    use crate::containment::cgroup::removed_after_drain;
+
+    let file = match std::fs::File::open(leaf.events_path()) {
+        Ok(f) => f,
+        Err(e) if removed_after_drain(&e) => return Ok(TreeDrain::AllMembersExited),
+        Err(e) => return Err(Error::Io(e)),
+    };
     let mut afd = AsyncFd::with_interest(file, Interest::PRIORITY).map_err(Error::Io)?;
     let mut buf = String::new();
     loop {
         buf.clear();
+        // Mirrors `CgroupLeaf::wait_drained`'s own leaf-removal race handling exactly (see its
+        // doc): `rmdir` on this leaf — `Drop`'s own retry, or an external cgroup manager's
+        // cleanup of an already-empty leaf — can land between this loop's own `ready()` wakeup
+        // and its next read, and observing that removal is itself proof every member had
+        // already exited (rmdir cannot precede full drain), not a failure.
         {
             let f = afd.get_mut();
-            f.seek(SeekFrom::Start(0)).map_err(Error::Io)?;
-            f.read_to_string(&mut buf).map_err(Error::Io)?;
+            if let Err(e) = f.seek(SeekFrom::Start(0)) {
+                return if removed_after_drain(&e) {
+                    Ok(TreeDrain::AllMembersExited)
+                } else {
+                    Err(Error::Io(e))
+                };
+            }
+            if let Err(e) = f.read_to_string(&mut buf) {
+                return if removed_after_drain(&e) {
+                    Ok(TreeDrain::AllMembersExited)
+                } else {
+                    Err(Error::Io(e))
+                };
+            }
         }
         match crate::containment::cgroup::parse_populated(&buf) {
             Some(false) => return Ok(TreeDrain::AllMembersExited),
@@ -399,15 +422,26 @@ async fn job_wait_tree_drained(
 ) -> Result<crate::containment::TreeDrain, Error> {
     use windows::Win32::Foundation::HANDLE;
 
-    use crate::containment::TreeDrain;
-
     // Duration::ZERO delegates to the sync one-shot probe — no thread-pool hop needed for a
     // call that cannot block (mirrors grace_wait's identical delegation).
     if crate::wait::remaining(deadline) == Some(std::time::Duration::ZERO) {
         return job.wait_drained(deadline, None);
     }
     let Some(raw_job) = job.as_handle() else {
-        return Ok(TreeDrain::AllMembersExited);
+        // Mirrors `JobHandle::wait_drained`'s own early return exactly (this function only
+        // reaches here once that method's Duration::ZERO delegation above has already been
+        // ruled out): the job handle was already consumed, so there is no live handle left to
+        // re-enumerate or open member handles from, and `TerminateJobObject`/`CloseHandle` are
+        // not documented as synchronous with member process teardown. Reporting
+        // `AllMembersExited` here would be a guess, not a live-checked verdict — see that
+        // method's doc and inline comment for the full justification.
+        return Err(Error::Unassessable {
+            detail: "the job handle was already closed (kill_tree()/hard_kill(), or the Child \
+                     was dropped) before this drain check ran; whether every member has \
+                     actually finished exiting can no longer be observed"
+                .into(),
+            source: None,
+        });
     };
 
     /// Signals the cancel event on drop (harmless after completion) so the blocking watcher

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -218,14 +218,19 @@ impl std::os::fd::AsRawFd for KqueueFd {
 ///
 /// `drain` returning `Ok(None)` is what `clear_ready` treats as "empty" — this loop has no way
 /// to verify that itself, since the closure's return type carries no more than "done" or "not
-/// done". The invariant holds for both current callers because NEITHER `Ok(None)` case ever
-/// consumes bytes: `drain_proc_exit`'s only non-`None` outcome is `NOTE_EXIT`, with no draining
-/// concept at all, and `marker_eof::drain_kqueue`'s caller here (`wait_tree_drained_inner`)
-/// always arms with `unbounded_wait: true`, under which `interpret_read_event` itself never
-/// drains (see `marker_eof`'s module doc — an unbounded wait cannot drain on a sustained
-/// writer's behalf without spinning). A future `drain` closure that DOES consume bytes on a
-/// non-`None`-but-also-non-terminal path would violate this silently; `watch_readable` cannot
-/// detect that on its own, so any such closure owns re-verifying this invariant itself.
+/// done". The invariant holds for both current callers: `drain_proc_exit`'s only non-`None`
+/// outcome is `NOTE_EXIT`, with no draining concept at all, and `marker_eof::drain_kqueue`'s
+/// caller here (`wait_tree_drained_inner`) passes through the SAME `unbounded_wait` its own
+/// caller computed from the real deadline (`crate::wait::remaining(deadline).is_none()`,
+/// matching the sync backend's `block_until_drained` exactly) — when `true`,
+/// `interpret_read_event` never drains at all (see `marker_eof`'s module doc — an unbounded wait
+/// cannot drain on a sustained writer's behalf without spinning); when `false`, a non-`None`
+/// non-terminal event DOES drain bytes, but only inside `interpret_read_event`'s own
+/// already-verified `Ok(None)` return, so the invariant this loop relies on — no closure
+/// silently drains behind an `Ok(None)` it can't see — still holds. A future `drain` closure
+/// that consumed bytes on a DIFFERENT non-`None`-but-non-terminal path would violate that
+/// silently; `watch_readable` cannot detect that on its own, so any such closure owns
+/// re-verifying this invariant itself.
 #[cfg(target_os = "macos")]
 async fn watch_readable<F>(afd: &::tokio::io::unix::AsyncFd<KqueueFd>, mut drain: F) -> Result<(), Error>
 where
@@ -267,14 +272,26 @@ where
 ///
 #[cfg(target_os = "macos")]
 pub(crate) async fn wait_tree_drained(read_end: std::os::fd::BorrowedFd<'_>) -> Result<(), Error> {
-    wait_tree_drained_inner(read_end, None).await
+    wait_tree_drained_inner(read_end, true, None).await
 }
 
 /// Deadline-bounded, [`TreeDrain`](crate::containment::TreeDrain)-returning wrapper over
-/// [`wait_tree_drained`] — the macOS arm of `tokio::Child::wait_tree`/`wait_tree_timeout`.
+/// [`wait_tree_drained_inner`] — the macOS arm of `tokio::Child::wait_tree`/`wait_tree_timeout`.
 /// `Duration::ZERO` delegates to the sync backend's one-shot, non-blocking probe (safe to call
 /// directly from async code), matching `grace_wait`'s identical `Duration::ZERO` delegation to
 /// `block_until_exit`.
+///
+/// The bounded arm (`Some(d)`) arms with `unbounded_wait: false` — computed the same way the
+/// sync backend's `block_until_drained` does (`crate::wait::remaining(deadline).is_none()`,
+/// `false` whenever a real deadline governs this call) — NOT via [`wait_tree_drained`], which is
+/// always unbounded by construction (see its own doc). Arming unbounded here would be a real,
+/// observable divergence from the sync twin: `refuse_if_write_end_held` would refuse an
+/// `Unassessable` write-end scan that a bounded caller should tolerate (its own deadline caps
+/// the risk), and `interpret_read_event` would stop draining a sustained writer at the low-water
+/// clamp, so a bounded wait could only ever expire into `MembersRemain` where the sync call
+/// drains through to the real edge. `tokio::time::timeout` still supplies the actual bound —
+/// the same pattern `grace_wait` uses over `wait_exit` — this only fixes what the ARMED kqueue
+/// itself is told.
 #[cfg(target_os = "macos")]
 pub(crate) async fn wait_tree_deadline(
     read_end: std::os::fd::BorrowedFd<'_>,
@@ -287,7 +304,7 @@ pub(crate) async fn wait_tree_deadline(
             Ok(TreeDrain::AllMarkersClosed)
         }
         Some(d) if d.is_zero() => crate::containment::marker_eof::probe(read_end),
-        Some(d) => match ::tokio::time::timeout(d, wait_tree_drained(read_end)).await {
+        Some(d) => match ::tokio::time::timeout(d, wait_tree_drained_inner(read_end, false, None)).await {
             Ok(res) => res.map(|()| TreeDrain::AllMarkersClosed),
             Err(_elapsed) => Ok(TreeDrain::MembersRemain),
         },
@@ -296,30 +313,35 @@ pub(crate) async fn wait_tree_deadline(
 
 /// Test-only entry point that reports the instant its kqueue is armed, on a channel the
 /// CALLER owns — no shared/global observer state, so concurrently-running tests (this file
-/// has four) cannot steal each other's notification.
+/// has four) cannot steal each other's notification. Always the unbounded arm, matching
+/// [`wait_tree_drained`] (its own real caller): these tests exercise the no-deadline API.
 #[cfg(all(test, target_os = "macos"))]
 pub(crate) async fn wait_tree_drained_for_test(
     read_end: std::os::fd::BorrowedFd<'_>,
     armed: std::sync::mpsc::Sender<()>,
 ) -> Result<(), Error> {
-    wait_tree_drained_inner(read_end, Some(armed)).await
+    wait_tree_drained_inner(read_end, true, Some(armed)).await
 }
 
+/// `unbounded_wait` must be the SAME expression the sync backend's `block_until_drained` uses
+/// (`crate::wait::remaining(deadline).is_none()`) for whichever deadline the caller is honoring
+/// — threaded through to both `arm` and `drain_kqueue` (see [`wait_tree_deadline`]'s own doc for
+/// why arming this wrong is a real, observable divergence, not a cosmetic one).
 #[cfg(target_os = "macos")]
 async fn wait_tree_drained_inner(
     read_end: std::os::fd::BorrowedFd<'_>,
+    unbounded_wait: bool,
     armed: Option<std::sync::mpsc::Sender<()>>,
 ) -> Result<(), Error> {
     use ::tokio::io::unix::AsyncFd;
     use ::tokio::io::Interest;
-    // Unbounded: this future has no deadline parameter at all (see the doc comment above).
-    let kq = crate::containment::marker_eof::arm(read_end, true)?;
+    let kq = crate::containment::marker_eof::arm(read_end, unbounded_wait)?;
     if let Some(tx) = armed {
         let _ = tx.send(());
     }
     let afd = AsyncFd::with_interest(KqueueFd(kq), Interest::READABLE).map_err(Error::Io)?;
     watch_readable(&afd, move |kq| {
-        crate::containment::marker_eof::drain_kqueue(kq, read_end, true).map(|d| d.map(|_| ()))
+        crate::containment::marker_eof::drain_kqueue(kq, read_end, unbounded_wait).map(|d| d.map(|_| ()))
     })
     .await
 }

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -265,13 +265,33 @@ where
 /// same descriptor directly would take over the first's registration and park it forever —
 /// each call arms its OWN private kqueue (`marker_eof::arm`).
 ///
-/// No production caller exists yet — `Attached::wait_drained` wires the SYNC form only;
-/// wiring this async form into `graceful_shutdown_tree` is a later change's job.
-/// `#[allow(dead_code)]` reflects that honestly, mirroring `marker_eof::probe`.
 #[cfg(target_os = "macos")]
-#[allow(dead_code)]
 pub(crate) async fn wait_tree_drained(read_end: std::os::fd::BorrowedFd<'_>) -> Result<(), Error> {
     wait_tree_drained_inner(read_end, None).await
+}
+
+/// Deadline-bounded, [`TreeDrain`](crate::containment::TreeDrain)-returning wrapper over
+/// [`wait_tree_drained`] — the macOS arm of `tokio::Child::wait_tree`/`wait_tree_timeout`.
+/// `Duration::ZERO` delegates to the sync backend's one-shot, non-blocking probe (safe to call
+/// directly from async code), matching `grace_wait`'s identical `Duration::ZERO` delegation to
+/// `block_until_exit`.
+#[cfg(target_os = "macos")]
+pub(crate) async fn wait_tree_deadline(
+    read_end: std::os::fd::BorrowedFd<'_>,
+    deadline: Option<Option<std::time::Instant>>,
+) -> Result<crate::containment::TreeDrain, Error> {
+    use crate::containment::TreeDrain;
+    match crate::wait::remaining(deadline) {
+        None => {
+            wait_tree_drained(read_end).await?;
+            Ok(TreeDrain::AllMembersExited)
+        }
+        Some(d) if d.is_zero() => crate::containment::marker_eof::probe(read_end),
+        Some(d) => match ::tokio::time::timeout(d, wait_tree_drained(read_end)).await {
+            Ok(res) => res.map(|()| TreeDrain::AllMembersExited),
+            Err(_elapsed) => Ok(TreeDrain::MembersRemain),
+        },
+    }
 }
 
 /// Test-only entry point that reports the instant its kqueue is armed, on a channel the
@@ -302,6 +322,163 @@ async fn wait_tree_drained_inner(
         crate::containment::marker_eof::drain_kqueue(kq, read_end, true).map(|d| d.map(|_| ()))
     })
     .await
+}
+
+/// Resolve when every process in the cgroup v2 leaf has EXITED (not reaped), observed via
+/// `cgroup.events`'s `populated` key over a reactor-registered `AsyncFd` (`EPOLLPRI`, tokio's
+/// `Interest::PRIORITY`) — genuinely reactor-native, no polling interval anywhere, and
+/// cancellable (dropping the future deregisters the fd, same as every other Unix watch in this
+/// file). Mirrors `CgroupLeaf::wait_drained`'s sync loop exactly, including read-before-arm: the
+/// file is read BEFORE every `ready()` await, not only after, so a transition that already
+/// happened is observed on the read rather than requiring a fresh edge that may never fire
+/// again. `deadline` follows the crate's watch convention; each round awaits readiness for
+/// exactly the caller's own remaining time (`tokio::time::timeout`), never an invented interval.
+#[cfg(target_os = "linux")]
+async fn cgroup_wait_tree_drained(
+    leaf: &crate::containment::cgroup::CgroupLeaf,
+    deadline: Option<Option<std::time::Instant>>,
+) -> Result<crate::containment::TreeDrain, Error> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    use ::tokio::io::unix::AsyncFd;
+    use ::tokio::io::Interest;
+
+    use crate::containment::TreeDrain;
+
+    let file = std::fs::File::open(leaf.events_path()).map_err(Error::Io)?;
+    let mut afd = AsyncFd::with_interest(file, Interest::PRIORITY).map_err(Error::Io)?;
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        {
+            let f = afd.get_mut();
+            f.seek(SeekFrom::Start(0)).map_err(Error::Io)?;
+            f.read_to_string(&mut buf).map_err(Error::Io)?;
+        }
+        match crate::containment::cgroup::parse_populated(&buf) {
+            Some(false) => return Ok(TreeDrain::AllMembersExited),
+            Some(true) => {}
+            None => {
+                return Err(Error::Io(std::io::Error::other(
+                    "cgroup.events has no 'populated' field — unexpected kernel format",
+                )))
+            }
+        }
+        let remaining = crate::wait::remaining(deadline);
+        if remaining == Some(std::time::Duration::ZERO) {
+            return Ok(TreeDrain::MembersRemain);
+        }
+        let mut ready = match remaining {
+            None => afd.ready(Interest::PRIORITY).await.map_err(Error::Io)?,
+            Some(d) => match ::tokio::time::timeout(d, afd.ready(Interest::PRIORITY)).await {
+                Ok(r) => r.map_err(Error::Io)?,
+                Err(_elapsed) => return Ok(TreeDrain::MembersRemain),
+            },
+        };
+        // A regular file has no "would block" concept to drain — any readiness means a
+        // transition fired (possibly stale by the time we re-read, which the loop's own
+        // re-read handles); clear and re-await.
+        ready.clear_ready();
+    }
+}
+
+/// Resolve when every process in the Windows job has EXITED (not reaped), or until `deadline`.
+/// Job objects expose no pollable handle, so — unlike the Linux/macOS arms in this file — this
+/// is NOT reactor-native: it hands the sync `JobHandle::wait_drained` loop to `spawn_blocking`,
+/// releasing the blocking thread promptly on drop via the same cancel-event idiom
+/// `blocking_watch` uses for `grace_wait`. Only the raw `HANDLE` value (`Copy`, `Send`) crosses
+/// into the blocking closure — `JobHandle` itself is never moved there — because the closure
+/// must be `'static` while `JobHandle` is only borrowed. This is sound because the caller
+/// (`wait_tree_drained`, transitively `tokio::Child::wait_tree`/`wait_tree_timeout`) holds
+/// `&Child` — and so `&JobHandle` — across this entire `.await`, so the job handle cannot be
+/// closed while the blocking task runs.
+#[cfg(windows)]
+async fn job_wait_tree_drained(
+    job: &crate::containment::windows::JobHandle,
+    deadline: Option<Option<std::time::Instant>>,
+) -> Result<crate::containment::TreeDrain, Error> {
+    use windows::Win32::Foundation::HANDLE;
+
+    use crate::containment::TreeDrain;
+
+    // Duration::ZERO delegates to the sync one-shot probe — no thread-pool hop needed for a
+    // call that cannot block (mirrors grace_wait's identical delegation).
+    if crate::wait::remaining(deadline) == Some(std::time::Duration::ZERO) {
+        return job.wait_drained(deadline, None);
+    }
+    let Some(raw_job) = job.as_handle() else {
+        return Ok(TreeDrain::AllMembersExited);
+    };
+
+    /// Signals the cancel event on drop (harmless after completion) so the blocking watcher
+    /// releases promptly instead of parking out the deadline, and `Runtime::drop` — which
+    /// joins blocking tasks — does not stall. Identical idiom to `blocking_watch`'s guard.
+    struct SignalOnDrop(std::sync::Arc<std::os::windows::io::OwnedHandle>);
+    impl Drop for SignalOnDrop {
+        fn drop(&mut self) {
+            crate::wait::backend::signal_cancel(&self.0);
+        }
+    }
+    let cancel = std::sync::Arc::new(crate::wait::backend::new_cancel_event()?);
+    let _guard = SignalOnDrop(cancel.clone());
+    // SAFETY: `cancel`'s OwnedHandle is kept alive by the Arc clone captured in the
+    // spawn_blocking closure below (and by `_guard`/`cancel` here) for the whole wait.
+    let cancel_raw = HANDLE(std::os::windows::io::AsRawHandle::as_raw_handle(&*cancel));
+    let cancel_for_blocking = cancel.clone();
+
+    /// `HANDLE`'s raw pointer is `!Send` by default; a job or event handle is sound to use
+    /// from another thread (the kernel serialises handle operations) — the same justification
+    /// as `JobHandle`'s own `unsafe impl Send`.
+    struct SendHandles {
+        job: HANDLE,
+        cancel: HANDLE,
+    }
+    unsafe impl Send for SendHandles {}
+    let handles = SendHandles {
+        job: raw_job,
+        cancel: cancel_raw,
+    };
+
+    let joined = ::tokio::task::spawn_blocking(move || {
+        let handles = handles;
+        let result = crate::containment::windows::wait_drained_raw(handles.job, deadline, Some(handles.cancel));
+        drop(cancel_for_blocking); // keep the handle alive for the full blocking call, explicitly
+        result
+    })
+    .await;
+    match joined {
+        Ok(result) => result,
+        // wait_drained_raw does not panic — a panic here is a bug, not an I/O condition;
+        // propagate it instead of masking it as an error.
+        Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+        Err(e) if e.is_cancelled() => Err(Error::Io(std::io::Error::other(
+            "tree-drain watcher cancelled (runtime shutting down)",
+        ))),
+        Err(e) => {
+            debug_assert!(false, "unknown JoinError variant: {e:?}");
+            Err(Error::Io(std::io::Error::other(e)))
+        }
+    }
+}
+
+/// Async equivalent of `Attached::wait_drained`, dispatched by mechanism. Linux and macOS are
+/// genuinely reactor-native (`AsyncFd`); Windows hands its sync loop to `spawn_blocking` with a
+/// cancel event (job objects have no pollable handle). Every other mechanism delegates to the
+/// sync `Attached::wait_drained`, whose non-drainable arm returns `Unsupported` immediately —
+/// never blocking — so calling it directly here (no `spawn_blocking`) is safe.
+pub(crate) async fn wait_tree_drained_dispatch(
+    attached: &crate::containment::Attached,
+    deadline: Option<Option<std::time::Instant>>,
+) -> Result<crate::containment::TreeDrain, Error> {
+    match attached {
+        #[cfg(target_os = "linux")]
+        crate::containment::Attached::Cgroup(leaf) => cgroup_wait_tree_drained(leaf, deadline).await,
+        #[cfg(windows)]
+        crate::containment::Attached::JobObject(job) => job_wait_tree_drained(job, deadline).await,
+        #[cfg(target_os = "macos")]
+        crate::containment::Attached::FdMarker(m) => wait_tree_deadline(m.read_end(), deadline).await,
+        other => other.wait_drained(deadline),
+    }
 }
 
 #[cfg(test)]

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -80,6 +80,15 @@ pub(crate) fn remaining(deadline: Option<Option<Instant>>) -> Option<Duration> {
     }
 }
 
+/// Convert a relative `duration` into the crate's `deadline` convention
+/// (`Option<Option<Instant>>`, the inverse of [`remaining`]): `Instant::now() + duration`,
+/// saturating to unbounded (`Some(None)`, read by `remaining` the same as outer `None`) on
+/// overflow rather than panicking. Shared by every `_timeout`/`grace`-style call that starts
+/// a fresh relative wait from "now".
+pub(crate) fn deadline_from(duration: Duration) -> Option<Option<Instant>> {
+    Some(Instant::now().checked_add(duration))
+}
+
 #[cfg(test)]
 #[path = "wait_tests.rs"]
 mod wait_tests;

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -164,25 +164,27 @@ fn child_graceful_shutdown_tree_escalates() {
 #[test]
 fn child_graceful_shutdown_tree_sweeps_survivor_after_graceful_root_exit() {
     use std::io::Read;
-    use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     // The exact case the sweep-before-reap invariant protects: the root honors the group
     // SIGTERM and exits within the grace, but the grandchild ignores it and survives — only
     // the post-grace hard sweep (running while the unreaped root still pins the group id)
-    // can tear it down. The root's status stays SIGTERM: the sweep no-ops on the dead root.
-    // The grandchild never exits, so on a drain-observable mechanism the full grace is always
-    // spent watching the whole tree (not just the root) before the sweep runs — 1s (not 30s)
-    // keeps this fast while staying a generous, non-flaky bound on the root's own SIGTERM
-    // response, which is what actually needs the margin.
+    // can tear it down. The grandchild never exits, so on a drain-observable mechanism the
+    // full grace is always spent watching the whole tree (not just the root) before the sweep
+    // runs — 1s (not 30s) keeps this fast while staying a generous bound.
+    //
+    // This test asserts ONLY survivor teardown, deliberately not the root's reaped signal:
+    // the handshake in `spawn_tree` proves the root is ready to RECEIVE the SIGTERM, not that
+    // it finishes dying from it before the grace expires and the hard sweep's SIGKILL reaches
+    // the same pid. If the root is still alive (not yet a zombie) at that instant, the sweep's
+    // SIGKILL can pre-empt the SIGTERM's own kill, flipping the observed signal under load —
+    // a genuine timing bet this test must not make. `child_graceful_shutdown_tree_graceful_root_sigterm`
+    // covers the root's SIGTERM status instead, in a single-process tree where the drain
+    // completes as soon as the root exits, so the sweep never runs concurrently with a still-alive
+    // root at all.
     let (child, mut socks) = common::spawn_tree("spawn-grandchild-stubborn-child", true);
-    let status = child
+    child
         .graceful_shutdown_tree(Duration::from_secs(1))
         .expect("tree graceful with survivor");
-    assert_eq!(
-        status.signal(),
-        Some(libc::SIGTERM),
-        "root must exit via SIGTERM (graceful), got {status:?}"
-    );
     for (i, s) in socks.iter_mut().enumerate() {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -170,9 +170,13 @@ fn child_graceful_shutdown_tree_sweeps_survivor_after_graceful_root_exit() {
     // SIGTERM and exits within the grace, but the grandchild ignores it and survives — only
     // the post-grace hard sweep (running while the unreaped root still pins the group id)
     // can tear it down. The root's status stays SIGTERM: the sweep no-ops on the dead root.
+    // The grandchild never exits, so on a drain-observable mechanism the full grace is always
+    // spent watching the whole tree (not just the root) before the sweep runs — 1s (not 30s)
+    // keeps this fast while staying a generous, non-flaky bound on the root's own SIGTERM
+    // response, which is what actually needs the margin.
     let (child, mut socks) = common::spawn_tree("spawn-grandchild-stubborn-child", true);
     let status = child
-        .graceful_shutdown_tree(Duration::from_secs(30))
+        .graceful_shutdown_tree(Duration::from_secs(1))
         .expect("tree graceful with survivor");
     assert_eq!(
         status.signal(),

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -385,28 +385,30 @@ async fn async_graceful_shutdown_tree_escalates_with_surviving_grandchild() {
 #[cfg(unix)]
 #[tokio::test]
 async fn async_graceful_shutdown_tree_sweeps_survivor_after_graceful_root_exit() {
-    use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     // The exact case the sweep-before-reap invariant protects: the root honors the group
     // SIGTERM and exits within the grace, but the grandchild ignores it and survives — only
     // the post-grace hard sweep (running while the unreaped root still pins the group id)
-    // can tear it down. The root's status stays SIGTERM: the sweep no-ops on the dead root.
-    // The grandchild never exits, so on a drain-observable mechanism the full grace is always
-    // spent watching the whole tree (not just the root) before the sweep runs — 1s (not 30s)
-    // keeps this fast while staying a generous, non-flaky bound on the root's own SIGTERM
-    // response, which is what actually needs the margin.
+    // can tear it down. The grandchild never exits, so on a drain-observable mechanism the
+    // full grace is always spent watching the whole tree (not just the root) before the sweep
+    // runs — 1s (not 30s) keeps this fast while staying a generous bound.
+    //
+    // This test asserts ONLY survivor teardown, deliberately not the root's reaped signal: the
+    // handshake in `spawn_tree_async` proves the root is ready to RECEIVE the SIGTERM, not that
+    // it finishes dying from it before the grace expires and the hard sweep's SIGKILL reaches
+    // the same pid. If the root is still alive (not yet a zombie) at that instant, the sweep's
+    // SIGKILL can pre-empt the SIGTERM's own kill, flipping the observed signal under load — a
+    // genuine timing bet this test must not make. `async_graceful_shutdown_tree_graceful_root_sigterm`
+    // covers the root's SIGTERM status instead, in a single-process tree where the drain
+    // completes as soon as the root exits, so the sweep never runs concurrently with a
+    // still-alive root at all.
     let (mut child, mut root, mut grand) = common::spawn_tree_async("spawn-grandchild-stubborn-child", |cmd| {
         cmd.contain();
     });
-    let status = child
+    child
         .graceful_shutdown_tree(Duration::from_secs(1))
         .await
         .expect("tree graceful with survivor");
-    assert_eq!(
-        status.signal(),
-        Some(libc::SIGTERM),
-        "root must exit via SIGTERM (graceful), got {status:?}"
-    );
     expect_eof("root", &mut root);
     expect_eof("grandchild", &mut grand);
 }

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -391,11 +391,15 @@ async fn async_graceful_shutdown_tree_sweeps_survivor_after_graceful_root_exit()
     // SIGTERM and exits within the grace, but the grandchild ignores it and survives — only
     // the post-grace hard sweep (running while the unreaped root still pins the group id)
     // can tear it down. The root's status stays SIGTERM: the sweep no-ops on the dead root.
+    // The grandchild never exits, so on a drain-observable mechanism the full grace is always
+    // spent watching the whole tree (not just the root) before the sweep runs — 1s (not 30s)
+    // keeps this fast while staying a generous, non-flaky bound on the root's own SIGTERM
+    // response, which is what actually needs the margin.
     let (mut child, mut root, mut grand) = common::spawn_tree_async("spawn-grandchild-stubborn-child", |cmd| {
         cmd.contain();
     });
     let status = child
-        .graceful_shutdown_tree(Duration::from_secs(30))
+        .graceful_shutdown_tree(Duration::from_secs(1))
         .await
         .expect("tree graceful with survivor");
     assert_eq!(


### PR DESCRIPTION
All three platforms expose a kernel edge that fires when a contained tree empties, and none was used. `graceful_shutdown_tree` therefore hard-killed unconditionally after its grace period, even when the tree had already exited on its own.

## The wait

`wait_tree` and `wait_tree_timeout` on `Child`, sync and async, following the existing `kill_tree`/`terminate_tree` naming. Backed per platform by:

- **Linux** — cgroup v2 `cgroup.events`' `populated` key. It flips on **exit**, not on reaping: the counter is decremented from `do_task_dead()`, long before the parent's `wait4()`, and `release_task()` never touches it. An unreaped zombie does not count as populated.
- **Windows** — a job object's `JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO` on an I/O completion port, associated at job creation *before* `AssignProcessToJobObject`. The one documented delivery-loss case is associating a port with an already-active job, so associating at creation excludes it structurally rather than narrowing it. Because Microsoft guarantees no delivery beyond that, the wait does not rely on the packet alone: it re-enumerates job membership and waits on real process handles, so a dropped message still resolves.
- **macOS** — the fd marker's EOF, lifted from the crate-internal accessor rather than rebuilt.

Mechanisms with no edge return `Error::Unsupported`, matching `require_contained`.

The verdict reuses `TreeDrain::{AllMembersExited, MembersRemain}`. It describes the tree's state, not the wait's outcome — "the deadline expired" is the caller's own fact, and folding it into the enum would conflate "members are still running" with "I stopped looking".

## Conditional escalation

On a drain-observable mechanism, `graceful_shutdown_tree` now watches the whole tree for up to `grace`. `AllMembersExited` skips the hard sweep entirely; `MembersRemain` or a watch error escalates exactly as before. On mechanisms without an edge, behaviour is unchanged.

**This changes timing for existing callers on drain-observable platforms.** `grace` now bounds the whole tree's drain rather than just the root's exit, so a scenario where the root exits and a descendant survives consumes the full grace before escalating. There is no earlier signal available: any survivor could exit at the last instant, so "won't drain in time" is not knowable before the deadline itself.

## Tests

The drain-skips-sweep tests arm a fault seam that makes `kill_tree` fail, so they observe that the sweep was never entered rather than that it ran and did nothing. They branch on `can_observe_drain()` at the host instead of skipping, asserting the complementary expectation where no edge exists.