### PR TITLE
test: pin the zombie edge with waitid(WNOWAIT) instead of the OS exit edge

### DIFF
--- a/src/containment/fdmarker_tests.rs
+++ b/src/containment/fdmarker_tests.rs
@@ -665,16 +665,11 @@ fn hard_kill_reaches_a_setsid_double_forked_orphan_the_ppid_walk_cannot() {
     std::io::Read::read_to_end(&mut out, &mut rest).expect("read to EOF on the orphan's stdout");
     assert!(rest.is_empty(), "unexpected trailing output from the orphan: {rest:?}");
 
-    // Redundant secondary check, not the proof: `is_alive` is zombie-EXCLUSIVE (unlike
-    // `ProcessId::of`/`exists`, which stay `Found`/`Present` for an unreaped zombie), so it
-    // reports `Dead` synchronously at the kill, matching what the EOF above already showed.
-    if let crate::identity::Resolved::Found(id) = crate::identity::ProcessId::of(orphan) {
-        assert_eq!(
-            id.is_alive(),
-            crate::identity::Liveness::Dead,
-            "pid {orphan} must not report alive after the EOF proof above"
-        );
-    }
+    // No liveness assertion follows the EOF, deliberately: `proc_exit` invalidates the fd table
+    // (what the EOF above observes) long before it marks the process a zombie, the state
+    // `is_alive` reads — so `Alive` is reachable here for an orphan that has already died. Nor is
+    // there a sound edge to wait for instead: this orphan belongs to launchd, so `waitid` returns
+    // `ECHILD`. The EOF is the proof, and it is the only one available.
 }
 
 /// A pid that stopped holding the marker before the sweep must survive a REAL `hard_kill()`,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -146,11 +146,18 @@ impl ProcessId {
         }
     }
 
