### PR TITLE
build: publish 0.2.0 to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "cosca"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "command-fds",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosca"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Anna Zhukova"]
 description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation."


### PR DESCRIPTION
Closes #88.

Version bump only, no code changes. Published 0.1.0 is three breaking commits and five features behind `main`, and its index entry does not list the `serde` feature, so `ProcessIdRecord` persistence is unreachable from the registry. Three `!`-breaking changes since 0.1.0 means the minor bump under 0.x.

Also exercises the trusted-publishing pipeline on a low-stakes release before a downstream consumer depends on it working.