-    /// Whether the process is currently *running* (has not exited). Authoritative and
-    /// synchronously correct the instant the process exits — on Windows via the handle's
-    /// signaled state, on Unix via process state / `/proc` presence. A reused PID (different
-    /// start token) is never alive. [`Liveness::Unknown`] when the OS refuses the query, or
-    /// answers ambiguously — never `Dead` on a process we could not assess.
+    /// Whether the process is currently *running* (has not exited). Answers out of the OS's own
+    /// exit bookkeeping — on Windows the handle's signaled state, on Unix process state /
+    /// `/proc` presence. A reused PID (different start token) is never alive.
+    /// [`Liveness::Unknown`] when the OS refuses the query, or answers ambiguously — never
+    /// `Dead` on a process we could not assess.
+    ///
+    /// **The OS exit *edge* can precede that bookkeeping.** macOS posts the `NOTE_EXIT` a
+    /// death-watch ([`Process::wait`](crate::Process::wait)) returns on from inside `proc_exit`,
+    /// before the same function sets the `p_stat = SZOMB` this reads — so `Alive` is briefly
+    /// reachable for a process that has already exited. Linux (`pidfd`) and Windows signal only
+    /// after their equivalent transition. Confirm a process is finished by reaping it or by a
+    /// real exit event, not by asking this immediately after a wait returns.
     pub fn is_alive(&self) -> Liveness {
         backend::is_running(self.pid, self.start)
     }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -152,12 +152,13 @@ impl ProcessId {
     /// [`Liveness::Unknown`] when the OS refuses the query, or answers ambiguously — never
     /// `Dead` on a process we could not assess.
     ///
-    /// **The OS exit *edge* can precede that bookkeeping.** macOS posts the `NOTE_EXIT` a
-    /// death-watch ([`Process::wait`](crate::Process::wait)) returns on from inside `proc_exit`,
-    /// before the same function sets the `p_stat = SZOMB` this reads — so `Alive` is briefly
-    /// reachable for a process that has already exited. Linux (`pidfd`) and Windows signal only
-    /// after their equivalent transition. Confirm a process is finished by reaping it or by a
-    /// real exit event, not by asking this immediately after a wait returns.
+    /// **On macOS the exit *edge* precedes that bookkeeping.** A death-watch
+    /// ([`Process::wait`](crate::Process::wait)) returning, and a pipe or socket EOF on the dying
+    /// process's own descriptors, both fire while the kernel is still tearing the process down —
+    /// before it is marked a zombie, which is the state this reads. So `Alive` is briefly
+    /// reachable for a process that has already exited; Linux and Windows signal only after their
+    /// equivalent transition. Confirm a process is finished by reaping it, or by
+    /// `waitid(WEXITED | WNOWAIT)` — never by asking this after an exit event.
     pub fn is_alive(&self) -> Liveness {
         backend::is_running(self.pid, self.start)
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -34,6 +34,37 @@ pub fn status_locked(cmd: &mut std::process::Command) -> std::io::Result<std::pr
     cmd.status()
 }
 
+/// Block until `pid` — which MUST be an unreaped child of this process — has exited AND become
+/// a zombie, leaving it unreaped for the caller to assert on and then reap. The canonical
+/// zombie edge for this suite: the ONLY sync point that a liveness assertion about a zombie may
+/// be taken at.
+///
+/// A death-watch is NOT a substitute. `Process::wait` returns on the OS exit edge, and on macOS
+/// that edge is `proc_exit`'s `proc_knote(p, NOTE_EXIT)`, which XNU posts well before the same
+/// function assigns `p->p_stat = SZOMB` — so a liveness check taken there can still read the
+/// process as running. `waitid` reports `WEXITED` only out of the kernel's `SZOMB` case, so its
+/// return IS the zombie transition, and `WNOWAIT` leaves the zombie collectable. Blocking,
+/// kernel-synchronised, and never a poll or a timeout.
+#[cfg(unix)]
+pub fn block_until_zombie(pid: cosca::identity::RawPid) {
+    loop {
+        let mut si: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        // SAFETY: `si` is a valid, correctly-sized out-param; `pid` is our own unreaped child.
+        let rc = unsafe { libc::waitid(libc::P_PID, pid as libc::id_t, &mut si, libc::WEXITED | libc::WNOWAIT) };
+        if rc == 0 {
+            return;
+        }
+        // EINTR is a restart, not a failure — the codebase's convention for every blocking
+        // syscall (see `wait/macos.rs`, `identity/macos/kinfo.rs`).
+        let e = std::io::Error::last_os_error();
+        assert_eq!(
+            e.raw_os_error(),
+            Some(libc::EINTR),
+            "waitid(P_PID, {pid}, WEXITED | WNOWAIT): {e}"
+        );
+    }
+}
+
 /// A capturing `log::Log` for asserting on log output from an integration-test process — a fresh
 /// copy of `src/log_capture.rs`'s `pub(crate)`-private original, which a separate compilation unit
 /// like this one cannot name.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -42,9 +42,10 @@ pub fn status_locked(cmd: &mut std::process::Command) -> std::io::Result<std::pr
 /// A death-watch is NOT a substitute. `Process::wait` returns on the OS exit edge, and on macOS
 /// that edge is `proc_exit`'s `proc_knote(p, NOTE_EXIT)`, which XNU posts well before the same
 /// function assigns `p->p_stat = SZOMB` — so a liveness check taken there can still read the
-/// process as running. `waitid` reports `WEXITED` only out of the kernel's `SZOMB` case, so its
-/// return IS the zombie transition, and `WNOWAIT` leaves the zombie collectable. Blocking,
-/// kernel-synchronised, and never a poll or a timeout.
+/// process as running. Neither is a pipe or socket EOF on the dying process's own descriptors:
+/// `proc_exit` invalidates the fd table earlier still. `waitid` reports `WEXITED` only out of
+/// the kernel's `SZOMB` case, so its return IS the zombie transition, and `WNOWAIT` leaves the
+/// zombie collectable.
 #[cfg(unix)]
 pub fn block_until_zombie(pid: cosca::identity::RawPid) {
     loop {

--- a/tests/identity_lifecycle.rs
+++ b/tests/identity_lifecycle.rs
@@ -120,8 +120,8 @@ fn identity_resolves_an_exited_unreaped_child() {
 }
 
 /// The start token must be STABLE across the alive -> zombie transition — the property
-/// `is_running`'s reused-PID guard depends on. `waitid(WEXITED | WNOWAIT)` pins the
-/// zombie: it returns only once the child IS a zombie and leaves it unreaped.
+/// `is_running`'s reused-PID guard depends on. `common::block_until_zombie` pins the zombie:
+/// it returns only once the child IS a zombie and leaves it unreaped.
 #[cfg(unix)]
 #[test]
 fn identity_survives_the_alive_to_zombie_transition() {
@@ -131,18 +131,7 @@ fn identity_survives_the_alive_to_zombie_transition() {
     assert_eq!(id.exists(), cosca::identity::Existence::Present, "live child exists");
     assert_eq!(id.is_alive(), cosca::identity::Liveness::Alive, "live child is alive");
     child.kill().expect("kill");
-    // WNOWAIT: leaves the zombie unreaped.
-    let mut si: libc::siginfo_t = unsafe { std::mem::zeroed() };
-    // SAFETY: `si` is a valid out-param; the child is ours and unreaped.
-    let rc = unsafe {
-        libc::waitid(
-            libc::P_PID,
-            child.id().pid() as libc::id_t,
-            &mut si,
-            libc::WEXITED | libc::WNOWAIT,
-        )
-    };
-    assert_eq!(rc, 0, "waitid(WNOWAIT): {}", std::io::Error::last_os_error());
+    common::block_until_zombie(child.id().pid());
     assert_eq!(
         id.exists(),
         cosca::identity::Existence::Present,

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -234,10 +234,14 @@ fn foreign_kill_surfaces_permission_denied() {
 #[cfg(unix)]
 #[test]
 fn is_alive_is_false_for_a_real_zombie() {
-    // The deferred Plan-2 test. Spawn a RAW std child (std does NOT reap on drop), take it
-    // foreign, death-watch it to its exit, then — before reaping — assert is_alive()==false
-    // (zombie) while the identity still resolves (exists). The kernel exit edge is the sync
-    // point; no sleep. Finally reap to avoid a leak.
+    // Spawn a RAW std child (std does NOT reap on drop), take it foreign, drive it to a
+    // zombie, then — before reaping — assert is_alive()==Dead while the identity still
+    // resolves (exists). Finally reap to avoid a leak.
+    //
+    // The foreign death-watch below is exercised but is NOT the sync point: `Process::wait`
+    // returns on the OS exit edge, which on macOS precedes the zombie transition that
+    // `is_alive` reads (see `common::block_until_zombie`). Only that helper's
+    // `waitid(WEXITED | WNOWAIT)` establishes this test's premise.
     use std::io::Read;
     use std::net::TcpListener;
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -254,7 +258,8 @@ fn is_alive_is_false_for_a_real_zombie() {
 
     let p = cosca::Process::from_pid(raw.id()).found().expect("raw child resolves");
     sock.write_all(b"x").expect("trigger exit");
-    p.wait().expect("death-watch"); // returns at the zombie instant (no reap yet)
+    p.wait().expect("death-watch"); // the OS exit edge — non-reaping, but not yet the zombie edge
+    common::block_until_zombie(raw.id()); // the zombie edge, still unreaped
 
     assert_eq!(
         p.is_alive(),

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,6 +1,9 @@
-//! Foreign `Process` integration tests. A child we spawn (and own) is treated as
-//! a foreign process via its `ProcessId`; death/liveness is proven only by a real
-//! exit event (control-socket EOF or the kernel exit edge), never by sleep/poll.
+//! Foreign `Process` integration tests. A child we spawn (and own) is treated as a foreign
+//! process via its `ProcessId`; nothing here is proven by sleep/poll. A real exit event
+//! (control-socket EOF, or the kernel exit edge a death-watch returns on) proves the EXIT.
+//! Only a reap or `common::block_until_zombie` proves NOT-ALIVE: on macOS both of those events
+//! fire while the kernel is still tearing the process down, before it is marked a zombie —
+//! the state `is_alive` reads.
 
 use std::io::{Read, Write};
 use std::time::Duration;
@@ -86,9 +89,9 @@ fn current_and_from_id_round_trip() {
 #[test]
 fn from_pid_resolves_a_live_foreign_child_then_reports_it_dead() {
     // from_pid resolves a live foreign child to its true identity; after the child is
-    // killed+reaped, that resolved Process reports !is_alive (the synchronously-correct
-    // liveness check, distinct from the zombie-inclusive exists()). Death is proven by the
-    // reap, never by sleep.
+    // killed+reaped, that resolved Process reports !is_alive (the zombie-EXCLUSIVE liveness
+    // check, distinct from the zombie-inclusive exists()). The reap is what makes the liveness
+    // assertion sound — an exit event alone would not (see the module doc).
     let (child, _sock) = spawn_blocker();
     let p = cosca::Process::from_pid(child.id().pid())
         .found()
@@ -237,11 +240,6 @@ fn is_alive_is_false_for_a_real_zombie() {
     // Spawn a RAW std child (std does NOT reap on drop), take it foreign, drive it to a
     // zombie, then — before reaping — assert is_alive()==Dead while the identity still
     // resolves (exists). Finally reap to avoid a leak.
-    //
-    // The foreign death-watch below is exercised but is NOT the sync point: `Process::wait`
-    // returns on the OS exit edge, which on macOS precedes the zombie transition that
-    // `is_alive` reads (see `common::block_until_zombie`). Only that helper's
-    // `waitid(WEXITED | WNOWAIT)` establishes this test's premise.
     use std::io::Read;
     use std::net::TcpListener;
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");


### PR DESCRIPTION
`is_alive_is_false_for_a_real_zombie` synchronised on the wrong edge.

The test drove a raw `std` child to exit, blocked in `Process::wait()`, and asserted
`is_alive() == Dead` — treating the death-watch's return as the zombie transition. On macOS it
is not. XNU's `proc_exit` posts `proc_knote(p, NOTE_EXIT)` — the kqueue event `wait/macos.rs`
arms and returns on — roughly 70 lines before the same function assigns `p->p_stat = SZOMB`,
with `proc_parent`, several `proc_list_lock` acquisitions and the parent rusage roll-up in
between. `is_alive` reads `p_stat` (`pbi_status` / `kinfo_proc.p_stat`), so a parent that wins
that race sees a matching start token and a non-`SZOMB` state, and correctly answers `Alive`.
The CI failure printed `left: Alive`, not `Unknown`, which is exactly this and rules out an
unassessable read. Linux and Windows are unaffected: `pidfd` readability is signalled after
`exit_state = EXIT_ZOMBIE`, and the Windows process object signals at termination.

`waitid(P_PID, pid, WEXITED | WNOWAIT)` is the real primitive: XNU reports `WEXITED` only out
of `case SZOMB`, and `WNOWAIT` leaves the zombie collectable. Its return therefore *is* the
zombie transition, so the assertion's premise holds by construction rather than by timing.
`tests/identity_lifecycle.rs` already synchronised this way; that inline copy and the fixed
test now share one `common::block_until_zombie` helper. The assertions are unchanged.

The same class of race was live one edge earlier in `fdmarker_tests.rs`'s launchd-reparented
orphan test, which asserted `is_alive() == Dead` off the orphan's stdout EOF —
`fdt_invalidate` runs ~390 lines before `p_stat = SZOMB`. That orphan is not our child, so no
zombie edge is reachable for it; the assertion was self-described as redundant to the EOF proof
and is now gone, with the reason recorded in its place.

`ProcessId::is_alive`'s doc claimed to be "synchronously correct the instant the process
exits", and `tests/process.rs`'s module doc made an exit event sufficient proof of not-alive.
Both now state the divergence and point callers at a reap or the zombie transition itself.

Closes #84
