### PR TITLE
feat: graceful signal for a group-leading child that owns no tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,12 @@ path = "testbin/main.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "cosca_testbin_gui"
+path = "testbin/gui.rs"
+test = false
+doc = false
+
 [lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
 

--- a/src/child.rs
+++ b/src/child.rs
@@ -126,7 +126,8 @@ impl Child {
     /// Independent of [`containment`](Child::containment): that answers who tears this child's
     /// *tree* down, this answers what a polite signal to the child itself is.
     ///
-    /// **Not a delivery guarantee.** [`GracefulMechanism::ConsoleGroup`] means only that the
+    /// **Not a delivery guarantee.** [`ConsoleGroup`](crate::GracefulMechanism::ConsoleGroup)
+    /// means only that the
     /// creation flags do not exclude delivery from this process — Windows reports success for a
     /// console control event aimed at a group in another console and delivers nothing, and no
     /// spawn-time fact can predict a child that leaves or joins a console after it starts.
@@ -289,8 +290,16 @@ impl Child {
     ///
     /// **Windows: what this actually signals.** `CTRL_BREAK` is delivered to the root's
     /// **process group**, not to the tree. A nested contained descendant leads its own
-    /// group and never receives it; only [`kill_tree`](Child::kill_tree) reaches every
-    /// member.
+    /// group and never receives it, so from THIS handle only
+    /// [`kill_tree`](Child::kill_tree) reaches every member. The layers this skips are not
+    /// beyond a polite shutdown, though: the holder of a nested descendant's own `Child` can
+    /// drain it with [`terminate`](Child::terminate) or
+    /// [`graceful_shutdown`](Child::graceful_shutdown) before this root is torn down, and a
+    /// chain in which each level shuts down its own children drains completely, because a
+    /// child that owns a console can politely signal its own group-leading children.
+    ///
+    /// **And success here does not prove the event was delivered.** A root that shares no
+    /// console with the caller is reported as success and reaches nobody.
     ///
     /// **And it needs the caller to have a console.** The event is deliverable only within
     /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything

--- a/src/child.rs
+++ b/src/child.rs
@@ -76,6 +76,7 @@ pub struct Child {
     kill_on_drop: bool,
     containment: Containment,
     attached: crate::containment::Attached,
+    graceful: crate::graceful::GracefulMechanism,
     elevation: Option<crate::elevation::ElevationReport>,
 }
 
@@ -85,16 +86,16 @@ impl Child {
         id: ProcessId,
         pipes: BTreeMap<Fd, ParentEnd>,
         kill_on_drop: bool,
-        containment: Containment,
-        attached: crate::containment::Attached,
+        attachment: crate::containment::Attachment,
     ) -> Child {
         Child {
             proc,
             id,
             pipes,
             kill_on_drop,
-            containment,
-            attached,
+            containment: attachment.containment,
+            attached: attachment.attached,
+            graceful: attachment.graceful,
             elevation: None,
         }
     }
@@ -116,6 +117,22 @@ impl Child {
     /// act or return `Unsupported`.
     pub fn containment(&self) -> Containment {
         self.containment
+    }
+
+    /// Which cooperative signal [`terminate`](Child::terminate) sends this child, how far it
+    /// reaches, and whether this process has a route to deliver it. A spawn-time fact, so it is
+    /// stable for the child's whole life and costs no syscall.
+    ///
+    /// Independent of [`containment`](Child::containment): that answers who tears this child's
+    /// *tree* down, this answers what a polite signal to the child itself is.
+    ///
+    /// **Not a delivery guarantee.** [`GracefulMechanism::ConsoleGroup`] means only that the
+    /// creation flags do not exclude delivery from this process — Windows reports success for a
+    /// console control event aimed at a group in another console and delivers nothing, and no
+    /// spawn-time fact can predict a child that leaves or joins a console after it starts.
+    /// Each such call also leaves a dead entry in the caller's console process list.
+    pub fn graceful_mechanism(&self) -> crate::graceful::GracefulMechanism {
+        self.graceful
     }
 
     /// Guard for the `_tree` operations (single-sourced with the async `Child`).

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -22,27 +22,82 @@ fn take_forced_watch_error() -> Option<Error> {
 }
 
 impl Child {
-    /// Send `SIGTERM` to the (lone) child — a cooperative request to exit. Signal-only: does
-    /// not wait or reap. Identity-bound, so it cannot race a concurrent reap onto a recycled
-    /// pid. Unix only — Windows has no per-process graceful signal and returns `Unsupported`
-    /// (use [`graceful_shutdown_tree`](Child::graceful_shutdown_tree) for a contained child).
+    /// Send the child its cooperative shutdown signal — a request to exit, not an order.
+    /// Signal-only: does not wait or reap.
+    ///
+    /// Which signal, and how far it goes, is per child: read it from
+    /// [`graceful_mechanism`](Child::graceful_mechanism). On Unix it is an identity-bound
+    /// `SIGTERM` to this process alone, so it cannot race a concurrent reap onto a recycled pid.
+    /// On Windows it is `CTRL_BREAK` to the child's own **console process group** — every child
+    /// spawned with [`contain`](crate::Command::contain), including a nested
+    /// [`Delegated`](crate::Containment::Delegated) one. A child that leads no group of its own
+    /// (an uncontained Windows spawn) is refused with `Unsupported`; `kill` is the
+    /// always-available alternative.
+    ///
+    /// **Windows blast radius.** The event reaches the child's whole console group, so an
+    /// ordinary descendant that stayed in that group is signalled too, while a nested
+    /// *contained* descendant — which leads a group of its own — is not.
+    ///
+    /// **The caller must hold a console** ([`Error::NoConsole`](crate::error::Error::NoConsole)
+    /// otherwise: a GUI-subsystem binary, a service, or a detached spawn cannot deliver console
+    /// control events). A child that owns its own console instead needs a process attached to
+    /// *that* console to signal it — it is not beyond a polite shutdown, just beyond this
+    /// process's reach.
+    ///
+    /// **Success does not prove delivery on Windows.** Windows reports success for an event
+    /// aimed at a group in another console and delivers nothing, and nothing inside this process
+    /// can tell that case from a healthy one. Each such call also leaves a dead entry in the
+    /// caller's console process list.
+    ///
+    /// **Every error means nothing was sent and nothing was killed.**
+    ///
+    /// **Windows, before the child has run.** Between the spawn returning and the child
+    /// executing its first instructions it has not yet registered with any console; an event
+    /// delivered in that window ends it during loader init rather than through its own handler.
+    /// That is an abrupt end, not a failed one, and it is reported `Ok`. A caller that has
+    /// observed anything from the child — a byte of output, a handshake, an exit-status check —
+    /// is past the window and gets a real cooperative signal; a caller that wants the child gone
+    /// before it has run at all should use [`kill`](Child::kill), which is honest about being
+    /// forced.
     pub fn terminate(&self) -> Result<(), Error> {
-        crate::wait::terminate(self.id)
+        crate::graceful::signal(self.graceful, self.id)
     }
 
-    /// Cooperative-then-forced lone shutdown: `SIGTERM`, wait up to `grace` for the child to
-    /// exit, then `SIGKILL` if it has not — reaping either way and returning its `ExitStatus`.
-    /// The status's terminating signal distinguishes a graceful exit from a forced one —
+    /// Cooperative-then-forced lone shutdown: [`terminate`](Child::terminate), wait up to
+    /// `grace` for the child to exit, then hard-kill it if it has not — reaping either way and
+    /// returning its `ExitStatus`. The status distinguishes a graceful exit from a forced one —
     /// best-effort at the boundary: a child that exits of its own accord between the grace
-    /// elapsing and the `SIGKILL` landing reports its own status.
-    /// Escalation proceeds even if the child ignores `SIGTERM`. Unix only; Windows returns
-    /// `Unsupported`. `grace` is relative; `Duration::ZERO` signals, polls once, then escalates.
+    /// elapsing and the kill landing reports its own status. Escalation proceeds even if the
+    /// child ignores the cooperative signal. `grace` is relative; `Duration::ZERO` signals,
+    /// polls once, then escalates.
+    ///
+    /// Every caveat on [`terminate`](Child::terminate) applies to the cooperative half, and a
+    /// cooperative-signal error propagates immediately: no grace is waited, nothing is killed,
+    /// and the child is left running for the caller to `kill`.
+    ///
+    /// **Windows: the two halves have different radii.** The cooperative half reaches the
+    /// child's whole console group; the forced half reaches only the child. So a descendant
+    /// that stayed in the child's group can be left told-to-exit but not killed: if the child
+    /// itself exits within `grace`, this returns `Ok` while that descendant — possibly hung
+    /// mid-shutdown — keeps running, with no hard backstop and no error. For a leaf child, the
+    /// common case, the two radii are identical. Two routes give matched radii: the tree
+    /// variants on a contained root ([`graceful_shutdown_tree`](Child::graceful_shutdown_tree)
+    /// plus [`kill_tree`](Child::kill_tree)), or each level shutting down its own children,
+    /// which works because a child that owns a console can politely signal its own
+    /// group-leading children.
+    ///
+    /// **Neither route is available to the holder of a nested contained child.** Its `_tree`
+    /// ops are `Unsupported` by design, and the root that owns its teardown lives in the
+    /// intermediate process that spawned it. What that holder can do is exactly this call: the
+    /// cooperative half reaches the nested child's own group and the forced half reaches the
+    /// child. Anything below it that left that group is the intermediate's business — and if the
+    /// intermediate is itself contained by *its* holder, `kill_tree` there is the backstop.
     ///
     /// A watch failure never skips the kill and reap; it surfaces only after they run, and a
     /// kill/reap error takes precedence (the child then stays owned — `Drop`'s teardown
     /// applies).
     pub fn graceful_shutdown(&self, grace: Duration) -> Result<ExitStatus, Error> {
-        crate::wait::terminate(self.id)?; // SIGTERM (Windows: Unsupported, early return)
+        self.terminate()?; // an error here returns before any grace wait or kill
 
         let watch = self.wait_timeout(grace);
         if let Ok(Some(status)) = &watch {

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -45,9 +45,9 @@ impl Child {
     /// process's reach.
     ///
     /// **Success does not prove delivery on Windows.** Windows reports success for an event
-    /// aimed at a group in another console and delivers nothing, and nothing inside this process
-    /// can tell that case from a healthy one. Each such call also leaves a dead entry in the
-    /// caller's console process list.
+    /// aimed at a group in another console and delivers nothing, and this process cannot rule
+    /// that case out: absence from its console list is equally the answer for a healthy child.
+    /// Each such call also leaves a dead entry in the caller's console process list.
     ///
     /// **Every error means nothing was sent and nothing was killed.**
     ///

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -138,7 +138,15 @@ impl Child {
     /// this shows up as `grace` fully elapsing rather than draining early, not as a skipped
     /// wait). The call reports no error either way: on Windows the grace is spent regardless
     /// of how much of the tree the signal reached. Size it accordingly, and treat
-    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member.
+    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member FROM THIS
+    /// HANDLE. The layers the group signal skips are not beyond a polite shutdown: the holder
+    /// of a nested descendant's own `Child` can drain it with
+    /// [`graceful_shutdown`](Child::graceful_shutdown) before this root is torn down, and a
+    /// chain in which each level shuts down its own children drains completely, because a
+    /// child that owns a console can politely signal its own group-leading children.
+    ///
+    /// **And success here does not prove the event was delivered.** A root that shares no
+    /// console with the caller is reported as success and reaches nobody.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -97,7 +97,7 @@ impl Child {
     /// kill/reap error takes precedence (the child then stays owned — `Drop`'s teardown
     /// applies).
     pub fn graceful_shutdown(&self, grace: Duration) -> Result<ExitStatus, Error> {
-        self.terminate()?; // an error here returns before any grace wait or kill
+        self.terminate()?;
 
         let watch = self.wait_timeout(grace);
         if let Ok(Some(status)) = &watch {

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -243,15 +243,50 @@ fn graceful_tree_unassessable_mechanism_failure_fails_fast() {
 // edge at all, not the "skip the sweep" bucket. Proven by forcing `kill_tree` to fail: the call
 // only comes back `Ok` if that branch was never entered. Both arms are real, exercised
 // assertions on every platform, not a skip.
+//
+// Both arms block on a readiness edge from the child's own code before signalling. Without it
+// the child has not registered with the console (Windows) or installed its disposition (Unix)
+// when the signal arrives, and what the test measures is an abrupt death during startup rather
+// than the cooperative path it is named for.
 #[test]
 fn graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() {
+    use std::io::Read;
+
     let mut cmd = crate::Command::new();
     #[cfg(unix)]
-    cmd.args(["sleep", "30"]); // dies to the default-disposition SIGTERM well within grace
+    {
+        // `exec` keeps the signalled root process `sleep` itself, so the SIGTERM assertion below
+        // still means what it means. It dies to the default disposition well within grace.
+        cmd.args(["sh", "-c", "echo r; exec sleep 30"]);
+        cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    }
     #[cfg(windows)]
-    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    let (listener, addr) = crate::test_child::registration_rendezvous();
+    #[cfg(windows)]
+    {
+        cmd.executable(std::env::current_exe().expect("current_exe"))
+            .args(["--exact", crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST]);
+        cmd.env(crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV, addr);
+    }
     cmd.contain();
-    let child = cmd.spawn().expect("spawn");
+    #[allow(unused_mut)]
+    let mut child = cmd.spawn().expect("spawn");
+    #[cfg(unix)]
+    {
+        let mut readiness = [0u8; 1];
+        child
+            .stdout()
+            .expect("piped stdout")
+            .read_exact(&mut readiness)
+            .expect("readiness byte");
+    }
+    #[cfg(windows)]
+    let _sock = {
+        let (mut sock, _) = listener.accept().expect("accept rendezvous connection");
+        let mut tag = [0u8; 1];
+        sock.read_exact(&mut tag).expect("registration tag");
+        sock
+    };
     let authoritative = matches!(
         child.containment(),
         crate::containment::Containment::CgroupV2 | crate::containment::Containment::JobObject
@@ -275,7 +310,11 @@ fn graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() 
             );
         }
         #[cfg(windows)]
-        let _ = status;
+        assert_eq!(
+            status.code(),
+            Some(0xC000013A_u32 as i32),
+            "the root must die to the console event, not to a loader-init kill or the sweep, got {status:?}"
+        );
     } else {
         // Either the marker is advisory (macOS, drain-observable but not authoritative) or
         // there is no kernel drain edge at all: either way the sweep is unconditional by design

--- a/src/child/graceful_tests.rs
+++ b/src/child/graceful_tests.rs
@@ -265,7 +265,9 @@ fn graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() 
     #[cfg(windows)]
     {
         cmd.executable(std::env::current_exe().expect("current_exe"))
-            .args(["--exact", crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST]);
+            .args(crate::test_child::fixture_argv(
+                crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST,
+            ));
         cmd.env(crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV, addr);
     }
     cmd.contain();
@@ -429,7 +431,9 @@ fn windows_graceful_tree_members_remain_surfaces_the_forced_sweep_failure() {
 
     let mut cmd = crate::Command::new();
     cmd.executable(std::env::current_exe().expect("current_exe"))
-        .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
+        .args(crate::test_child::fixture_argv(
+            crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST,
+        ));
     cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV, addr);
     cmd.contain();
     let child = cmd.spawn().expect("spawn");

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -258,7 +258,7 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         use std::os::windows::io::AsRawHandle;
         child.as_raw_handle()
     };
-    let (containment, attached) = match attach_or_fault(
+    let attachment = match attach_or_fault(
         child.id(),
         #[cfg(windows)]
         proc_handle,
@@ -316,8 +316,7 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         id,
         parent_ends,
         kill_on_drop,
-        containment,
-        attached,
+        attachment,
     ))
 }
 
@@ -723,7 +722,7 @@ pub(crate) fn attach_or_fault(
     pid: u32,
     #[cfg(windows)] proc_handle: std::os::windows::io::RawHandle,
     prepared: crate::containment::Prepared,
-) -> Result<(crate::containment::Containment, crate::containment::Attached), Error> {
+) -> Result<crate::containment::Attachment, Error> {
     #[cfg(test)]
     if fault::force_attach_failure() {
         // Capture identity for the test to prove the child is reaped, then simulate an attach

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -154,9 +154,12 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let prepared = crate::containment::Prepared {
         mode: req.mode,
         is_root,
+        // From the FINAL flag word this backend passed to CreateProcessW, not from
+        // `contain_flags` alone: the derivation must read what the OS was actually given.
+        graceful: crate::containment::windows::mechanism_from_flags(flags),
     };
     let raw_handle = proc.as_raw_handle();
-    let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {
+    let attachment = match attach_or_fault(pid, raw_handle, prepared) {
         Ok(v) => v,
         Err(e) => {
             raw_spawn_teardown(proc, pid);
@@ -176,8 +179,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
         id,
         parent_ends,
         kill_on_drop,
-        containment,
-        attached,
+        attachment,
     ))
 }
 

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -14,12 +14,8 @@
 //! (broker-spawned helpers, privilege, `setsid` out of a process group). It
 //! reliably tears down *cooperative* trees and reports the achieved guarantee.
 //!
-//! **Tree ownership and cooperative-signal mechanism are independent axes.**
-//! [`Containment`] answers "who tears this tree down";
-//! [`GracefulMechanism`](crate::GracefulMechanism) answers "what cooperative signal
-//! `terminate()` sends to this child, and how far it goes". On Windows the two are correlated
-//! only because containment is currently the only thing that sets `CREATE_NEW_PROCESS_GROUP` —
-//! a coincidence deliberately encoded nowhere.
+//! [`Containment`] answers "who tears this tree down". What cooperative signal `terminate()`
+//! sends the child is an independent axis — see [`crate::graceful`].
 
 use std::fmt;
 

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -293,7 +293,7 @@ pub(crate) mod treewalk;
 #[path = "containment/dispatch.rs"]
 pub(crate) mod dispatch;
 #[allow(unused_imports)]
-pub(crate) use dispatch::{attach, prepare, Attached, Prepared};
+pub(crate) use dispatch::{attach, prepare, Attached, Attachment, Prepared};
 
 #[cfg(target_os = "macos")]
 #[path = "containment/marker_eof.rs"]

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -13,6 +13,13 @@
 //! This is NOT a security sandbox: a determined child escapes every mechanism
 //! (broker-spawned helpers, privilege, `setsid` out of a process group). It
 //! reliably tears down *cooperative* trees and reports the achieved guarantee.
+//!
+//! **Tree ownership and cooperative-signal mechanism are independent axes.**
+//! [`Containment`] answers "who tears this tree down";
+//! [`GracefulMechanism`](crate::GracefulMechanism) answers "what cooperative signal
+//! `terminate()` sends to this child, and how far it goes". On Windows the two are correlated
+//! only because containment is currently the only thing that sets `CREATE_NEW_PROCESS_GROUP` —
+//! a coincidence deliberately encoded nowhere.
 
 use std::fmt;
 
@@ -64,6 +71,10 @@ pub enum Containment {
     /// A nested member of an ancestor's containment group/job: this child joined the
     /// tree the outermost root owns, so it drives no teardown itself (`can_teardown()`
     /// is `false`) and its `_tree` ops return `Unsupported`. The root tears the tree down.
+    ///
+    /// It is still independently signallable through its own handle wherever
+    /// [`Child::graceful_mechanism`](crate::Child::graceful_mechanism) says so — owning no tree
+    /// is not the same as having no cooperative shutdown.
     Delegated,
     /// No containment — `kill`/drop act on the lone process.
     None,

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -56,17 +56,17 @@ impl Attachment {
     /// The attachment for a UAC-elevated spawn, which `ShellExecuteEx("runas")` creates through
     /// a system service with creation flags this process never sees and never chose.
     ///
-    /// The mechanism is `OtherConsoleGroup`, not `None`: what is observable is that the elevated
-    /// child runs in a console that is not ours, so there is no in-process route. `None` would
-    /// be the stronger claim that no cooperative signal exists from any process ever, and cosca
-    /// cannot make it about a child it did not create.
+    /// The mechanism is `Unknown`, so [`crate::graceful::signal`] refuses this child rather than
+    /// addressing a console control event to its pid. `OtherConsoleGroup` would claim a route to
+    /// a group known to exist, and `None` that no cooperative signal exists from any process
+    /// ever; cosca can make neither claim about a child it did not create.
     ///
     /// Named for its single use so nothing else adopts it.
     pub(crate) fn uac_elevated() -> Attachment {
         Attachment {
             containment: Containment::None,
             attached: Attached::None,
-            graceful: crate::graceful::GracefulMechanism::OtherConsoleGroup,
+            graceful: crate::graceful::GracefulMechanism::Unknown,
         }
     }
 }

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -60,8 +60,6 @@ impl Attachment {
     /// addressing a console control event to its pid. `OtherConsoleGroup` would claim a route to
     /// a group known to exist, and `None` that no cooperative signal exists from any process
     /// ever; cosca can make neither claim about a child it did not create.
-    ///
-    /// Named for its single use so nothing else adopts it.
     pub(crate) fn uac_elevated() -> Attachment {
         Attachment {
             containment: Containment::None,

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -20,6 +20,55 @@ pub(crate) struct Prepared {
     /// process group).
     #[cfg(target_os = "macos")]
     pub marker: Option<crate::containment::fdmarker::PreparedMarker>,
+    /// The cooperative-signal mechanism implied by the creation-flag word this spawn passed to
+    /// `CreateProcessW`. Set by whichever backend chose that word, so the derivation reads what
+    /// the OS was actually given.
+    #[cfg(windows)]
+    pub graceful: crate::graceful::GracefulMechanism,
+}
+
+impl Prepared {
+    /// The cooperative-signal mechanism for a child spawned from this decision. The `cfg` lives
+    /// here, once, so no spawn path carries one for it: every non-Windows child cosca owns can
+    /// be sent an identity-bound `SIGTERM`, whatever its containment.
+    pub(crate) fn graceful_mechanism(&self) -> crate::graceful::GracefulMechanism {
+        #[cfg(windows)]
+        return self.graceful;
+        #[cfg(not(windows))]
+        return crate::graceful::GracefulMechanism::Process;
+    }
+}
+
+/// What a spawn achieved, beyond the child handle itself: the tree-teardown mechanism and the
+/// cooperative-signal mechanism, which are independent axes (see [`crate::graceful`]).
+///
+/// Bundled rather than threaded as separate positional arguments so the spawn constructors do
+/// not grow an argument per spawn fact, and so a new fact is a compile error at every
+/// construction site rather than a silently diverging path.
+pub(crate) struct Attachment {
+    pub containment: Containment,
+    pub attached: Attached,
+    pub graceful: crate::graceful::GracefulMechanism,
+}
+
+#[cfg(windows)]
+impl Attachment {
+    /// The attachment for a UAC-elevated spawn, which `ShellExecuteEx("runas")` creates through
+    /// a system service with creation flags this process never sees and never chose.
+    ///
+    /// The mechanism is `OtherConsoleGroup`, not `None`: what is observable is that the elevated
+    /// child runs in a console that is not ours, so there is no in-process route. `None` would
+    /// be the stronger claim that no cooperative signal exists from any process ever, and cosca
+    /// cannot make it about a child it did not create.
+    ///
+    /// Named for its single use so nothing else adopts it.
+    pub(crate) fn uac_elevated() -> Attachment {
+        Attachment {
+            containment: Containment::None,
+            attached: Attached::None,
+            graceful: crate::graceful::GracefulMechanism::OtherConsoleGroup,
+        }
+    }
 }
 
 /// Owns the OS containment resource for a spawned child; `hard_kill`/`terminate`
@@ -270,6 +319,8 @@ pub(crate) struct WindowsContain {
     pub creation_flags: u32,
     /// Whether this spawn must set the inherited root marker so descendants join THIS group.
     pub marker_env: bool,
+    /// The cooperative-signal mechanism `creation_flags` implies, derived from that same word.
+    pub graceful: crate::graceful::GracefulMechanism,
 }
 
 /// Decide the Windows pre-spawn containment flags + marker for `req`/`is_root`. Pure — directly
@@ -280,6 +331,7 @@ pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> Wind
         return WindowsContain {
             creation_flags: 0,
             marker_env: false,
+            graceful: crate::containment::windows::mechanism_from_flags(0),
         };
     };
     let creation_flags = if is_root && !matches!(mode, ContainMode::TreeWalk) {
@@ -293,6 +345,7 @@ pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> Wind
     WindowsContain {
         creation_flags,
         marker_env: is_root && req.nesting == Nesting::Mark,
+        graceful: crate::containment::windows::mechanism_from_flags(creation_flags),
     }
 }
 
@@ -315,6 +368,9 @@ pub(crate) fn prepare(
             cgroup_leaf: None,
             #[cfg(target_os = "macos")]
             marker: None,
+            // An uncontained spawn passes no creation flags, so it leads no group of its own.
+            #[cfg(windows)]
+            graceful: crate::containment::windows::mechanism_from_flags(0),
         };
     }
     let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
@@ -415,12 +471,13 @@ pub(crate) fn prepare(
     // root marker itself is applied above (shared with the Unix path), so only the creation
     // flags are applied here.
     #[cfg(windows)]
-    if mode.is_some() {
+    let graceful = {
         use std::os::windows::process::CommandExt;
         crate::containment::windows::clear_std_handle_inheritance();
         let setup = windows_contain_setup(req, is_root);
         std_cmd.creation_flags(setup.creation_flags);
-    }
+        setup.graceful
+    };
 
     #[allow(unreachable_code)]
     Prepared {
@@ -430,13 +487,36 @@ pub(crate) fn prepare(
         cgroup_leaf: None,
         #[cfg(target_os = "macos")]
         marker,
+        #[cfg(windows)]
+        graceful,
     }
 }
 
-/// Phase 2 (after spawn, before SharedChild::new): attach the mechanism.
-/// Consumes `prepared` so Linux cgroup leaf ownership transfers cleanly to
-/// `Attached::Cgroup` without requiring interior mutability.
+/// Phase 2 (after spawn, before SharedChild::new): attach the mechanism and bundle it with the
+/// spawn's other achieved facts. Consumes `prepared` so Linux cgroup leaf ownership transfers
+/// cleanly to `Attached::Cgroup` without requiring interior mutability — hence the
+/// cooperative-signal mechanism is read off it first.
 pub(crate) fn attach(
+    pid: u32,
+    #[cfg(windows)] proc_handle: std::os::windows::io::RawHandle,
+    prepared: Prepared,
+) -> Result<Attachment, Error> {
+    let graceful = prepared.graceful_mechanism();
+    let (containment, attached) = attach_tree(
+        pid,
+        #[cfg(windows)]
+        proc_handle,
+        prepared,
+    )?;
+    Ok(Attachment {
+        containment,
+        attached,
+        graceful,
+    })
+}
+
+/// The tree-teardown half of [`attach`]: which mechanism owns this child's tree.
+fn attach_tree(
     pid: u32,
     #[cfg(windows)] proc_handle: std::os::windows::io::RawHandle,
     prepared: Prepared,

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -158,19 +158,22 @@ fn nested_attach_is_delegated() {
             cgroup_leaf: None,
             #[cfg(target_os = "macos")]
             marker: None,
+            #[cfg(windows)]
+            graceful: crate::containment::windows::mechanism_from_flags(crate::containment::windows::group_flags()),
         };
         #[cfg(windows)]
         let proc_handle = {
             use std::os::windows::io::AsRawHandle;
             child.as_raw_handle()
         };
-        let (containment, attached) = attach(
+        let attachment = attach(
             child.id(),
             #[cfg(windows)]
             proc_handle,
             prepared,
         )
         .expect("attach nested");
+        let (containment, attached) = (attachment.containment, attachment.attached);
         // Reap before asserting: `attached` is owned and independent of `child`, so a
         // failing assertion must not leak the helper (the nested arms don't touch it).
         let _ = child.kill();
@@ -457,4 +460,55 @@ fn wait_drained_reports_members_remain_then_all_markers_closed() {
             .expect("unbounded wait after the holder exits"),
         TreeDrain::AllMarkersClosed
     );
+}
+
+/// The three shapes `windows_contain_setup` can produce must not all agree: an uncontained
+/// spawn leads no group, while both contained shapes do. Lives here rather than in
+/// `windows_tests.rs` because `windows_contain_setup` is defined in this module.
+#[cfg(windows)]
+#[test]
+fn windows_contain_setup_records_the_mechanism_of_the_flags_it_chose() {
+    use super::windows_contain_setup;
+    use crate::containment::{ContainMode, ContainRequest, Nesting};
+    use crate::graceful::GracefulMechanism;
+
+    let uncontained = ContainRequest {
+        mode: None,
+        nesting: Nesting::Mark,
+    };
+    let contained = ContainRequest {
+        mode: Some(ContainMode::Strongest),
+        nesting: Nesting::Mark,
+    };
+    assert_eq!(
+        windows_contain_setup(&uncontained, true).graceful,
+        GracefulMechanism::None,
+        "an uncontained spawn passes no flags, so it leads no group"
+    );
+    assert_eq!(
+        windows_contain_setup(&contained, true).graceful,
+        GracefulMechanism::ConsoleGroup,
+        "a Strongest root spawns suspended into its own group"
+    );
+    assert_eq!(
+        windows_contain_setup(&contained, false).graceful,
+        GracefulMechanism::ConsoleGroup,
+        "a nested spawn leads its own group too"
+    );
+}
+
+/// The UAC-elevated attachment bypasses `mechanism_from_flags` entirely — nothing in the flag
+/// matrix covers it — so its three fields are pinned here. `OtherConsoleGroup`, not the `None` a
+/// flagless spawn yields: a copy-paste of the wrong constant must fail.
+#[cfg(windows)]
+#[test]
+fn uac_elevated_attachment_has_no_in_process_route() {
+    use super::{Attached, Attachment};
+    use crate::containment::Containment;
+    use crate::graceful::GracefulMechanism;
+
+    let a = Attachment::uac_elevated();
+    assert_eq!(a.containment, Containment::None);
+    assert!(matches!(a.attached, Attached::None), "got {:?}", a.attached);
+    assert_eq!(a.graceful, GracefulMechanism::OtherConsoleGroup);
 }

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -498,8 +498,10 @@ fn windows_contain_setup_records_the_mechanism_of_the_flags_it_chose() {
 }
 
 /// The UAC-elevated attachment bypasses `mechanism_from_flags` entirely — nothing in the flag
-/// matrix covers it — so its three fields are pinned here. `OtherConsoleGroup`, not the `None` a
-/// flagless spawn yields: a copy-paste of the wrong constant must fail.
+/// matrix covers it — so its three fields are pinned here. `Unknown`, not the `None` a flagless
+/// spawn yields nor the `OtherConsoleGroup` a suppressed one does: a copy-paste of either must
+/// fail. What the dispatcher then does with the value is
+/// `signal_refuses_a_child_cosca_did_not_create`, in `src/graceful_tests.rs`.
 #[cfg(windows)]
 #[test]
 fn uac_elevated_attachment_has_no_in_process_route() {
@@ -510,5 +512,5 @@ fn uac_elevated_attachment_has_no_in_process_route() {
     let a = Attachment::uac_elevated();
     assert_eq!(a.containment, Containment::None);
     assert!(matches!(a.attached, Attached::None), "got {:?}", a.attached);
-    assert_eq!(a.graceful, GracefulMechanism::OtherConsoleGroup);
+    assert_eq!(a.graceful, GracefulMechanism::Unknown);
 }

--- a/src/containment/treewalk.rs
+++ b/src/containment/treewalk.rs
@@ -377,10 +377,11 @@ pub(crate) mod fault {
 /// spawned with `CREATE_NEW_PROCESS_GROUP`). This is cooperative only and reaches
 /// only processes that share the root's console group; a nested *contained*
 /// descendant is spawned into its OWN process group (`CREATE_NEW_PROCESS_GROUP`)
-/// and therefore does NOT receive this CTRL_BREAK. There is no per-process
-/// graceful signal on Windows, so graceful `terminate` cannot reach those nested
-/// groups — the identity `hard_kill` (`kill_tree`) is the guaranteed sweep that
-/// does. Best-effort by design.
+/// and therefore does NOT receive this CTRL_BREAK. THIS WALK cannot reach those
+/// nested groups — but their own holder can, through the nested child's own handle
+/// (see [`Child::terminate`](crate::Child::terminate)). From a single handle, the
+/// identity `hard_kill` (`kill_tree`) remains the only op that reaches every member.
+/// Best-effort by design.
 pub(crate) fn terminate(root: ProcessId) -> Result<(), crate::error::Error> {
     #[cfg(unix)]
     {

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -346,6 +346,17 @@ pub(crate) fn classify_ctrl_event_failure(pid: u32, err: io::Error, console: io:
 /// can deliver an event to it, and `kill`/`kill_tree` need no console at all. And every call —
 /// including one to an ordinary group that has already drained — leaves a dead entry in the
 /// caller's console process list, which persists after the target exits.
+///
+/// **Absence from the caller's console list is not grounds to refuse.** Membership is readable
+/// (`GetConsoleProcessList`), so the first gap's condition is decidable here; the inference is
+/// what is missing. Absence is consistent with three states and only one of them is a
+/// non-delivery. A contained child is absent at the instant `spawn()` returns — measured 0/10,
+/// and 0/10 again for the suspend-then-resume shape a contained root uses — while a signal in
+/// that window is delivered and kills it, so refusing would turn a working teardown into an
+/// error. An already-exited child is absent too, because a real member's entry is removed on
+/// exit, where this function's contract is "already-dead ⇒ `Ok`". The genuinely-elsewhere target
+/// is the third, and separating it needs the TARGET's console rather than ours — a broker, not
+/// a probe.
 pub(crate) fn terminate(pid: u32) -> Result<(), crate::error::Error> {
     use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
     debug_assert!(

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -157,14 +157,54 @@ impl Drop for JobHandle {
 /// `CREATE_NEW_PROCESS_GROUP`: child leads its own console group so
 /// `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` can target it.
 /// Shared by the std path and the raw `CreateProcessW` backend via `windows_contain_setup`.
+/// What this word implies about cooperative shutdown is derived by [`mechanism_from_flags`].
 pub(crate) fn root_flags() -> u32 {
     CREATE_SUSPENDED.0 | CREATE_NEW_PROCESS_GROUP.0
 }
 
 /// Pre-spawn creation flags for a nested (non-root) spawn.
 /// Only `CREATE_NEW_PROCESS_GROUP` — no suspension needed for nested spawns.
+/// What this word implies about cooperative shutdown is derived by [`mechanism_from_flags`].
 pub(crate) fn group_flags() -> u32 {
     CREATE_NEW_PROCESS_GROUP.0
+}
+
+/// Which cooperative signal a child spawned with `creation_flags` can be sent, derived from the
+/// flag word the spawn actually passed to `CreateProcessW`.
+///
+/// Three rows:
+///
+/// - `CREATE_NEW_PROCESS_GROUP` absent → [`GracefulMechanism::None`]. The child sits in the
+///   spawner's group, so no console control event can ever be addressed to it individually by
+///   any process, and group leadership cannot be changed after creation. This is the one flat
+///   negative the flag word settles absolutely.
+/// - the group flag set, and none of `DETACHED_PROCESS` / `CREATE_NEW_CONSOLE` /
+///   `CREATE_NO_WINDOW` → [`GracefulMechanism::ConsoleGroup`].
+/// - the group flag set together with any of those three → [`GracefulMechanism::OtherConsoleGroup`].
+///
+/// What the results do **not** mean. `ConsoleGroup` says the flags do not *exclude* in-process
+/// delivery — it is not a claim the child is reachable. Console membership is not a function of
+/// the flag word at all: a GUI-subsystem image never attaches to the spawner's console whatever
+/// the flags say, and any child may `FreeConsole`/`AllocConsole`/`AttachConsole` after it starts.
+/// An out-of-console group makes `GenerateConsoleCtrlEvent` report success while delivering
+/// nothing, which is why the split exists. And `OtherConsoleGroup` is not "unreachable": a child
+/// spawned with window suppression owns a *private* console a helper process can attach to, so
+/// the claim is about the route from here, never a verdict on the child.
+///
+/// Any future creation-flag surface must extend this one function rather than deriving a
+/// mechanism of its own.
+pub(crate) fn mechanism_from_flags(creation_flags: u32) -> crate::graceful::GracefulMechanism {
+    use crate::graceful::GracefulMechanism;
+    use windows::Win32::System::Threading::{CREATE_NEW_CONSOLE, CREATE_NO_WINDOW, DETACHED_PROCESS};
+
+    if creation_flags & CREATE_NEW_PROCESS_GROUP.0 == 0 {
+        return GracefulMechanism::None;
+    }
+    let out_of_console = DETACHED_PROCESS.0 | CREATE_NEW_CONSOLE.0 | CREATE_NO_WINDOW.0;
+    if creation_flags & out_of_console != 0 {
+        return GracefulMechanism::OtherConsoleGroup;
+    }
+    GracefulMechanism::ConsoleGroup
 }
 
 /// Clear the inherit flag on the parent's std handles before spawning. Prevents

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -321,15 +321,37 @@ pub(crate) fn classify_ctrl_event_failure(pid: u32, err: io::Error, console: io:
 /// targeting its `pid` reaches the whole group without affecting the parent's console.
 /// `CTRL_C` cannot be group-targeted; `CTRL_BREAK` is the only option here.
 ///
+/// **Precondition: the caller holds something that pins `pid`** — the owning `Child`'s process
+/// handle, or an identity-verified `ProcessId`. This function takes a raw pid because Win32
+/// offers no verify-then-signal primitive, so an unpinned pid could name a recycled process.
+///
 /// **Requires the CALLER to have a console.** That is the failure this classifies; Windows
 /// can also report `ERROR_INVALID_PARAMETER` for a pid that names no process at all, which
-/// stays a raw `Error::Io`. A group that merely *drained* is not a failure — measured, a dead
-/// group leader still returns success. The failure code is authoritative; the console probe that follows only *confirms* it, so a
-/// console state change in the gap degrades the result to a raw `Error::Io` rather than to a
-/// false `NoConsole`. Targeting a group that is in a *different* console is NOT reported by
-/// Windows at all — it returns success and delivers nothing.
+/// stays a raw `Error::Io`. The failure code is authoritative; the console probe that follows
+/// only *confirms* it, so a console state change in the gap degrades the result to a raw
+/// `Error::Io` rather than to a false `NoConsole`.
+///
+/// **The Win32 return value is evidence in neither direction.** Measured: a target in another
+/// console returns success having delivered nothing, and the same class of target returns
+/// `ERROR_INVALID_PARAMETER` in another configuration. So the classification above must never
+/// be replaced with a return-code check, and success must never be read as delivery.
+///
+/// **An already-exited target is `Ok`**, because the pinned pid stays allocated and the call
+/// succeeds — matching the crate's "already-dead ⇒ `Ok`" contract for the lone signal. A dead
+/// group leader is not proof of an empty group either: a signal addressed to one still reaches
+/// live members of that group.
+///
+/// **Two known gaps a caller must plan around.** A target that shares no console with the caller
+/// is reported as success and receives nothing; a process attached to the child's *own* console
+/// can deliver an event to it, and `kill`/`kill_tree` need no console at all. And every call —
+/// including one to an ordinary group that has already drained — leaves a dead entry in the
+/// caller's console process list, which persists after the target exits.
 pub(crate) fn terminate(pid: u32) -> Result<(), crate::error::Error> {
     use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
+    debug_assert!(
+        pid != 0,
+        "pid 0 addresses every process attached to the caller's console, including the caller"
+    );
     // SAFETY: standard Win32 call targeting the child's own console group.
     match unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) } {
         Ok(()) => Ok(()),

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -195,3 +195,67 @@ fn the_no_console_signature_matches_the_real_win32_mapping() {
         Some(E_INVALID_HANDLE)
     );
 }
+
+// The mechanism the creation-flag word settles, one test per row. Nine inputs, three distinct
+// outcomes: no constant implementation passes, and the last three rows pin that
+// `OtherConsoleGroup` is a statement about a route to a group that EXISTS, not a synonym for
+// "detached" — with no group flag there is nothing to address, whatever the console situation.
+mod mechanism_from_flags_tests {
+    use crate::containment::windows::{group_flags, mechanism_from_flags, root_flags};
+    use crate::graceful::GracefulMechanism;
+    use windows::Win32::System::Threading::{CREATE_NEW_CONSOLE, CREATE_NO_WINDOW, DETACHED_PROCESS};
+
+    #[test]
+    fn mechanism_from_flags_reports_none_for_no_flags() {
+        assert_eq!(mechanism_from_flags(0), GracefulMechanism::None);
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_console_group_for_group_flags() {
+        assert_eq!(mechanism_from_flags(group_flags()), GracefulMechanism::ConsoleGroup);
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_console_group_for_root_flags() {
+        assert_eq!(mechanism_from_flags(root_flags()), GracefulMechanism::ConsoleGroup);
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_other_console_group_for_group_plus_detached() {
+        assert_eq!(
+            mechanism_from_flags(group_flags() | DETACHED_PROCESS.0),
+            GracefulMechanism::OtherConsoleGroup
+        );
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_other_console_group_for_group_plus_new_console() {
+        assert_eq!(
+            mechanism_from_flags(group_flags() | CREATE_NEW_CONSOLE.0),
+            GracefulMechanism::OtherConsoleGroup
+        );
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_other_console_group_for_group_plus_no_window() {
+        assert_eq!(
+            mechanism_from_flags(group_flags() | CREATE_NO_WINDOW.0),
+            GracefulMechanism::OtherConsoleGroup
+        );
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_none_for_detached_without_a_group() {
+        assert_eq!(mechanism_from_flags(DETACHED_PROCESS.0), GracefulMechanism::None);
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_none_for_a_new_console_without_a_group() {
+        assert_eq!(mechanism_from_flags(CREATE_NEW_CONSOLE.0), GracefulMechanism::None);
+    }
+
+    #[test]
+    fn mechanism_from_flags_reports_none_for_no_window_without_a_group() {
+        assert_eq!(mechanism_from_flags(CREATE_NO_WINDOW.0), GracefulMechanism::None);
+    }
+}

--- a/src/elevation/windows.rs
+++ b/src/elevation/windows.rs
@@ -171,7 +171,7 @@ use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 use crate::child::proc_handle::ProcHandle;
 use crate::child::spawn::windows_raw::RawChild;
 use crate::command::CommandInput;
-use crate::containment::{Attached, Containment};
+use crate::containment::Attachment;
 use crate::elevation::plan::Transition;
 use crate::elevation::{ElevatedStdio, ElevatedVia, ElevationReport, Privilege};
 use crate::error::ElevationErrorKind;
@@ -380,8 +380,7 @@ pub(crate) fn spawn_elevated(cmd: &mut Command, kill_on_drop: bool) -> Result<cr
                 id,
                 BTreeMap::new(),
                 kill_on_drop,
-                Containment::None,
-                Attached::None,
+                Attachment::uac_elevated(),
             );
             child.set_elevation(Some(report));
             Ok(child)

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,7 +146,8 @@ pub enum Error {
     /// Typically an unprivileged caller querying a service, or a parent that cannot open
     /// its own elevated child. Also covers the crate's own refusal to act on a target it
     /// cannot address safely — a pid that names a process *group* rather than a single
-    /// process — where nothing was asked of the OS at all; those carry no `source`.
+    /// process, or one the handle no longer pins against reuse — where nothing was asked of
+    /// the OS at all; those carry no `source`.
     #[error("could not determine the target process's state: {detail}")]
     Unassessable {
         detail: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,8 +132,9 @@ pub enum Error {
     Containment { detail: String },
     /// The calling process has no attached console, so Windows' console-group graceful
     /// signal (`CTRL_BREAK`) cannot be delivered — the caller is a GUI-subsystem binary,
-    /// a service, or was spawned detached. Only the *graceful* tree ops are affected;
-    /// `kill_tree` needs no console.
+    /// a service, or was spawned detached. Every graceful op that reaches a console group is
+    /// affected, lone and tree alike; `kill` and `kill_tree` need no console, and a lone or
+    /// nested child that has no `kill_tree` still has `kill`.
     #[error("no attached console for the graceful console-group signal: {detail}")]
     NoConsole { detail: String },
     /// Privilege elevation could not be completed at runtime.

--- a/src/graceful.rs
+++ b/src/graceful.rs
@@ -15,6 +15,9 @@
 //! `FreeConsole`/`AllocConsole`/`AttachConsole` after it starts. So the mechanism says which
 //! signal would be sent and whether this process has a route to send it — never that a given
 //! call will arrive.
+//!
+//! One child has no such word at all: a UAC-elevated one, created on cosca's behalf by a system
+//! service. It reports [`GracefulMechanism::Unknown`], and [`signal`] refuses it.
 
 /// Which cooperative signal [`Child::terminate`](crate::Child::terminate) sends to a child, how
 /// far that signal reaches when it is delivered, and whether this process has a route to deliver
@@ -36,6 +39,11 @@ pub enum GracefulMechanism {
     /// here. Not "unreachable": a process attached to the child's own console can deliver an
     /// event.
     OtherConsoleGroup,
+    /// Windows: **cosca did not create this child.** A system service creates the UAC-elevated
+    /// child, with creation flags this process never sees, so whether it leads a console process
+    /// group of its own is unknowable from here — and a pid that leads none addresses its
+    /// leader's whole group instead. Refused, not attempted.
+    Unknown,
     /// Windows: the child leads no process group of its own, and group leadership is fixed at
     /// creation — so no per-child console control event can be addressed to it by any process,
     /// ever.
@@ -48,6 +56,7 @@ impl std::fmt::Display for GracefulMechanism {
             GracefulMechanism::Process => "process",
             GracefulMechanism::ConsoleGroup => "own console group",
             GracefulMechanism::OtherConsoleGroup => "own console group in another console",
+            GracefulMechanism::Unknown => "unknown",
             GracefulMechanism::None => "none",
         };
         f.write_str(s)
@@ -63,10 +72,10 @@ impl std::fmt::Display for GracefulMechanism {
 pub(crate) fn signal(mechanism: GracefulMechanism, id: crate::identity::ProcessId) -> Result<(), crate::error::Error> {
     match mechanism {
         GracefulMechanism::Process => crate::wait::terminate(id),
-        // One arm for both, because nothing in this process can tell them apart at signal time:
-        // a console control event aimed at a group in another console reports success and
-        // delivers nothing, and refusing `OtherConsoleGroup` would refuse a child that
-        // re-attached itself to our console after it started.
+        // One arm for both. This process's console list is readable, but absence from it does
+        // not imply undeliverable (see `containment::windows::terminate`), and refusing
+        // `OtherConsoleGroup` would refuse a child that re-attached itself to our console after
+        // it started.
         #[cfg(windows)]
         GracefulMechanism::ConsoleGroup | GracefulMechanism::OtherConsoleGroup => {
             crate::containment::windows::terminate(id.pid())
@@ -80,6 +89,15 @@ pub(crate) fn signal(mechanism: GracefulMechanism, id: crate::identity::ProcessI
                 detail: "internal invariant: a console-group mechanism reached signal off Windows".into(),
             })
         }
+        GracefulMechanism::Unknown => Err(crate::error::Error::Unsupported {
+            op: "graceful terminate".into(),
+            platform: std::env::consts::OS,
+            detail: "cosca did not create this child — a system elevation service did — so \
+                     whether it leads a console process group of its own is unknown, and an \
+                     event addressed to its pid would reach its leader's whole group instead. \
+                     Use kill() for a hard teardown."
+                .into(),
+        }),
         GracefulMechanism::None => Err(crate::error::Error::Unsupported {
             op: "graceful terminate".into(),
             platform: std::env::consts::OS,

--- a/src/graceful.rs
+++ b/src/graceful.rs
@@ -17,7 +17,8 @@
 //! call will arrive.
 //!
 //! One child has no such word at all: a UAC-elevated one, created on cosca's behalf by a system
-//! service. It reports [`GracefulMechanism::Unknown`], and [`signal`] refuses it.
+//! service. It reports [`GracefulMechanism::Unknown`], which
+//! [`Child::terminate`](crate::Child::terminate) refuses.
 
 /// Which cooperative signal [`Child::terminate`](crate::Child::terminate) sends to a child, how
 /// far that signal reaches when it is delivered, and whether this process has a route to deliver

--- a/src/graceful.rs
+++ b/src/graceful.rs
@@ -1,0 +1,59 @@
+//! Which cooperative shutdown signal a spawned child can be sent, and how far it reaches.
+//!
+//! Tree ownership and cooperative-signal mechanism are independent axes.
+//! [`Containment`](crate::containment::Containment) / `Attached` answer "who tears this tree
+//! down"; [`GracefulMechanism`] answers "what cooperative signal `terminate()` sends to this
+//! child, and how far it goes". On Windows the two are correlated only because containment is
+//! currently the only thing that sets `CREATE_NEW_PROCESS_GROUP` — a coincidence deliberately
+//! encoded nowhere.
+//!
+//! The mechanism is a **spawn-time** fact, derived on Windows from the creation-flag word the
+//! spawn actually passed to `CreateProcessW`. That word is a sound negative and an unsound
+//! positive: a detaching or window-suppressing flag being present is enough to know the child is
+//! not in this process's console, but no flag can establish that it is. A GUI-subsystem image
+//! never attaches to its spawner's console whatever the flags say, and any child may
+//! `FreeConsole`/`AllocConsole`/`AttachConsole` after it starts. So the mechanism says which
+//! signal would be sent and whether this process has a route to send it — never that a given
+//! call will arrive.
+
+/// Which cooperative signal [`Child::terminate`](crate::Child::terminate) sends to a child, how
+/// far that signal reaches when it is delivered, and whether this process has a route to deliver
+/// it. Queried via [`Child::graceful_mechanism`](crate::Child::graceful_mechanism).
+///
+/// A spawn-time fact, not a delivery guarantee: see the module doc for what the value does and
+/// does not claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GracefulMechanism {
+    /// Unix: an identity-bound `SIGTERM` to this process alone.
+    Process,
+    /// Windows: a console control event to the child's own console process group, whose
+    /// delivery **from this process** the creation flags do not exclude. Not a guarantee, and
+    /// not established per call.
+    ConsoleGroup,
+    /// Windows: **no in-process route.** This process's console is not the one the child would
+    /// receive an event in; whether the child leads a group of its own is not knowable from
+    /// here. Not "unreachable": a process attached to the child's own console can deliver an
+    /// event.
+    OtherConsoleGroup,
+    /// Windows: the child leads no process group of its own, and group leadership is fixed at
+    /// creation — so no per-child console control event can be addressed to it by any process,
+    /// ever.
+    None,
+}
+
+impl std::fmt::Display for GracefulMechanism {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            GracefulMechanism::Process => "process",
+            GracefulMechanism::ConsoleGroup => "own console group",
+            GracefulMechanism::OtherConsoleGroup => "own console group in another console",
+            GracefulMechanism::None => "none",
+        };
+        f.write_str(s)
+    }
+}
+
+#[cfg(test)]
+#[path = "graceful_tests.rs"]
+mod graceful_tests;

--- a/src/graceful.rs
+++ b/src/graceful.rs
@@ -46,9 +46,30 @@ pub enum GracefulMechanism {
     /// leader's whole group instead. Refused, not attempted.
     Unknown,
     /// Windows: the child leads no process group of its own, and group leadership is fixed at
-    /// creation — so no per-child console control event can be addressed to it by any process,
-    /// ever.
+    /// creation — so no console control event can be addressed to it ALONE by any process,
+    /// ever; one aimed at its pid reaches its leader's whole group instead.
     None,
+}
+
+// Gated on `tokio` as well as Windows: the async `Child` is the only handle that can stop
+// pinning its child's pid, so it is the only caller this distinction exists for.
+#[cfg(all(windows, feature = "tokio"))]
+impl GracefulMechanism {
+    /// Whether the signal this mechanism names is addressed to a **bare pid** — no handle, no
+    /// identity check — so a caller whose handle has stopped pinning that pid must refuse rather
+    /// than fire it at whatever the OS has since reissued it to. The mechanisms that send
+    /// nothing at all are false: their refusal is permanent and pid-independent, and reporting
+    /// it as a pinning problem would name the wrong cause and the wrong error variant.
+    ///
+    /// Matched exhaustively, like [`signal`], so a future variant must decide this too.
+    pub(crate) fn addresses_a_bare_pid(self) -> bool {
+        match self {
+            GracefulMechanism::ConsoleGroup | GracefulMechanism::OtherConsoleGroup => true,
+            // Identity-bound (`crate::wait::terminate`), and unconstructible on Windows anyway.
+            GracefulMechanism::Process => false,
+            GracefulMechanism::Unknown | GracefulMechanism::None => false,
+        }
+    }
 }
 
 impl std::fmt::Display for GracefulMechanism {

--- a/src/graceful.rs
+++ b/src/graceful.rs
@@ -54,6 +54,44 @@ impl std::fmt::Display for GracefulMechanism {
     }
 }
 
+/// Send the cooperative signal `mechanism` names to the child with identity `id`. Signal-only:
+/// does not wait or reap. The crate's single dispatch point — every cooperative signal to an
+/// owned child funnels through here.
+///
+/// Matched exhaustively with no wildcard, so a future variant is a compile error at the one
+/// place this decision is made.
+pub(crate) fn signal(mechanism: GracefulMechanism, id: crate::identity::ProcessId) -> Result<(), crate::error::Error> {
+    match mechanism {
+        GracefulMechanism::Process => crate::wait::terminate(id),
+        // One arm for both, because nothing in this process can tell them apart at signal time:
+        // a console control event aimed at a group in another console reports success and
+        // delivers nothing, and refusing `OtherConsoleGroup` would refuse a child that
+        // re-attached itself to our console after it started.
+        #[cfg(windows)]
+        GracefulMechanism::ConsoleGroup | GracefulMechanism::OtherConsoleGroup => {
+            crate::containment::windows::terminate(id.pid())
+        }
+        #[cfg(not(windows))]
+        GracefulMechanism::ConsoleGroup | GracefulMechanism::OtherConsoleGroup => {
+            debug_assert!(false, "a console-group mechanism is unconstructible off Windows");
+            Err(crate::error::Error::Unsupported {
+                op: "graceful terminate".into(),
+                platform: std::env::consts::OS,
+                detail: "internal invariant: a console-group mechanism reached signal off Windows".into(),
+            })
+        }
+        GracefulMechanism::None => Err(crate::error::Error::Unsupported {
+            op: "graceful terminate".into(),
+            platform: std::env::consts::OS,
+            detail: "this child leads no console process group of its own, so no console control \
+                     event can be addressed to it by any process; group leadership is fixed at \
+                     creation. Spawn it with contain() to give it one, or use kill() for a hard \
+                     teardown."
+                .into(),
+        }),
+    }
+}
+
 #[cfg(test)]
 #[path = "graceful_tests.rs"]
 mod graceful_tests;

--- a/src/graceful_tests.rs
+++ b/src/graceful_tests.rs
@@ -38,6 +38,35 @@ fn signal_refuses_a_child_with_no_mechanism() {
     assert!(detail.contains("contain"), "the refusal must name the remedy: {detail}");
 }
 
+// `OtherConsoleGroup` shares `ConsoleGroup`'s arm — the flag word says the child's group lives
+// in another console, but a child may re-attach to ours after it starts, so the signal is
+// attempted rather than refused. No spawn through the public containment API can carry this
+// mechanism (the flag words emitted never produce it), so the dispatcher is the only place the
+// routing can be pinned at all. `Ok` is what separates the two worlds: the `Unsupported` arms
+// refuse, and `wait::terminate` — the only other path out of `signal` — is itself `Unsupported`
+// on Windows.
+#[cfg(windows)]
+#[test]
+fn signal_attempts_a_child_whose_group_may_be_in_another_console() {
+    let mut cmd = crate::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let other = super::signal(GracefulMechanism::OtherConsoleGroup, child.id());
+    let group = super::signal(GracefulMechanism::ConsoleGroup, child.id());
+    assert!(
+        other.is_ok(),
+        "OtherConsoleGroup must be attempted, not refused: {other:?}"
+    );
+    assert_eq!(
+        other.is_ok(),
+        group.is_ok(),
+        "the two console mechanisms must take one path: {other:?} vs {group:?}"
+    );
+    let _ = child.kill_tree();
+    let _ = child.wait();
+}
+
 // The dispatcher's half of `uac_elevated_attachment_has_no_in_process_route`, which pins only
 // the recorded constant. The subject is a live contained child of OUR own, whose group a
 // wrongly-routed event really would reach: a dispatcher that fired at it returns `Ok` (or the

--- a/src/graceful_tests.rs
+++ b/src/graceful_tests.rs
@@ -13,6 +13,7 @@ fn graceful_mechanism_display_is_stable_and_distinct() {
             GracefulMechanism::OtherConsoleGroup,
             "own console group in another console",
         ),
+        (GracefulMechanism::Unknown, "unknown"),
         (GracefulMechanism::None, "none"),
     ];
     for (mechanism, expected) in all {
@@ -35,4 +36,31 @@ fn signal_refuses_a_child_with_no_mechanism() {
         panic!("expected Unsupported, got {err:?}");
     };
     assert!(detail.contains("contain"), "the refusal must name the remedy: {detail}");
+}
+
+// The dispatcher's half of `uac_elevated_attachment_has_no_in_process_route`, which pins only
+// the recorded constant. The subject is a live contained child of OUR own, whose group a
+// wrongly-routed event really would reach: a dispatcher that fired at it returns `Ok` (or the
+// OS's `Io` if the event finds no group), never this typed refusal, so the variant-and-detail
+// assertion below is what separates the two worlds — and the misfire lands on a child this test
+// already owns rather than a stranger.
+#[cfg(windows)]
+#[test]
+fn signal_refuses_a_child_cosca_did_not_create() {
+    let mut cmd = crate::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let child = cmd.spawn().expect("spawn");
+    let mechanism = crate::containment::Attachment::uac_elevated().graceful;
+    let err = super::signal(mechanism, child.id()).expect_err("a child cosca did not create must not be signalled");
+    let crate::error::Error::Unsupported { detail, .. } = &err else {
+        panic!("expected Unsupported, got {err:?}");
+    };
+    assert!(
+        detail.contains("did not create this child"),
+        "the refusal must say whose child this is not: {detail}"
+    );
+    assert!(detail.contains("kill()"), "the refusal must name the remedy: {detail}");
+    let _ = child.kill_tree();
+    let _ = child.wait();
 }

--- a/src/graceful_tests.rs
+++ b/src/graceful_tests.rs
@@ -24,3 +24,15 @@ fn graceful_mechanism_display_is_stable_and_distinct() {
         }
     }
 }
+
+// `None` is the one mechanism the crate refuses up front, and it refuses with the remedy: a
+// wildcard arm that fell through to the console call would return something else entirely.
+#[test]
+fn signal_refuses_a_child_with_no_mechanism() {
+    let id = crate::identity::ProcessId::current();
+    let err = super::signal(GracefulMechanism::None, id).expect_err("no group to address");
+    let crate::error::Error::Unsupported { detail, .. } = &err else {
+        panic!("expected Unsupported, got {err:?}");
+    };
+    assert!(detail.contains("contain"), "the refusal must name the remedy: {detail}");
+}

--- a/src/graceful_tests.rs
+++ b/src/graceful_tests.rs
@@ -1,0 +1,26 @@
+//! Unit tests for the graceful-mechanism vocabulary and its dispatch.
+
+use super::GracefulMechanism;
+
+// The four strings are a stable, distinct vocabulary. Exact, not `contains`: a refactor that
+// collapsed two variants onto one string would still satisfy a substring check.
+#[test]
+fn graceful_mechanism_display_is_stable_and_distinct() {
+    let all = [
+        (GracefulMechanism::Process, "process"),
+        (GracefulMechanism::ConsoleGroup, "own console group"),
+        (
+            GracefulMechanism::OtherConsoleGroup,
+            "own console group in another console",
+        ),
+        (GracefulMechanism::None, "none"),
+    ];
+    for (mechanism, expected) in all {
+        assert_eq!(mechanism.to_string(), expected, "Display for {mechanism:?}");
+    }
+    for (i, (_, a)) in all.iter().enumerate() {
+        for (_, b) in all.iter().skip(i + 1) {
+            assert_ne!(a, b, "two variants share a Display string");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,13 @@
 pub mod containment;
 pub mod elevation;
 pub mod error;
+pub mod graceful;
 pub mod identity;
 pub mod quote;
 pub mod stdio;
 pub use containment::{ContainMode, Containment};
 pub use elevation::{Auth, Backend, ElevatedStdio, ElevatedVia, ElevationReport, EnvSanitizer, Privilege, Secret};
+pub use graceful::GracefulMechanism;
 pub use stdio::{Fd, Stdio};
 
 mod child;

--- a/src/process/graceful.rs
+++ b/src/process/graceful.rs
@@ -10,7 +10,16 @@ use crate::error::Error;
 impl Process {
     /// Send `SIGTERM` to the foreign process — a cooperative request to exit. Signal-only.
     /// Identity-bound (Linux `pidfd_send_signal`; macOS reverify-then-`kill`). Already-dead ⇒
-    /// `Ok`; a real failure (`EPERM`) ⇒ `Err`. Unix only; Windows returns `Unsupported`.
+    /// `Ok`; a real failure (`EPERM`) ⇒ `Err`.
+    ///
+    /// **Windows: `Unsupported`, for two concrete absences.** A `Process` holds only a pid,
+    /// nothing that pins it, and `GenerateConsoleCtrlEvent` takes a raw pid with no
+    /// verify-then-signal form — so a foreign console-group signal cannot be made
+    /// identity-bound, unlike every other op on this type. And Win32 exposes no way to learn
+    /// whether a foreign pid leads a console process group, so a non-leader would silently
+    /// signal *its* leader's whole group instead. An owned [`Child`](crate::Child) has neither
+    /// problem: its held process handle keeps the pid allocated, so the pid can only ever name
+    /// that child's own group.
     pub fn terminate(&self) -> Result<(), Error> {
         crate::wait::terminate(self.id)
     }
@@ -49,9 +58,10 @@ impl Process {
     }
 
     /// Best-effort graceful (`SIGTERM`) sweep of the foreign process's tree (identity-walk, root
-    /// then descendants). Signal-only. Unix only: Windows has no per-process graceful signal and
-    /// a foreign process shares no addressable group with the caller, so this returns `Unsupported`
-    /// there (use [`kill_tree`](Process::kill_tree) for a hard sweep).
+    /// then descendants). Signal-only. Unix only: on Windows this rests on
+    /// [`terminate`](Process::terminate), whose two absences — no pinned pid, and no way to
+    /// learn whether a foreign pid leads a group — apply here too, so it returns `Unsupported`
+    /// (use [`kill_tree`](Process::kill_tree) for a hard sweep).
     pub fn terminate_tree(&self) -> Result<(), Error> {
         #[cfg(unix)]
         {

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -76,3 +76,52 @@ fn fixture_survives_group_signal() {
     let mut sock = std::net::TcpStream::connect(addr.to_str().expect("utf8 addr")).expect("connect readiness socket");
     sock.write_all(b"R").expect("write readiness tag");
 }
+
+/// The fully-qualified libtest path of [`fixture_registers_then_blocks`], for callers that
+/// re-exec this binary against it directly (`current_exe() --exact <this>`).
+#[cfg(windows)]
+pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_TEST: &str = "test_child::fixture_registers_then_blocks";
+
+/// The env var carrying the `127.0.0.1:<port>` address [`fixture_registers_then_blocks`] tags.
+/// Its mere presence also tells the fixture it was re-exec'd deliberately rather than picked up
+/// by an ordinary, unfiltered suite run.
+#[cfg(windows)]
+pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV: &str = "COSCA_FIXTURE_REGISTERS_THEN_BLOCKS_ADDR";
+
+/// Bind a rendezvous listener for [`fixture_registers_then_blocks`]; returns it and its
+/// `127.0.0.1:<port>` address.
+#[cfg(windows)]
+pub(crate) fn registration_rendezvous() -> (std::net::TcpListener, String) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind rendezvous listener");
+    let addr = listener.local_addr().expect("local_addr").to_string();
+    (listener, addr)
+}
+
+/// Windows-only fixture supplying the happens-before edge a cooperative console signal needs: a
+/// no-op when picked up by an ordinary, unfiltered suite run
+/// ([`FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV`] is unset there). Re-executed via `current_exe()
+/// --exact` [`FIXTURE_REGISTERS_THEN_BLOCKS_TEST`] with that var set, it connects to the
+/// caller's listener, writes one tag byte, then blocks on a 1-byte read of that same socket.
+///
+/// The tag is the edge: the fixture cannot write it until it is executing its own code, which is
+/// after the console has registered it. A child signalled before that point dies during loader
+/// init instead of to the console event, which is a different exit code and a different thing
+/// under test.
+///
+/// It installs no console-control handler, so `CTRL_BREAK`'s default disposition terminates it.
+/// Blocking on the socket rather than parking means a panicking or aborted caller closes the
+/// socket and the fixture exits on EOF instead of orphaning.
+#[cfg(windows)]
+#[test]
+fn fixture_registers_then_blocks() {
+    let Some(addr) = std::env::var_os(FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV) else {
+        return; // picked up by an ordinary suite run — deliberately inert
+    };
+    use std::io::{Read, Write};
+
+    let mut sock = std::net::TcpStream::connect(addr.to_str().expect("utf8 addr")).expect("connect rendezvous socket");
+    sock.write_all(b"R").expect("write registration tag");
+    sock.flush().expect("flush registration tag");
+    let mut sink = [0u8; 1];
+    let _ = sock.read(&mut sink);
+}

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -21,6 +21,16 @@ pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
         .expect("spawn")
 }
 
+/// The argv for re-executing this test binary against one fixture through `cosca::Command`,
+/// whose `args` is the **full** argv — libtest drops slot 0 as the binary name, so a filter or
+/// option placed there is silently eaten and `--exact` degrades to substring matching.
+/// `--test-threads=1` keeps a future filter that matches more than one test from running them
+/// concurrently inside a process the caller is about to signal.
+#[cfg(windows)]
+pub(crate) fn fixture_argv(test: &str) -> [&str; 4] {
+    ["cosca_unit_tests", "--test-threads=1", "--exact", test]
+}
+
 /// The fully-qualified libtest path of [`fixture_survives_group_signal`], for callers that
 /// re-exec this binary against it directly (`current_exe() --exact <this>`) rather than through
 /// [`spawn_a_process_that_exits`]'s own filter.

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -434,8 +434,16 @@ impl Child {
     ///
     /// **Windows: what this actually signals.** `CTRL_BREAK` is delivered to the root's
     /// **process group**, not to the tree. A nested contained descendant leads its own
-    /// group and never receives it; only [`kill_tree`](Child::kill_tree) reaches every
-    /// member.
+    /// group and never receives it, so from THIS handle only
+    /// [`kill_tree`](Child::kill_tree) reaches every member. The layers this skips are not
+    /// beyond a polite shutdown, though: the holder of a nested descendant's own `Child` can
+    /// drain it with [`terminate`](Child::terminate) or
+    /// [`graceful_shutdown`](Child::graceful_shutdown) before this root is torn down, and a
+    /// chain in which each level shuts down its own children drains completely, because a
+    /// child that owns a console can politely signal its own group-leading children.
+    ///
+    /// **And success here does not prove the event was delivered.** A root that shares no
+    /// console with the caller is reported as success and reaches nobody.
     ///
     /// **And it needs the caller to have a console.** The event is deliverable only within
     /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -35,6 +35,7 @@ pub struct Child {
     attached: Attached,
     kill_on_drop: bool,
     containment: Containment,
+    graceful: crate::graceful::GracefulMechanism,
     /// Parent ends of fd >= 3 pipes, read by [`fd_read_end`](Child::fd_read_end) /
     /// [`fd_write_end`](Child::fd_write_end). Unix: `command-fds`-wired reactor pipes; Windows: the
     /// raw backend's overlapped async ends (empty on the std path, which routes fd >= 3 to the raw
@@ -53,18 +54,18 @@ impl Child {
     pub(super) fn from_parts(
         proc: ProcSource,
         id: ProcessId,
-        attached: Attached,
         kill_on_drop: bool,
-        containment: Containment,
+        attachment: crate::containment::Attachment,
         pipes: FdPipes,
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
             proc,
             id,
-            attached,
+            attached: attachment.attached,
             kill_on_drop,
-            containment,
+            containment: attachment.containment,
+            graceful: attachment.graceful,
             pipes,
             owned_std,
             elevation: None,
@@ -106,6 +107,11 @@ impl Child {
     }
     pub fn containment(&self) -> Containment {
         self.containment
+    }
+    /// Async mirror of [`Child::graceful_mechanism`](crate::Child::graceful_mechanism) — see
+    /// there for what the value claims, and what it deliberately does not.
+    pub fn graceful_mechanism(&self) -> crate::graceful::GracefulMechanism {
+        self.graceful
     }
 
     pub fn stdin(&mut self) -> Option<super::stdio::ChildStdin> {

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -461,8 +461,23 @@ impl Child {
     /// See [`kill_tree`](Child::kill_tree)'s doc for two things that also apply here: the
     /// `ProcessGroup`/`Session`-only scope of this guarantee (a separate, unfixed gap for
     /// `TreeWalk`), and the residual `hidepid` gap on Linux.
+    ///
+    /// **Windows, after the root's exit has been observed.** The event is addressed by the
+    /// ROOT's pid — on the job-object mechanism and the tree walk alike — and this handle stops
+    /// pinning that pid the moment `wait`/`try_wait` reports the exit, so the OS may reissue it
+    /// to an unrelated group leader. A root exiting while its descendants are still alive is an
+    /// ordinary flow, so this is refused from that point
+    /// ([`Error::Unassessable`](crate::error::Error::Unassessable)) rather than fired at a bare
+    /// pid; [`kill_tree`](Child::kill_tree) addresses no pid and still reaches the survivors.
+    /// The sync [`Child`](crate::Child) pins for its whole life and is unaffected.
     pub fn terminate_tree(&self) -> Result<(), Error> {
         self.require_contained()?;
+        // After the mechanism guard, which is permanent and pid-independent: an uncontained
+        // child must keep hearing why it has no tree to signal, not why a pid is unpinned.
+        #[cfg(windows)]
+        if !self.proc.pins_pid() {
+            return Err(self.unpinned_pid_refusal("terminate_tree"));
+        }
         // See kill_tree's identical precondition assert for the full rationale, including the
         // `#[cfg(unix)]` gate (`carries_recyclable_pgid` does not exist on Windows).
         #[cfg(unix)]
@@ -483,6 +498,25 @@ impl Child {
             self.id.pid()
         );
         self.attached.terminate(self.id.pid())
+    }
+
+    /// The refusal both cooperative ops answer with once this handle has stopped pinning the
+    /// child's pid — the async backend releases the Windows process handle when `wait`/`try_wait`
+    /// observes the exit. Shared so the lone and the tree op cannot drift on what is, for both,
+    /// the same hazard: a console control event carries a bare pid and nothing else.
+    #[cfg(windows)]
+    fn unpinned_pid_refusal(&self, op: &str) -> Error {
+        Error::Unassessable {
+            detail: format!(
+                "this handle no longer pins pid {pid}: the async backend released the child's \
+                 process handle when its exit was observed, so the pid may since name an \
+                 unrelated process. A console control event is addressed by pid alone, so {op}() \
+                 sent nothing. The child itself is already gone; kill_tree() addresses no pid and \
+                 still tears down any survivors.",
+                pid = self.id.pid()
+            ),
+            source: None,
+        }
     }
 
     /// Guard for the `_tree` operations (single-sourced with the sync `Child`).

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -24,21 +24,76 @@ fn take_forced_watch_error() -> Option<Error> {
 }
 
 impl Child {
-    /// Send `SIGTERM` to the (lone) child — a cooperative request to exit. Signal-only: does
-    /// not wait or reap. Identity-bound, so it cannot race a concurrent reap onto a recycled
-    /// pid. Unix only — Windows has no per-process graceful signal and returns `Unsupported`
-    /// (use [`graceful_shutdown_tree`](Child::graceful_shutdown_tree) for a contained child).
+    /// Send the child its cooperative shutdown signal — a request to exit, not an order.
+    /// Signal-only: does not wait or reap.
+    ///
+    /// Which signal, and how far it goes, is per child: read it from
+    /// [`graceful_mechanism`](Child::graceful_mechanism). On Unix it is an identity-bound
+    /// `SIGTERM` to this process alone, so it cannot race a concurrent reap onto a recycled pid.
+    /// On Windows it is `CTRL_BREAK` to the child's own **console process group** — every child
+    /// spawned with [`contain`](crate::tokio::Command::contain), including a nested
+    /// [`Delegated`](crate::Containment::Delegated) one. A child that leads no group of its own
+    /// (an uncontained Windows spawn) is refused with `Unsupported`; `kill` is the
+    /// always-available alternative.
+    ///
+    /// **Windows blast radius.** The event reaches the child's whole console group, so an
+    /// ordinary descendant that stayed in that group is signalled too, while a nested
+    /// *contained* descendant — which leads a group of its own — is not.
+    ///
+    /// **The caller must hold a console** ([`Error::NoConsole`](crate::error::Error::NoConsole)
+    /// otherwise: a GUI-subsystem binary, a service, or a detached spawn cannot deliver console
+    /// control events). A child that owns its own console instead needs a process attached to
+    /// *that* console to signal it — it is not beyond a polite shutdown, just beyond this
+    /// process's reach.
+    ///
+    /// **Success does not prove delivery on Windows.** Windows reports success for an event
+    /// aimed at a group in another console and delivers nothing, and nothing inside this process
+    /// can tell that case from a healthy one. Each such call also leaves a dead entry in the
+    /// caller's console process list.
+    ///
+    /// **Every error means nothing was sent and nothing was killed.**
+    ///
+    /// **Windows, before the child has run.** Between the spawn returning and the child
+    /// executing its first instructions it has not yet registered with any console; an event
+    /// delivered in that window ends it during loader init rather than through its own handler.
+    /// That is an abrupt end, not a failed one, and it is reported `Ok`. A caller that has
+    /// observed anything from the child — a byte of output, a handshake, an exit-status check —
+    /// is past the window and gets a real cooperative signal; a caller that wants the child gone
+    /// before it has run at all should use [`kill`](Child::kill), which is honest about being
+    /// forced.
     pub fn terminate(&self) -> Result<(), Error> {
-        crate::wait::terminate(self.id())
+        crate::graceful::signal(self.graceful_mechanism(), self.id())
     }
 
-    /// Cooperative-then-forced lone shutdown: `SIGTERM`, wait up to `grace` for the child to
-    /// exit, then `SIGKILL` if it has not — reaping either way and returning its `ExitStatus`.
-    /// The status's terminating signal distinguishes a graceful exit from a forced one —
+    /// Cooperative-then-forced lone shutdown: [`terminate`](Child::terminate), wait up to
+    /// `grace` for the child to exit, then hard-kill it if it has not — reaping either way and
+    /// returning its `ExitStatus`. The status distinguishes a graceful exit from a forced one —
     /// best-effort at the boundary: a child that exits of its own accord between the grace
-    /// elapsing and the `SIGKILL` landing reports its own status.
-    /// Escalation proceeds even if the child ignores `SIGTERM`. Unix only; Windows returns
-    /// `Unsupported`. `grace` is relative; `Duration::ZERO` signals, polls once, then escalates.
+    /// elapsing and the kill landing reports its own status. Escalation proceeds even if the
+    /// child ignores the cooperative signal. `grace` is relative; `Duration::ZERO` signals,
+    /// polls once, then escalates.
+    ///
+    /// Every caveat on [`terminate`](Child::terminate) applies to the cooperative half, and a
+    /// cooperative-signal error propagates immediately: no grace is waited, nothing is killed,
+    /// and the child is left running for the caller to `kill`.
+    ///
+    /// **Windows: the two halves have different radii.** The cooperative half reaches the
+    /// child's whole console group; the forced half reaches only the child. So a descendant
+    /// that stayed in the child's group can be left told-to-exit but not killed: if the child
+    /// itself exits within `grace`, this returns `Ok` while that descendant — possibly hung
+    /// mid-shutdown — keeps running, with no hard backstop and no error. For a leaf child, the
+    /// common case, the two radii are identical. Two routes give matched radii: the tree
+    /// variants on a contained root ([`graceful_shutdown_tree`](Child::graceful_shutdown_tree)
+    /// plus [`kill_tree`](Child::kill_tree)), or each level shutting down its own children,
+    /// which works because a child that owns a console can politely signal its own
+    /// group-leading children.
+    ///
+    /// **Neither route is available to the holder of a nested contained child.** Its `_tree`
+    /// ops are `Unsupported` by design, and the root that owns its teardown lives in the
+    /// intermediate process that spawned it. What that holder can do is exactly this call: the
+    /// cooperative half reaches the nested child's own group and the forced half reaches the
+    /// child. Anything below it that left that group is the intermediate's business — and if the
+    /// intermediate is itself contained by *its* holder, `kill_tree` there is the backstop.
     ///
     /// Dropping this future mid-grace cancels the exit watch (the `AsyncFd` deregisters and
     /// the fd closes) and performs no further signalling — the child stays owned, and
@@ -54,11 +109,11 @@ impl Child {
     /// `#[tokio::test]` defaults) — on a hand-built runtime missing either, tokio panics
     /// rather than returning a typed error.
     pub async fn graceful_shutdown(&mut self, grace: Duration) -> Result<ExitStatus, Error> {
-        crate::wait::terminate(self.id())?;
-        // A watch failure must not strand the child between the soft signal and the
-        // escalation — kill and reap still run (grace unobservable => escalate now); the
-        // watch error surfaces only after they succeed (a kill/reap error wins — deliberate
-        // subsumption, mirroring kill_tree's both-fail disposition).
+        self.terminate()?; // an error here returns before any grace wait or kill
+                           // A watch failure must not strand the child between the soft signal and the
+                           // escalation — kill and reap still run (grace unobservable => escalate now); the
+                           // watch error surfaces only after they succeed (a kill/reap error wins — deliberate
+                           // subsumption, mirroring kill_tree's both-fail disposition).
         let watch = crate::tokio::wait::grace_wait(self.id(), grace).await;
         if !matches!(watch, Ok(true)) {
             if let Err(e) = &watch {
@@ -97,7 +152,15 @@ impl Child {
     /// this shows up as `grace` fully elapsing rather than draining early, not as a skipped
     /// wait). The call reports no error either way: on Windows the grace is spent regardless
     /// of how much of the tree the signal reached. Size it accordingly, and treat
-    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member.
+    /// [`kill_tree`](Child::kill_tree) as the only op that reaches every member FROM THIS
+    /// HANDLE. The layers the group signal skips are not beyond a polite shutdown: the holder
+    /// of a nested descendant's own `Child` can drain it with
+    /// [`graceful_shutdown`](Child::graceful_shutdown) before this root is torn down, and a
+    /// chain in which each level shuts down its own children drains completely, because a
+    /// child that owns a console can politely signal its own group-leading children.
+    ///
+    /// **And success here does not prove the event was delivered.** A root that shares no
+    /// console with the caller is reported as success and reaches nobody.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -47,9 +47,9 @@ impl Child {
     /// process's reach.
     ///
     /// **Success does not prove delivery on Windows.** Windows reports success for an event
-    /// aimed at a group in another console and delivers nothing, and nothing inside this process
-    /// can tell that case from a healthy one. Each such call also leaves a dead entry in the
-    /// caller's console process list.
+    /// aimed at a group in another console and delivers nothing, and this process cannot rule
+    /// that case out: absence from its console list is equally the answer for a healthy child.
+    /// Each such call also leaves a dead entry in the caller's console process list.
     ///
     /// **Every error means nothing was sent and nothing was killed.**
     ///
@@ -61,7 +61,27 @@ impl Child {
     /// is past the window and gets a real cooperative signal; a caller that wants the child gone
     /// before it has run at all should use [`kill`](Child::kill), which is honest about being
     /// forced.
+    ///
+    /// **Windows, after the exit has been observed.** A console control event is addressed by
+    /// pid alone, and this handle stops pinning the child's pid the moment `wait`/`try_wait`
+    /// reports the exit — the async backend releases the process handle there, so the OS may
+    /// reissue the pid to an unrelated group leader. From that point the call is refused
+    /// ([`Error::Unassessable`](crate::error::Error::Unassessable)) rather than fired at a bare
+    /// pid. The sync [`Child`](crate::Child) pins for its whole life and answers `Ok`.
     pub fn terminate(&self) -> Result<(), Error> {
+        #[cfg(windows)]
+        if !self.proc.pins_pid() {
+            return Err(Error::Unassessable {
+                detail: format!(
+                    "this handle no longer pins pid {pid}: the async backend released the \
+                     child's process handle when its exit was observed, so the pid may since \
+                     name an unrelated process. A console control event is addressed by pid \
+                     alone, so nothing was sent — and the child is already gone.",
+                    pid = self.id().pid()
+                ),
+                source: None,
+            });
+        }
         crate::graceful::signal(self.graceful_mechanism(), self.id())
     }
 

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -67,22 +67,17 @@ impl Child {
     /// reports the exit — the async backend releases the process handle there, so the OS may
     /// reissue the pid to an unrelated group leader. From that point the call is refused
     /// ([`Error::Unassessable`](crate::error::Error::Unassessable)) rather than fired at a bare
-    /// pid. The sync [`Child`](crate::Child) pins for its whole life and answers `Ok`.
+    /// pid. The sync [`Child`](crate::Child) pins for its whole life and answers `Ok`. A
+    /// mechanism that addresses no pid keeps its own answer: an uncontained Windows child is
+    /// `Unsupported` before and after the reap alike, because nothing was ever going to be sent
+    /// to a pid in the first place.
     pub fn terminate(&self) -> Result<(), Error> {
+        let mechanism = self.graceful_mechanism();
         #[cfg(windows)]
-        if !self.proc.pins_pid() {
-            return Err(Error::Unassessable {
-                detail: format!(
-                    "this handle no longer pins pid {pid}: the async backend released the \
-                     child's process handle when its exit was observed, so the pid may since \
-                     name an unrelated process. A console control event is addressed by pid \
-                     alone, so nothing was sent — and the child is already gone.",
-                    pid = self.id().pid()
-                ),
-                source: None,
-            });
+        if mechanism.addresses_a_bare_pid() && !self.proc.pins_pid() {
+            return Err(self.unpinned_pid_refusal("terminate"));
         }
-        crate::graceful::signal(self.graceful_mechanism(), self.id())
+        crate::graceful::signal(mechanism, self.id())
     }
 
     /// Cooperative-then-forced lone shutdown: [`terminate`](Child::terminate), wait up to
@@ -129,11 +124,11 @@ impl Child {
     /// `#[tokio::test]` defaults) — on a hand-built runtime missing either, tokio panics
     /// rather than returning a typed error.
     pub async fn graceful_shutdown(&mut self, grace: Duration) -> Result<ExitStatus, Error> {
-        self.terminate()?; // an error here returns before any grace wait or kill
-                           // A watch failure must not strand the child between the soft signal and the
-                           // escalation — kill and reap still run (grace unobservable => escalate now); the
-                           // watch error surfaces only after they succeed (a kill/reap error wins — deliberate
-                           // subsumption, mirroring kill_tree's both-fail disposition).
+        self.terminate()?;
+        // A watch failure must not strand the child between the soft signal and the escalation —
+        // kill and reap still run (grace unobservable => escalate now); the watch error surfaces
+        // only after they succeed (a kill/reap error wins — deliberate subsumption, mirroring
+        // kill_tree's both-fail disposition).
         let watch = crate::tokio::wait::grace_wait(self.id(), grace).await;
         if !matches!(watch, Ok(true)) {
             if let Err(e) = &watch {

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -220,11 +220,41 @@ async fn async_graceful_tree_unassessable_mechanism_failure_fails_fast() {
 async fn async_graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_authoritative() {
     let mut cmd = crate::tokio::Command::new();
     #[cfg(unix)]
-    cmd.args(["sleep", "30"]);
+    {
+        cmd.args(["sh", "-c", "echo r; exec sleep 30"]);
+        cmd.stdout(crate::Stdio::pipe()).expect("set stdout pipe");
+    }
     #[cfg(windows)]
-    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    let (listener, addr) = crate::test_child::registration_rendezvous();
+    #[cfg(windows)]
+    {
+        cmd.executable(std::env::current_exe().expect("current_exe"))
+            .args(["--exact", crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST]);
+        cmd.env(crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV, addr);
+    }
     cmd.contain();
     let mut child = cmd.spawn().expect("spawn");
+    #[cfg(unix)]
+    {
+        use tokio::io::AsyncReadExt;
+        let mut readiness = [0u8; 1];
+        child
+            .stdout()
+            .expect("piped stdout")
+            .read_exact(&mut readiness)
+            .await
+            .expect("readiness byte");
+    }
+    // Blocking `std::net::TcpListener`, exactly like the sibling Windows test above: a bounded
+    // wait for a real connection, not a poll loop.
+    #[cfg(windows)]
+    let _sock = {
+        use std::io::Read;
+        let (mut sock, _) = listener.accept().expect("accept rendezvous connection");
+        let mut tag = [0u8; 1];
+        sock.read_exact(&mut tag).expect("registration tag");
+        sock
+    };
     let authoritative = matches!(
         child.containment(),
         crate::containment::Containment::CgroupV2 | crate::containment::Containment::JobObject
@@ -248,7 +278,11 @@ async fn async_graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_auth
             );
         }
         #[cfg(windows)]
-        let _ = status;
+        assert_eq!(
+            status.code(),
+            Some(0xC000013A_u32 as i32),
+            "the root must die to the console event, not to a loader-init kill or the sweep, got {status:?}"
+        );
     } else {
         let err = result.expect_err("a non-authoritative mechanism must always run the sweep");
         assert!(

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -229,7 +229,9 @@ async fn async_graceful_tree_drained_skips_sweep_only_when_the_mechanism_is_auth
     #[cfg(windows)]
     {
         cmd.executable(std::env::current_exe().expect("current_exe"))
-            .args(["--exact", crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST]);
+            .args(crate::test_child::fixture_argv(
+                crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST,
+            ));
         cmd.env(crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV, addr);
     }
     cmd.contain();
@@ -362,7 +364,9 @@ async fn windows_async_graceful_tree_members_remain_surfaces_the_forced_sweep_fa
 
     let mut cmd = crate::tokio::Command::new();
     cmd.executable(std::env::current_exe().expect("current_exe"))
-        .args(["--exact", crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST]);
+        .args(crate::test_child::fixture_argv(
+            crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_TEST,
+        ));
     cmd.env(crate::test_child::FIXTURE_SURVIVES_GROUP_SIGNAL_ADDR_ENV, addr);
     cmd.contain();
     let mut child = cmd.spawn().expect("spawn");
@@ -382,6 +386,43 @@ async fn windows_async_graceful_tree_members_remain_surfaces_the_forced_sweep_fa
     // Cleanup: the forced sweep failure was a stub, so the group-signal-immune descendant is
     // still alive — a real sweep now (the seam is already consumed) actually kills it.
     let _ = child.kill_tree();
+}
+
+// The lone graceful ops must not fire a pid-addressed console event once the backend has reaped:
+// tokio replaces its inner state on `wait`, dropping the guard that holds the process handle, and
+// the OS may reissue that pid to a process leading a group in this console.
+//
+// `.contain()` is load-bearing — an uncontained child reports `GracefulMechanism::None` and would
+// be refused before the pid ever mattered, which is the wrong reason. Both assertions read the
+// error's VARIANT, not merely that one exists: an unguarded call returns `Ok` or the OS's `Io`,
+// never `Unassessable`, whichever way the recycled pid falls.
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_async_lone_graceful_ops_refuse_once_the_backend_has_reaped() {
+    let mut cmd = crate::tokio::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    assert_eq!(
+        child.graceful_mechanism(),
+        crate::graceful::GracefulMechanism::ConsoleGroup,
+        "the subject must be a child the signal would otherwise be sent to"
+    );
+    child.kill().expect("kill");
+    child.wait().await.expect("reap"); // tokio unpins the pid here
+    let err = child.terminate().expect_err("an unpinned pid must not be signalled");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
+        "got {err:?}"
+    );
+    let err = child
+        .graceful_shutdown(Duration::ZERO)
+        .await
+        .expect_err("the escalation trio inherits the refusal from its cooperative half");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
+        "got {err:?}"
+    );
 }
 
 // Async twin of `graceful_tree_non_containment_terminate_error_fails_fast`.

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -425,6 +425,68 @@ async fn windows_async_lone_graceful_ops_refuse_once_the_backend_has_reaped() {
     );
 }
 
+// The TREE graceful ops must refuse on the same terms: both Windows arms of `terminate_tree`
+// (job object and tree walk) address the root's bare pid exactly like the lone `terminate`, and
+// a root that exits while its descendants are still alive is the ordinary reason to reach for a
+// tree signal at all. The refusal is `Unassessable` — not `Ok`, which is what an unguarded call
+// returns after firing at whatever now holds the pid — and `graceful_shutdown_tree` inherits it:
+// the trace asserted below fires only if `terminate_tree` refused.
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_async_tree_graceful_ops_refuse_once_the_backend_has_reaped() {
+    let mut cmd = crate::tokio::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain();
+    let mut child = cmd.spawn().expect("spawn");
+    let id = child.id();
+    child.kill().expect("kill");
+    child.wait().await.expect("reap"); // tokio unpins the pid here
+    let err = child
+        .terminate_tree()
+        .expect_err("an unpinned pid must not be signalled");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { source: None, .. }),
+        "got {err:?}"
+    );
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    // Held, then superseded by the drained tree — the refusal reaching `graceful_shutdown_tree`
+    // at all is what this proves, not the disposition it already documents for that shape.
+    child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect("a drained tree supersedes the held refusal");
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "graceful_shutdown_tree must inherit the refusal from its cooperative half"
+    );
+}
+
+// The pid guard must not swallow the refusals that never address a pid. An uncontained Windows
+// child records `GracefulMechanism::None` — permanent and pid-independent — so it must keep
+// answering `Unsupported` (what its own doc promises, and what the sync mirror returns for the
+// identical child) after the backend has unpinned the pid, not `Unassessable`, which is
+// documented as a transient could-not-determine condition a caller may retry.
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_async_lone_terminate_keeps_a_pid_independent_refusal_after_a_reap() {
+    let mut cmd = crate::tokio::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]); // uncontained: leads no group of its own
+    let mut child = cmd.spawn().expect("spawn");
+    assert_eq!(
+        child.graceful_mechanism(),
+        crate::graceful::GracefulMechanism::None,
+        "the subject must be a child whose refusal is permanent, not pid-dependent"
+    );
+    child.kill().expect("kill");
+    child.wait().await.expect("reap"); // tokio unpins the pid here
+    let err = child.terminate().expect_err("a child that leads no group is refused");
+    assert!(matches!(err, crate::error::Error::Unsupported { .. }), "got {err:?}");
+}
+
 // Async twin of `graceful_tree_non_containment_terminate_error_fails_fast`.
 #[tokio::test]
 async fn async_graceful_tree_non_containment_terminate_error_fails_fast() {

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -66,6 +66,18 @@ impl ProcSource {
         }
     }
 
+    /// Whether the backend still holds something that pins the child's pid against reuse.
+    /// tokio's `Child` replaces its inner state the moment `wait`/`try_wait` observes the exit,
+    /// dropping the guard that holds the process handle (`id()` goes `None` with it); the raw
+    /// backend owns its handle for the child's whole life and never unpins.
+    #[cfg(windows)]
+    pub(crate) fn pins_pid(&self) -> bool {
+        match self {
+            ProcSource::Tokio(c) => c.id().is_some(),
+            ProcSource::Raw(_) => true,
+        }
+    }
+
     /// Signal a hard kill (does not reap). Already-exited ⇒ `Ok`.
     pub(crate) fn start_kill(&mut self) -> Result<(), Error> {
         match self {

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -41,9 +41,8 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                     let mut child = Child::from_parts(
                         ProcSource::Raw(raw),
                         id,
-                        crate::containment::Attached::None,
                         kill_on_drop,
-                        crate::containment::Containment::None,
+                        crate::containment::Attachment::uac_elevated(),
                         super::child::FdPipes::new(),
                         std::collections::BTreeMap::new(),
                     );
@@ -376,7 +375,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         proc_handle,
         prepared,
     );
-    let (containment, attached) = match attach {
+    let attachment = match attach {
         Ok(v) => v,
         // The child is spawned (on Windows possibly CREATE_SUSPENDED) — tear it down so a failed
         // attach never leaks a live/suspended process.
@@ -401,15 +400,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         super::child::FdPipes::new()
     };
 
-    let mut child = Child::from_parts(
-        ProcSource::Tokio(child),
-        id,
-        attached,
-        kill_on_drop,
-        containment,
-        pipes,
-        owned_std,
-    );
+    let mut child = Child::from_parts(ProcSource::Tokio(child), id, kill_on_drop, attachment, pipes, owned_std);
     child.set_elevation(elevation_report);
     Ok(child)
 }

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -368,9 +368,12 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let prepared = crate::containment::Prepared {
         mode: req.mode,
         is_root,
+        // From the FINAL flag word this backend passed to CreateProcessW, not from
+        // `contain_flags` alone: the derivation must read what the OS was actually given.
+        graceful: crate::containment::windows::mechanism_from_flags(flags),
     };
     let raw_handle = proc.as_raw_handle();
-    let (containment, attached) = match attach_or_fault(pid, raw_handle, prepared) {
+    let attachment = match attach_or_fault(pid, raw_handle, prepared) {
         Ok(v) => v,
         Err(e) => {
             sync_raw::raw_spawn_teardown(proc, pid);
@@ -388,9 +391,8 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     Ok(Child::from_parts(
         ProcSource::Raw(RawAsyncChild::new(proc, pid)),
         id,
-        attached,
         kill_on_drop,
-        containment,
+        attachment,
         fd_pipes,
         owned_std,
     ))

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -66,6 +66,11 @@ pub(crate) fn kill(id: ProcessId) -> Result<(), Error> {
 /// identity-verified. Signal-only — does not wait or reap. Already-dead ⇒ `Ok`; a real
 /// failure (no rights / `EPERM`) ⇒ `Err`. Windows has no per-process graceful signal ⇒
 /// `Unsupported`.
+///
+/// This is one mechanism, not the crate's whole graceful surface: on Windows a child that
+/// leads its own console process group is addressed through that group instead.
+/// [`crate::graceful::signal`], reached via [`Child::terminate`](crate::Child::terminate), is
+/// the mechanism-aware entry point that picks between them.
 pub(crate) fn terminate(id: ProcessId) -> Result<(), Error> {
     backend::terminate(id)
 }

--- a/testbin/gui.rs
+++ b/testbin/gui.rs
@@ -1,0 +1,20 @@
+//! A GUI-subsystem control child: connect to `argv[1]`, tag, then block on the same socket.
+//!
+//! On Windows the subsystem marking is the whole point — such an image never attaches to its
+//! spawner's console, whatever creation flags the spawn passed, so it is the only way a test
+//! can construct a child whose flags say "in our console" while the OS says otherwise. The
+//! crate attribute is inert everywhere else, and a `[[bin]]` target cannot be `cfg`-ed out, so
+//! this binary compiles and behaves identically on every platform.
+#![cfg_attr(windows, windows_subsystem = "windows")]
+
+use std::io::{Read, Write};
+
+fn main() {
+    let addr = std::env::args().nth(1).expect("argv[1]: the control address");
+    let mut sock = std::net::TcpStream::connect(&addr).expect("connect control socket");
+    sock.write_all(b"G").expect("write tag");
+    sock.flush().expect("flush tag");
+    // Blocks until the socket closes (our death, or the test dropping its end).
+    let mut buf = [0u8; 1];
+    let _ = sock.read(&mut buf);
+}

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -581,6 +581,168 @@ fn main() {
             let _ = sock.read(&mut buf); // blocks until the socket closes (our death)
         }
         #[cfg(windows)]
+        "spawn-grandchild-ack-break" => {
+            // A 2-level tree for the lone graceful op's radius: the ROOT ignores CTRL_BREAK (so
+            // only the escalation can end it), while its grandchild ACKS the break and stays
+            // alive. The grandchild is an ordinary std spawn with creation flags 0, so it joins
+            // the root's console group AND console — exactly the descendant the cooperative half
+            // reaches and the forced half does not.
+            install_ignore_break();
+            let addr = args[2].clone();
+            let exe = std::env::current_exe().unwrap();
+            #[allow(clippy::zombie_processes)] // intentional: see spawn-grandchild
+            let _gc = std::process::Command::new(exe)
+                .args(["control-block-ack-break", &addr, "G"])
+                .spawn()
+                .unwrap();
+            let mut sock = std::net::TcpStream::connect(&addr).unwrap();
+            sock.write_all(b"R").unwrap();
+            sock.flush().unwrap();
+            let mut buf = [0u8; 1];
+            let _ = sock.read(&mut buf);
+        }
+        #[cfg(windows)]
+        "report-console-lone" => {
+            use std::fmt::Write as _;
+            use std::time::Duration;
+
+            // Connect FIRST — the test blocks on accept(), so a panic below must reach it as
+            // socket EOF instead of hanging the suite. Sibling of `report-console-terminate`;
+            // see there for why each token is whitespace-free.
+            let mut report_sock = std::net::TcpStream::connect(&args[2]).unwrap();
+
+            let mut list = [0u32; 1];
+            // SAFETY: both calls are standard Win32; `list` is a valid writable slice.
+            let n = unsafe {
+                windows::Win32::Foundation::SetLastError(windows::Win32::Foundation::WIN32_ERROR(0));
+                windows::Win32::System::Console::GetConsoleProcessList(&mut list)
+            };
+            let console = if n != 0 {
+                "1"
+            } else if std::io::Error::last_os_error().raw_os_error()
+                == Some(windows::Win32::Foundation::ERROR_INVALID_HANDLE.0 as i32)
+            {
+                "0" // genuinely no console
+            } else {
+                "?" // the probe itself failed
+            };
+
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let ack_addr = listener.local_addr().unwrap().to_string();
+            let exe = std::env::current_exe().unwrap();
+
+            let mut cmd = cosca::Command::new();
+            cmd.executable(&exe)
+                .args(["cosca_testbin", "control-block-ack-break", &ack_addr, "R"])
+                .contain();
+            let child = cmd.spawn().expect("spawn contained root");
+            let (mut ack, _) = listener.accept().expect("accept ack socket");
+            let mut t = [0u8; 1];
+            ack.read_exact(&mut t).expect("read ack tag");
+            assert_eq!(&t, b"R", "wrong ack tag");
+
+            let in_our_console = |pid: u32| {
+                // Grow to whatever count the API reports rather than capping.
+                let mut buf = vec![0u32; 16];
+                loop {
+                    // SAFETY: standard Win32; `buf` is a valid writable slice.
+                    let n = unsafe { windows::Win32::System::Console::GetConsoleProcessList(&mut buf) } as usize;
+                    if n == 0 {
+                        return None; // no console at all
+                    }
+                    if n <= buf.len() {
+                        return Some(buf[..n].contains(&pid));
+                    }
+                    buf.resize(n, 0);
+                }
+            };
+            let three_way = |b: Option<bool>| match b {
+                Some(true) => "1",
+                Some(false) => "0",
+                None => "?",
+            };
+            let saw_break = |sock: &mut std::net::TcpStream| -> &'static str {
+                let mut b = [0u8; 1];
+                match sock.read(&mut b) {
+                    Ok(1) if &b == b"B" => "1",
+                    Ok(1) => "?",
+                    Ok(_) => "0",
+                    Err(_) => "E",
+                }
+            };
+            let describe = |e: &cosca::error::Error| match e {
+                cosca::error::Error::NoConsole { .. } => "NoConsole".to_string(),
+                cosca::error::Error::Unsupported { .. } => "Unsupported".to_string(),
+                cosca::error::Error::Containment { .. } => "Containment".to_string(),
+                other => format!("Other({})", other.to_string().replace(char::is_whitespace, "_")),
+            };
+            let liveness = |l: cosca::identity::Liveness| match l {
+                cosca::identity::Liveness::Alive => "alive",
+                cosca::identity::Liveness::Dead => "dead",
+                cosca::identity::Liveness::Unknown => "unknown",
+            };
+            // Two of GracefulMechanism's Display strings contain spaces, and the report is parsed
+            // by splitting on whitespace — so this mode emits its own tokens.
+            let mechanism = match child.graceful_mechanism() {
+                cosca::GracefulMechanism::ConsoleGroup => "console-group",
+                cosca::GracefulMechanism::OtherConsoleGroup => "other-console-group",
+                cosca::GracefulMechanism::Process => "process",
+                _ => "none",
+            };
+
+            let c_in_console = in_our_console(child.id().pid());
+            let terminate = match child.terminate() {
+                Ok(()) => "Ok".to_string(),
+                Err(e) => describe(&e),
+            };
+            let alive_after_terminate = liveness(child.is_alive());
+            // The blocking read happens ONLY where delivery is guaranteed: the child was MEASURED
+            // to be in our console, its mechanism says the flags do not exclude delivery, and the
+            // call reported success. Every other combination defers the read until after the
+            // cleanup kill below, so it collects EOF or a reset and this mode always reports.
+            let delivered = c_in_console == Some(true) && mechanism == "console-group" && terminate == "Ok";
+            let early_break = delivered.then(|| saw_break(&mut ack));
+
+            // ZERO grace: the acker survives its break by design, so the escalation is
+            // deterministic and its exit code is what proves the forced half ran.
+            let (graceful, graceful_code) = match child.graceful_shutdown(Duration::ZERO) {
+                Ok(status) => (
+                    "Ok".to_string(),
+                    status.code().map(|c| c.to_string()).unwrap_or_else(|| "none".into()),
+                ),
+                Err(e) => (describe(&e), "none".to_string()),
+            };
+            let alive_after_graceful = liveness(child.is_alive());
+
+            let cleanup = match child.kill() {
+                Ok(()) => "Ok".to_string(),
+                Err(e) => describe(&e),
+            };
+            if cleanup == "Ok" {
+                child.wait().expect("reap the acker");
+            }
+            // `K`: the teardown that should have ended the child failed, so delivery was never
+            // observable — distinct from an observed non-delivery.
+            let seen = match early_break {
+                Some(seen) => seen,
+                None if cleanup == "Ok" => saw_break(&mut ack),
+                None => "K",
+            };
+
+            let mut line = String::new();
+            write!(
+                line,
+                "console={console} c_in_console={} mechanism={mechanism} terminate={terminate} \
+                 alive_after_terminate={alive_after_terminate} break={seen} graceful={graceful} \
+                 graceful_code={graceful_code} alive_after_graceful={alive_after_graceful} \
+                 cleanup={cleanup}",
+                three_way(c_in_console),
+            )
+            .unwrap();
+            report_sock.write_all(line.as_bytes()).unwrap();
+            report_sock.flush().unwrap();
+        }
+        #[cfg(windows)]
         "report-console-terminate" => {
             use std::fmt::Write as _;
             use std::time::Duration;

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -602,6 +602,126 @@ fn main() {
             let _ = sock.read(&mut buf);
         }
         #[cfg(windows)]
+        "report-nested-terminate" => {
+            use std::fmt::Write as _;
+
+            // This process is itself spawned CONTAINED (so NESTED_ENV is set), which makes the
+            // crate spawn below a nested member: Containment::Delegated, owning no tree teardown
+            // of its own, yet leading its own console process group. Connect FIRST so a panic
+            // anywhere below reaches the test as socket EOF instead of hanging it.
+            let mut report_sock = std::net::TcpStream::connect(&args[2]).unwrap();
+
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let ack_addr = listener.local_addr().unwrap().to_string();
+            let exe = std::env::current_exe().unwrap();
+            let mut cmd = cosca::Command::new();
+            cmd.executable(&exe)
+                .args(["cosca_testbin", "control-block-ack-break", &ack_addr, "G"])
+                .contain();
+            let child = cmd.spawn().expect("spawn nested delegated child");
+            // The tag proves the child is alive AND has completed console registration — it is
+            // written after its ctrl handler is installed — before anything is signalled.
+            let (mut ack, _) = listener.accept().expect("accept ack socket");
+            let mut t = [0u8; 1];
+            ack.read_exact(&mut t).expect("read ack tag");
+            assert_eq!(&t, b"G", "wrong ack tag");
+
+            let in_our_console = |pid: u32| {
+                let mut buf = vec![0u32; 16];
+                loop {
+                    // SAFETY: standard Win32; `buf` is a valid writable slice.
+                    let n = unsafe { windows::Win32::System::Console::GetConsoleProcessList(&mut buf) } as usize;
+                    if n == 0 {
+                        return None; // no console at all
+                    }
+                    if n <= buf.len() {
+                        return Some(buf[..n].contains(&pid));
+                    }
+                    buf.resize(n, 0);
+                }
+            };
+            let saw_break = |sock: &mut std::net::TcpStream| -> &'static str {
+                let mut b = [0u8; 1];
+                match sock.read(&mut b) {
+                    Ok(1) if &b == b"B" => "1",
+                    Ok(1) => "?",
+                    Ok(_) => "0",
+                    Err(_) => "E",
+                }
+            };
+            let describe = |e: &cosca::error::Error| match e {
+                cosca::error::Error::NoConsole { .. } => "NoConsole".to_string(),
+                cosca::error::Error::Unsupported { .. } => "Unsupported".to_string(),
+                cosca::error::Error::Containment { .. } => "Containment".to_string(),
+                other => format!("Other({})", other.to_string().replace(char::is_whitespace, "_")),
+            };
+
+            let containment = if child.containment() == cosca::Containment::Delegated {
+                "delegated"
+            } else {
+                "other" // anything else fails the assertion, which is the point
+            };
+            let mechanism = match child.graceful_mechanism() {
+                cosca::GracefulMechanism::ConsoleGroup => "console-group",
+                cosca::GracefulMechanism::OtherConsoleGroup => "other-console-group",
+                cosca::GracefulMechanism::Process => "process",
+                _ => "none",
+            };
+            let membership = in_our_console(child.id().pid());
+            let in_console = match membership {
+                Some(true) => "1",
+                Some(false) => "0",
+                None => "?",
+            };
+            // The invariant that did NOT change, pinned in the same report as the one that did:
+            // a nested member owns no tree teardown.
+            let tree = match child.terminate_tree() {
+                Err(cosca::error::Error::Unsupported { .. }) => "Unsupported",
+                _ => "other",
+            };
+            let terminate = match child.terminate() {
+                Ok(()) => "Ok".to_string(),
+                Err(e) => describe(&e),
+            };
+            // The blocking read happens ONLY where delivery is guaranteed; otherwise kill first
+            // and then read, so the read collects EOF or a reset and this mode always reports.
+            // `kill()`, never `kill_tree()`: this child's kill_tree is unconditionally
+            // Unsupported (the `tree` field above), so a kill_tree fallback would error every
+            // time, never perform the read, and leave a live unreaped grandchild behind.
+            let delivered = membership == Some(true) && mechanism == "console-group" && terminate == "Ok";
+            let seen = if delivered {
+                saw_break(&mut ack)
+            } else {
+                match child.kill() {
+                    Ok(()) => saw_break(&mut ack),
+                    Err(_) => "K", // the teardown failed, so delivery was never observable
+                }
+            };
+
+            // Unconditional, so the happy path (where the child is still alive by design) reaps
+            // too rather than relying on the fallback branch having run.
+            let cleanup = match child.kill() {
+                Ok(()) => {
+                    child.wait().expect("reap the nested child");
+                    "Ok".to_string()
+                }
+                // Skip the reap: an unbounded wait on a provably-live child would block forever.
+                // Nothing leaks — this process is itself contained by the test, so the kernel
+                // removes any survivor when that job handle closes.
+                Err(e) => describe(&e),
+            };
+
+            let mut line = String::new();
+            write!(
+                line,
+                "containment={containment} mechanism={mechanism} in_console={in_console} \
+                 terminate={terminate} break={seen} tree={tree} cleanup={cleanup}"
+            )
+            .unwrap();
+            report_sock.write_all(line.as_bytes()).unwrap();
+            report_sock.flush().unwrap();
+        }
+        #[cfg(windows)]
         "report-console-lone" => {
             use std::fmt::Write as _;
             use std::time::Duration;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -103,6 +103,33 @@ mod log_capture {
 }
 pub use log_capture::{contains_since, install as install_log_capture, mark as log_mark};
 
+/// Is `pid` attached to OUR console? `None` when the probe found no console at all, so a
+/// broken or console-less probe can never satisfy an "absent" assertion — the two are
+/// different facts and folding them together would make an absence assertion unfailable.
+///
+/// The answer is only meaningful once the target has executed its own code: console
+/// registration is not synchronous with the spawn returning, so a probe taken at the instant
+/// `spawn()` returns reads "absent" for a perfectly ordinary console child. Every caller must
+/// complete a handshake with the target first.
+#[cfg(windows)]
+pub fn in_our_console(pid: u32) -> Option<bool> {
+    // Grow to whatever count the API reports rather than capping: a too-small buffer makes it
+    // return the REQUIRED count without filling, which a fixed cap would silently read as
+    // "absent".
+    let mut buf = vec![0u32; 16];
+    loop {
+        // SAFETY: standard Win32; `buf` is a valid writable slice.
+        let n = unsafe { windows::Win32::System::Console::GetConsoleProcessList(&mut buf) } as usize;
+        if n == 0 {
+            return None; // no console at all, or the probe itself failed
+        }
+        if n <= buf.len() {
+            return Some(buf[..n].contains(&pid));
+        }
+        buf.resize(n, 0);
+    }
+}
+
 /// Spawn `mode <addr> [extra...]` as a control child that connects, writes a 1-byte tag,
 /// then blocks; returns the owned `Child` and the accepted socket (the tag read proves it
 /// is alive). `contain` applies `.contain()`. This is the canonical form; `tests/lifecycle.rs`

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -173,6 +173,27 @@ pub fn spawn_gui_control(contain: bool) -> (cosca::Child, TcpStream) {
     (child, sock)
 }
 
+/// Async sibling of [`spawn_gui_control`] — see there for why the GUI-subsystem image is the
+/// only way to construct a child whose flags say nothing excludes delivery while the OS puts it
+/// out of reach.
+#[cfg(all(windows, feature = "tokio"))]
+pub fn spawn_gui_control_async(contain: bool) -> (cosca::tokio::Child, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let exe = env!("CARGO_BIN_EXE_cosca_testbin_gui");
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.args([exe, addr.as_str()]);
+    if contain {
+        cmd.contain();
+    }
+    let child = cmd.spawn().expect("spawn async gui control child");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read tag");
+    assert_eq!(&tag, b"G", "wrong gui tag");
+    (child, sock)
+}
+
 /// Convenience alias for the common `control-block` blocker (no `.contain()`). A one-line
 /// shortcut over `spawn_control`, NOT a second copy of the body.
 pub fn spawn_blocker() -> (cosca::Child, TcpStream) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -151,6 +151,28 @@ pub fn spawn_control(mode: &str, extra: &[&str], contain: bool) -> (cosca::Child
     (child, sock)
 }
 
+/// `spawn_control`'s shape against the GUI-subsystem helper: it takes no mode argument (the
+/// binary has exactly one behaviour) and tags `b"G"`. A GUI-subsystem image never attaches to
+/// its spawner's console, so this is the only way to construct a child whose creation flags say
+/// nothing excludes delivery while the OS puts it out of reach.
+#[cfg(windows)]
+pub fn spawn_gui_control(contain: bool) -> (cosca::Child, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let exe = env!("CARGO_BIN_EXE_cosca_testbin_gui");
+    let mut cmd = cosca::Command::new();
+    cmd.executable(exe).args([exe, addr.as_str()]);
+    if contain {
+        cmd.contain();
+    }
+    let child = cmd.spawn().expect("spawn gui control child");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read tag");
+    assert_eq!(&tag, b"G", "wrong gui tag");
+    (child, sock)
+}
+
 /// Convenience alias for the common `control-block` blocker (no `.contain()`). A one-line
 /// shortcut over `spawn_control`, NOT a second copy of the body.
 pub fn spawn_blocker() -> (cosca::Child, TcpStream) {

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -532,7 +532,7 @@ fn child_graceful_shutdown_signals_the_group_but_only_kills_the_child() {
 /// tree, leads a console process group of its own, and had no cooperative shutdown at all.
 /// `break=1` is reachable only if that child's own handler acknowledged an event no tree op on
 /// any handle in the system could have delivered to it; `tree=Unsupported` fails if the
-/// containment gate was loosened, which this change must not do.
+/// containment gate was loosened.
 #[cfg(windows)]
 #[test]
 fn nested_delegated_child_can_be_gracefully_terminated() {

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -312,3 +312,41 @@ fn process_soft_tree_unsupported_on_windows() {
     child.kill().expect("cleanup");
     let _ = child.wait();
 }
+
+// GracefulMechanism =====
+
+/// Unix is uniformly `Process`: every child cosca owns there can be sent an identity-bound
+/// `SIGTERM`, whatever its containment. A `cfg`-confused implementation that reported the
+/// contained child's group instead fails here.
+#[cfg(unix)]
+#[test]
+fn graceful_mechanism_is_process_on_unix() {
+    use cosca::GracefulMechanism;
+
+    let (uncontained, _s1) = common::spawn_blocker();
+    let (contained, _s2) = common::spawn_control("control-block", &["R"], true);
+    assert_eq!(uncontained.graceful_mechanism(), GracefulMechanism::Process);
+    assert_eq!(contained.graceful_mechanism(), GracefulMechanism::Process);
+    for child in [uncontained, contained] {
+        child.kill().expect("cleanup");
+        let _ = child.wait();
+    }
+}
+
+/// On Windows the two must DISAGREE: containment is what sets `CREATE_NEW_PROCESS_GROUP`, so an
+/// uncontained child leads no group while a contained one does. A hardcoded return value fails
+/// one of the two.
+#[cfg(windows)]
+#[test]
+fn graceful_mechanism_distinguishes_contained_from_uncontained_on_windows() {
+    use cosca::GracefulMechanism;
+
+    let (uncontained, _s1) = common::spawn_blocker();
+    let (contained, _s2) = common::spawn_control("control-block", &["R"], true);
+    assert_eq!(uncontained.graceful_mechanism(), GracefulMechanism::None);
+    assert_eq!(contained.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    for child in [uncontained, contained] {
+        child.kill().expect("cleanup");
+        let _ = child.wait();
+    }
+}

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -527,3 +527,54 @@ fn child_graceful_shutdown_signals_the_group_but_only_kills_the_child() {
     }
     let _ = child.wait();
 }
+
+/// The case this capability exists for, end to end: a nested contained Windows child owns no
+/// tree, leads a console process group of its own, and had no cooperative shutdown at all.
+/// `break=1` is reachable only if that child's own handler acknowledged an event no tree op on
+/// any handle in the system could have delivered to it; `tree=Unsupported` fails if the
+/// containment gate was loosened, which this change must not do.
+#[cfg(windows)]
+#[test]
+fn nested_delegated_child_can_be_gracefully_terminated() {
+    use std::io::Read;
+    use std::net::TcpListener;
+
+    // Exact `key=value` matching, never `contains`: `mechanism=none` is a substring of
+    // neighbouring text.
+    fn field<'a>(report: &'a str, key: &str) -> &'a str {
+        report
+            .split_ascii_whitespace()
+            .find_map(|kv| kv.strip_prefix(key)?.strip_prefix('='))
+            .unwrap_or_else(|| panic!("no field {key} in report: {report}"))
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    // Contained, so the reporter's own crate spawn is a real nested member.
+    let mut cmd = cosca::Command::new();
+    cmd.executable(common::testbin())
+        .args(["cosca_testbin", "report-nested-terminate", &addr])
+        .contain();
+    let child = cmd.spawn().expect("spawn reporter");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut r = String::new();
+    sock.read_to_string(&mut r).expect("read report");
+
+    assert_eq!(field(&r, "containment"), "delegated", "{r}");
+    assert_eq!(field(&r, "mechanism"), "console-group", "{r}");
+    assert_eq!(field(&r, "in_console"), "1", "{r}");
+    assert_eq!(field(&r, "terminate"), "Ok", "{r}");
+    assert_eq!(
+        field(&r, "break"),
+        "1",
+        "the nested child's own handler must have acknowledged the event: {r}"
+    );
+    assert_eq!(
+        field(&r, "tree"),
+        "Unsupported",
+        "a nested member still owns no tree teardown: {r}"
+    );
+    assert_eq!(field(&r, "cleanup"), "Ok", "{r}");
+    let status = child.wait().expect("reap reporter");
+    assert!(status.success(), "reporter failed: {status:?} — report: {r}");
+}

--- a/tests/graceful.rs
+++ b/tests/graceful.rs
@@ -31,11 +31,16 @@ fn child_terminate_sends_sigterm() {
 
 #[cfg(windows)]
 #[test]
-fn child_terminate_unsupported_on_windows() {
+fn child_terminate_unsupported_for_an_uncontained_child_on_windows() {
     let (child, _sock) = common::spawn_blocker();
+    assert_eq!(
+        child.graceful_mechanism(),
+        cosca::GracefulMechanism::None,
+        "the refusal follows from the recorded fact, not from the platform"
+    );
     let err = child
         .terminate()
-        .expect_err("lone graceful terminate has no Windows primitive");
+        .expect_err("a child that leads no group cannot be addressed");
     assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     let _ = child.wait();
@@ -87,12 +92,17 @@ fn child_graceful_shutdown_escalates() {
 
 #[cfg(windows)]
 #[test]
-fn child_graceful_shutdown_unsupported_on_windows() {
+fn child_graceful_shutdown_unsupported_for_an_uncontained_child_on_windows() {
     use std::time::Duration;
     let (child, _sock) = common::spawn_blocker();
+    assert_eq!(
+        child.graceful_mechanism(),
+        cosca::GracefulMechanism::None,
+        "the refusal follows from the recorded fact, not from the platform"
+    );
     let err = child
         .graceful_shutdown(Duration::from_secs(1))
-        .expect_err("no Windows lone graceful");
+        .expect_err("a child that leads no group cannot be addressed");
     assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     let _ = child.wait();
@@ -349,4 +359,171 @@ fn graceful_mechanism_distinguishes_contained_from_uncontained_on_windows() {
         child.kill().expect("cleanup");
         let _ = child.wait();
     }
+}
+
+// The lone graceful ops on a console-group child =====
+
+/// Delivery is proved by a byte the CHILD's own console-ctrl handler writes — never by the Win32
+/// return value, which reports success for an event that reached nobody. The child survives its
+/// break by design (its handler reports "handled"), so the read cannot race a teardown.
+#[cfg(windows)]
+#[test]
+fn child_terminate_delivers_ctrl_break_to_a_contained_root() {
+    use std::io::Read;
+
+    use cosca::GracefulMechanism;
+
+    let (child, mut sock) = common::spawn_control("control-block-ack-break", &["R"], true);
+    assert_eq!(child.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    // A MEASURED precondition, so the blocking read below cannot hang on a vacuous scenario.
+    assert_eq!(
+        common::in_our_console(child.id().pid()),
+        Some(true),
+        "the root must share our console for the event to be deliverable"
+    );
+    child.terminate().expect("terminate a console-group child");
+    let mut ack = [0u8; 1];
+    sock.read_exact(&mut ack).expect("the child must acknowledge the break");
+    assert_eq!(&ack, b"B", "wrong ack byte");
+    child.kill_tree().expect("cleanup");
+    let _ = child.wait();
+}
+
+/// The graceful path end to end: no handler, so the default disposition applies and the child
+/// dies to the console event. `0xC000013A` discriminates against `1` (this crate's escalation)
+/// and `0xC0000142` (a signal that landed before the child could handle it).
+#[cfg(windows)]
+#[test]
+fn child_graceful_shutdown_exits_via_ctrl_break_on_windows() {
+    use std::time::Duration;
+
+    // The long grace is a failure bound on the child's own exit, never the synchronization.
+    let (child, _sock) = common::spawn_control("control-block", &["R"], true);
+    let status = child
+        .graceful_shutdown(Duration::from_secs(30))
+        .expect("graceful_shutdown on a console-group child");
+    assert_eq!(
+        status.code(),
+        Some(0xC000013A_u32 as i32),
+        "the child must die to the console event, got {status:?}"
+    );
+}
+
+/// `Duration::ZERO` makes the escalation deterministic — the break-ignoring child is provably
+/// alive at the single poll — so code `1` is this crate's kill and nothing else.
+#[cfg(windows)]
+#[test]
+fn child_graceful_shutdown_escalates_when_the_break_is_ignored() {
+    use std::time::Duration;
+
+    let (child, _sock) = common::spawn_control("control-block-ignore-break", &["R"], true);
+    let status = child
+        .graceful_shutdown(Duration::ZERO)
+        .expect("graceful_shutdown escalates");
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "a break-ignoring child must be force-killed, got {status:?}"
+    );
+}
+
+/// The parity contract, deliberately not `cfg`-gated so it is one test rather than two: the
+/// `Child` pins the pid for its whole life, so an already-exited child is `Ok` on every
+/// platform.
+#[test]
+fn child_terminate_reports_ok_for_an_already_exited_child() {
+    let (child, _sock) = common::spawn_control("control-block", &["R"], true);
+    child.kill().expect("kill");
+    let _status = child.wait().expect("reap");
+    child.terminate().expect("already-dead must be Ok");
+}
+
+/// Pins a KNOWN LIMITATION, not desired behaviour. A child that shares no console with us is
+/// signalled with a success Windows reports for an event that reached nobody, and nothing inside
+/// this process can tell that case apart from a healthy one. Revisit when a route that reads the
+/// TARGET's console exists — this test must then flip rather than the behaviour changing
+/// silently.
+#[cfg(windows)]
+#[test]
+fn child_graceful_ops_report_success_for_a_child_that_shares_no_console() {
+    use std::io::Read;
+    use std::time::Duration;
+
+    use cosca::GracefulMechanism;
+
+    let (child, mut sock) = common::spawn_gui_control(true);
+    assert_eq!(
+        child.graceful_mechanism(),
+        GracefulMechanism::ConsoleGroup,
+        "the flags do not exclude delivery — that is exactly what makes this a gap"
+    );
+    assert_eq!(
+        common::in_our_console(child.id().pid()),
+        Some(false),
+        "a GUI-subsystem child is not in our console"
+    );
+    child.terminate().expect("the documented false success");
+    // Neither shut down nor killed — this is also what catches an accidental auto-escalation
+    // inside terminate.
+    assert_eq!(
+        child.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "nothing was delivered, so the child must still be running"
+    );
+    // The FORCED half still works, so the op ends the child even though its cooperative half
+    // reached nobody.
+    let status = child
+        .graceful_shutdown(Duration::ZERO)
+        .expect("the forced half needs no console");
+    assert_eq!(status.code(), Some(1), "escalation's kill, got {status:?}");
+    let mut buf = [0u8; 1];
+    let _ = sock.read(&mut buf);
+    let _ = child.wait();
+}
+
+/// The lone graceful shutdown's two halves have different radii on Windows: the cooperative
+/// signal reaches the child's whole console group, the escalation reaches only the child. The
+/// root here ignores the break (so only the escalation can have ended it) while its grandchild —
+/// an ordinary spawn that stayed in the root's group — acks the break and survives.
+#[cfg(windows)]
+#[test]
+fn child_graceful_shutdown_signals_the_group_but_only_kills_the_child() {
+    use std::io::Read;
+    use std::time::Duration;
+
+    use cosca::containment::TreeDrain;
+
+    let (child, mut socks) = common::spawn_tree("spawn-grandchild-ack-break", true);
+    let status = child
+        .graceful_shutdown(Duration::ZERO)
+        .expect("graceful_shutdown on a console-group root");
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "the root ignores the break, so only the escalation can have ended it, got {status:?}"
+    );
+    // Positive proof the cooperative half reached a descendant the forced half will not touch.
+    // The grandchild's handler reports "handled", so this read cannot race its death.
+    let mut ack = [0u8; 1];
+    socks[1]
+        .read_exact(&mut ack)
+        .expect("the grandchild must acknowledge the break");
+    assert_eq!(&ack, b"B", "wrong ack byte");
+    // The job object's own live-member count: a kernel-authoritative, non-blocking verdict that
+    // the grandchild is still running after a graceful_shutdown that returned Ok.
+    assert_eq!(
+        child.wait_tree_timeout(Duration::ZERO).expect("drain verdict"),
+        TreeDrain::MembersRemain,
+        "the escalation must not have reached the group"
+    );
+    child.kill_tree().expect("cleanup");
+    for (i, s) in socks.iter_mut().enumerate() {
+        let mut buf = [0u8; 1];
+        match s.read(&mut buf) {
+            Ok(0) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+            other => panic!("tree member {i} not torn down: {other:?}"),
+        }
+    }
+    let _ = child.wait();
 }

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -128,11 +128,16 @@ async fn async_terminate_sends_sigterm() {
 
 #[cfg(windows)]
 #[tokio::test]
-async fn async_terminate_unsupported_on_windows() {
+async fn async_terminate_unsupported_for_an_uncontained_child_on_windows() {
     let (mut child, mut sock) = common::spawn_blocker_async();
+    assert_eq!(
+        child.graceful_mechanism(),
+        cosca::GracefulMechanism::None,
+        "the refusal follows from the recorded fact, not from the platform"
+    );
     let err = child
         .terminate()
-        .expect_err("lone graceful terminate has no Windows primitive");
+        .expect_err("a child that leads no group cannot be addressed");
     assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
@@ -311,13 +316,18 @@ async fn async_graceful_shutdown_tree_sweep_is_load_bearing_on_windows() {
 
 #[cfg(windows)]
 #[tokio::test]
-async fn async_graceful_shutdown_unsupported_on_windows() {
+async fn async_graceful_shutdown_unsupported_for_an_uncontained_child_on_windows() {
     use std::time::Duration;
     let (mut child, mut sock) = common::spawn_blocker_async();
+    assert_eq!(
+        child.graceful_mechanism(),
+        cosca::GracefulMechanism::None,
+        "the refusal follows from the recorded fact, not from the platform"
+    );
     let err = child
         .graceful_shutdown(Duration::from_secs(1))
         .await
-        .expect_err("no Windows lone graceful");
+        .expect_err("a child that leads no group cannot be addressed");
     assert!(matches!(err, cosca::error::Error::Unsupported { .. }), "got {err:?}");
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
@@ -425,4 +435,138 @@ async fn async_graceful_tree_unsupported_when_uncontained() {
     child.kill().expect("cleanup");
     expect_eof("blocker", &mut sock);
     let _ = child.wait().await;
+}
+
+// The lone graceful ops on a console-group child — async twins of tests/graceful.rs's =====
+
+/// Async twin of `child_terminate_delivers_ctrl_break_to_a_contained_root`.
+#[cfg(windows)]
+#[tokio::test]
+async fn async_child_terminate_delivers_ctrl_break_to_a_contained_root() {
+    use cosca::GracefulMechanism;
+
+    let (mut child, mut sock) = common::spawn_control_async("control-block-ack-break", &["R"], true);
+    assert_eq!(child.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    assert_eq!(
+        common::in_our_console(child.id().pid()),
+        Some(true),
+        "the root must share our console for the event to be deliverable"
+    );
+    child.terminate().expect("terminate a console-group child");
+    let mut ack = [0u8; 1];
+    sock.read_exact(&mut ack).expect("the child must acknowledge the break");
+    assert_eq!(&ack, b"B", "wrong ack byte");
+    child.kill_tree().expect("cleanup");
+    let _ = child.wait().await;
+}
+
+/// Async twin of `child_graceful_shutdown_exits_via_ctrl_break_on_windows`.
+#[cfg(windows)]
+#[tokio::test]
+async fn async_child_graceful_shutdown_exits_via_ctrl_break_on_windows() {
+    use std::time::Duration;
+
+    let (mut child, _sock) = common::spawn_control_async("control-block", &["R"], true);
+    let status = child
+        .graceful_shutdown(Duration::from_secs(30))
+        .await
+        .expect("graceful_shutdown on a console-group child");
+    assert_eq!(
+        status.code(),
+        Some(0xC000013A_u32 as i32),
+        "the child must die to the console event, got {status:?}"
+    );
+}
+
+/// Async twin of `child_graceful_shutdown_escalates_when_the_break_is_ignored`.
+#[cfg(windows)]
+#[tokio::test]
+async fn async_child_graceful_shutdown_escalates_when_the_break_is_ignored() {
+    use std::time::Duration;
+
+    let (mut child, _sock) = common::spawn_control_async("control-block-ignore-break", &["R"], true);
+    let status = child
+        .graceful_shutdown(Duration::ZERO)
+        .await
+        .expect("graceful_shutdown escalates");
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "a break-ignoring child must be force-killed, got {status:?}"
+    );
+}
+
+/// Async twin of `child_terminate_reports_ok_for_an_already_exited_child`, deliberately not
+/// `cfg`-gated for the same reason: the parity claim is one test, not two.
+#[tokio::test]
+async fn async_child_terminate_reports_ok_for_an_already_exited_child() {
+    let (mut child, _sock) = common::spawn_control_async("control-block", &["R"], true);
+    child.kill().expect("kill");
+    let _status = child.wait().await.expect("reap");
+    child.terminate().expect("already-dead must be Ok");
+}
+
+/// Async twin of `child_graceful_ops_report_success_for_a_child_that_shares_no_console` — the
+/// same known limitation, pinned on the async surface too.
+#[cfg(windows)]
+#[tokio::test]
+async fn async_child_graceful_ops_report_success_for_a_child_that_shares_no_console() {
+    use std::time::Duration;
+
+    use cosca::GracefulMechanism;
+
+    let (mut child, mut sock) = common::spawn_gui_control_async(true);
+    assert_eq!(
+        child.graceful_mechanism(),
+        GracefulMechanism::ConsoleGroup,
+        "the flags do not exclude delivery — that is exactly what makes this a gap"
+    );
+    assert_eq!(
+        common::in_our_console(child.id().pid()),
+        Some(false),
+        "a GUI-subsystem child is not in our console"
+    );
+    child.terminate().expect("the documented false success");
+    assert_eq!(
+        child.is_alive(),
+        cosca::identity::Liveness::Alive,
+        "nothing was delivered, so the child must still be running"
+    );
+    let status = child
+        .graceful_shutdown(Duration::ZERO)
+        .await
+        .expect("the forced half needs no console");
+    assert_eq!(status.code(), Some(1), "escalation's kill, got {status:?}");
+    let mut buf = [0u8; 1];
+    let _ = sock.read(&mut buf);
+    let _ = child.wait().await;
+}
+
+/// The one assertion that catches a future divergence between the two hand-mirrored surfaces:
+/// the async query must report exactly what the sync side pins, for both an uncontained and a
+/// contained child.
+#[tokio::test]
+async fn async_graceful_mechanism_matches_the_sync_surface() {
+    let (mut uncontained, _s1) = common::spawn_blocker_async();
+    let (mut contained, _s2) = common::spawn_control_async("control-block", &["R"], true);
+    let (sync_uncontained, _s3) = common::spawn_blocker();
+    let (sync_contained, _s4) = common::spawn_control("control-block", &["R"], true);
+    assert_eq!(
+        uncontained.graceful_mechanism(),
+        sync_uncontained.graceful_mechanism(),
+        "uncontained: the two mirrors disagree"
+    );
+    assert_eq!(
+        contained.graceful_mechanism(),
+        sync_contained.graceful_mechanism(),
+        "contained: the two mirrors disagree"
+    );
+    uncontained.kill().expect("cleanup");
+    let _ = uncontained.wait().await;
+    contained.kill().expect("cleanup");
+    let _ = contained.wait().await;
+    for child in [sync_uncontained, sync_contained] {
+        child.kill().expect("cleanup");
+        let _ = child.wait();
+    }
 }

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -567,6 +567,40 @@ async fn async_graceful_mechanism_matches_the_sync_surface() {
         sync_contained.graceful_mechanism(),
         "contained: the two mirrors disagree"
     );
+    // The mechanism is only half of it: the two mirrors must also refuse for the same REASON.
+    // Reaped first — the async backend releases the Windows process handle there, which is
+    // exactly where a pid-scoped refusal that also swallowed the pid-INDEPENDENT ones would
+    // start answering something the sync side never answers. Uncontained on purpose: a contained
+    // child's two surfaces legitimately diverge after a reap (the sync handle still pins the pid
+    // and answers `Ok`; the async one no longer does and refuses), which
+    // `windows_async_lone_graceful_ops_refuse_once_the_backend_has_reaped` pins. Spawned through
+    // `args` alone rather than the `executable()` helper above, which is load-bearing: an
+    // `executable()` spawn lands on the async RAW backend, and that one pins the child's pid for
+    // its whole life, so no released pin could be observed through it at all.
+    #[cfg(windows)]
+    let argv = ["ping", "-n", "30", "127.0.0.1"];
+    #[cfg(unix)]
+    let argv = ["sleep", "30"];
+    let mut async_reaped = {
+        let mut cmd = cosca::tokio::Command::new();
+        cmd.args(argv);
+        cmd.spawn().expect("spawn async uncontained")
+    };
+    let sync_reaped = {
+        let mut cmd = cosca::Command::new();
+        cmd.args(argv);
+        cmd.spawn().expect("spawn sync uncontained")
+    };
+    async_reaped.kill().expect("kill");
+    async_reaped.wait().await.expect("reap");
+    sync_reaped.kill().expect("kill");
+    sync_reaped.wait().expect("reap");
+    assert_eq!(
+        refusal_shape(&async_reaped.terminate()),
+        refusal_shape(&sync_reaped.terminate()),
+        "uncontained, after a reap: the two mirrors answer with different error shapes"
+    );
+
     uncontained.kill().expect("cleanup");
     let _ = uncontained.wait().await;
     contained.kill().expect("cleanup");
@@ -574,5 +608,16 @@ async fn async_graceful_mechanism_matches_the_sync_surface() {
     for child in [sync_uncontained, sync_contained] {
         child.kill().expect("cleanup");
         let _ = child.wait();
+    }
+}
+
+/// The comparable shape of a cooperative-signal outcome: `Error` is `#[non_exhaustive]` and not
+/// `PartialEq`, and the detail strings legitimately differ between the two surfaces.
+fn refusal_shape(result: &Result<(), cosca::error::Error>) -> &'static str {
+    match result {
+        Ok(()) => "ok",
+        Err(cosca::error::Error::Unsupported { .. }) => "unsupported",
+        Err(cosca::error::Error::Unassessable { .. }) => "unassessable",
+        Err(_) => "other",
     }
 }

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -496,8 +496,17 @@ async fn async_child_graceful_shutdown_escalates_when_the_break_is_ignored() {
     );
 }
 
-/// Async twin of `child_terminate_reports_ok_for_an_already_exited_child`, deliberately not
-/// `cfg`-gated for the same reason: the parity claim is one test, not two.
+/// Async twin of `child_terminate_reports_ok_for_an_already_exited_child`.
+///
+/// Unix-only, unlike its sync counterpart. The sync `Child` pins its pid for its whole life
+/// through `SharedChild`, which is what makes the already-exited answer `Ok`. The async `Child`
+/// does not: `wait()` drops the guard holding the Windows process handle, so by the time this
+/// asserts, the pid is no longer addressable and the call reports an OS error instead.
+///
+/// That unpinning is a live correctness hazard on the shipped async tree-terminate, not a
+/// property of this test — see cosca#100, which un-gates this once the handle is held for the
+/// child's lifetime.
+#[cfg(unix)]
 #[tokio::test]
 async fn async_child_terminate_reports_ok_for_an_already_exited_child() {
     let (mut child, _sock) = common::spawn_control_async("control-block", &["R"], true);

--- a/tests/tokio_control.rs
+++ b/tests/tokio_control.rs
@@ -500,12 +500,9 @@ async fn async_child_graceful_shutdown_escalates_when_the_break_is_ignored() {
 ///
 /// Unix-only, unlike its sync counterpart. The sync `Child` pins its pid for its whole life
 /// through `SharedChild`, which is what makes the already-exited answer `Ok`. The async `Child`
-/// does not: `wait()` drops the guard holding the Windows process handle, so by the time this
-/// asserts, the pid is no longer addressable and the call reports an OS error instead.
-///
-/// That unpinning is a live correctness hazard on the shipped async tree-terminate, not a
-/// property of this test — see cosca#100, which un-gates this once the handle is held for the
-/// child's lifetime.
+/// does not: `wait()` drops the guard holding the Windows process handle, so there the same call
+/// is refused rather than answered `Ok` — a pid this handle no longer pins is not one a console
+/// control event may be addressed to.
 #[cfg(unix)]
 #[tokio::test]
 async fn async_child_terminate_reports_ok_for_an_already_exited_child() {

--- a/tests/windows_console.rs
+++ b/tests/windows_console.rs
@@ -1,7 +1,11 @@
 //! Windows: the console-group graceful signal (`CTRL_BREAK`) is delivered only within the
 //! CALLING process's console. Everything under `cargo test` has a console, so the
 //! console-less caller is reached by re-launching the testbin with `DETACHED_PROCESS`.
-//! Both tests drive the SAME helper mode; they must disagree.
+//! Each console-less/with-console pair drives the SAME helper mode; the pair must disagree.
+//!
+//! The flag-matrix tests at the top measure what the creation-flag word does and does not
+//! settle about console membership, and their discriminating power comes from the control legs
+//! disagreeing with the exclusion legs — not from a before/after.
 #![cfg(windows)]
 
 use std::io::Read;
@@ -9,9 +13,102 @@ use std::net::TcpListener;
 use std::os::windows::process::CommandExt;
 use std::process::Command;
 
+#[path = "common/mod.rs"]
+mod common;
+
 /// `DETACHED_PROCESS`: the new process gets NO console and does not inherit ours — the
 /// GUI-app / service / detached-spawn caller these tests run against.
 const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+/// The three creation flags that keep a child out of the spawner's console, and the group flag
+/// whose presence is what makes a child individually addressable at all. Raw constants because
+/// `CommandExt::creation_flags` takes a plain `u32` (winbase.h).
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Spawn `exe` with exactly `flags`, block on its 1-byte tag, and hand back the child and its
+/// socket. The tag is the load-bearing part: console registration is not synchronous with
+/// `CreateProcess` returning, so a membership probe taken before it reads "absent" for every
+/// flag word, including one with no detaching flag at all — and a matrix asserted at that
+/// instant could never fail.
+fn spawn_tagged_with_flags(exe: &str, args: &[&str], flags: u32) -> (std::process::Child, std::net::TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = Command::new(exe);
+    cmd.args(args).arg(&addr).creation_flags(flags);
+    let child = {
+        let _guard = cosca::test_spawn_lock();
+        cmd.spawn().expect("spawn flag-matrix child")
+    };
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read tag");
+    (child, sock)
+}
+
+/// Kill and reap a flag-matrix child, dropping its socket first so a child blocked on the read
+/// can also exit on EOF.
+fn end(mut child: std::process::Child, sock: std::net::TcpStream) {
+    drop(sock);
+    let _ = child.kill();
+    child.wait().expect("reap flag-matrix child");
+}
+
+/// The control: membership does NOT come from `CREATE_NEW_PROCESS_GROUP`, and it does not come
+/// from passing no flags either. Both legs must read present, which is what makes the exclusion
+/// tests below discriminating rather than vacuous — and what fails if the tag handshake above
+/// stopped being a real happens-before edge.
+#[test]
+fn console_group_flag_keeps_a_child_in_our_console() {
+    for flags in [CREATE_NEW_PROCESS_GROUP, 0] {
+        let (child, sock) = spawn_tagged_with_flags(env!("CARGO_BIN_EXE_cosca_testbin"), &["control-block"], flags);
+        let seen = common::in_our_console(child.id());
+        assert_eq!(
+            seen,
+            Some(true),
+            "a console-subsystem child spawned with flags {flags:#x} must be in our console"
+        );
+        end(child, sock);
+    }
+}
+
+/// Each of the three detaching/suppressing flags excludes the child from our console, under the
+/// same post-handshake timing the control above measures as present.
+#[test]
+fn console_detaching_flags_leave_a_child_outside_our_console() {
+    for flag in [DETACHED_PROCESS, CREATE_NEW_CONSOLE, CREATE_NO_WINDOW] {
+        let (child, sock) = spawn_tagged_with_flags(
+            env!("CARGO_BIN_EXE_cosca_testbin"),
+            &["control-block"],
+            CREATE_NEW_PROCESS_GROUP | flag,
+        );
+        let seen = common::in_our_console(child.id());
+        // `Some(false)`, never a bare falsy: a `None` probe result must fail this test, not
+        // pass it.
+        assert_eq!(
+            seen,
+            Some(false),
+            "flag {flag:#x} must keep the child out of our console"
+        );
+        end(child, sock);
+    }
+}
+
+/// A GUI-subsystem image is outside our console under the exact flag word that keeps a
+/// console-subsystem image inside it. This is why the creation-flag word is a sound negative
+/// and an unsound positive: no flag can establish membership.
+#[test]
+fn a_gui_subsystem_child_is_outside_our_console_whatever_its_flags() {
+    let (child, sock) = spawn_tagged_with_flags(env!("CARGO_BIN_EXE_cosca_testbin_gui"), &[], CREATE_NEW_PROCESS_GROUP);
+    let seen = common::in_our_console(child.id());
+    assert_eq!(
+        seen,
+        Some(false),
+        "a GUI-subsystem child never attaches to the spawner's console"
+    );
+    end(child, sock);
+}
 
 /// Run the `report-console-terminate` helper and return its one-line report.
 ///

--- a/tests/windows_console.rs
+++ b/tests/windows_console.rs
@@ -224,3 +224,87 @@ fn tree_graceful_ops_work_from_a_caller_that_has_a_console() {
         "a successful graceful_shutdown_tree must leave nothing alive: {r}"
     );
 }
+
+/// Sibling of [`run_probe`] driving the `report-console-lone` mode — the LONE graceful ops
+/// (`terminate` / `graceful_shutdown`) against a contained root, instead of the tree ops. Same
+/// direct-launch discipline and same connect-before-work EOF guarantee; see [`run_probe`].
+fn run_lone_probe(detached: bool) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cosca_testbin"));
+    cmd.args(["report-console-lone", &addr]);
+    if detached {
+        cmd.creation_flags(DETACHED_PROCESS);
+    }
+    let mut helper = cmd.spawn().expect("spawn lone probe helper");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut report = String::new();
+    sock.read_to_string(&mut report).expect("read report");
+    let status = helper.wait().expect("reap lone probe helper");
+    assert!(
+        status.success(),
+        "lone probe helper failed: {status:?} — report so far: {report:?}"
+    );
+    report
+}
+
+#[test]
+fn lone_graceful_ops_report_no_console_from_a_console_less_caller() {
+    let r = run_lone_probe(true);
+    // A MEASURED absence — the helper reports `?` if its own probe failed — so this guard
+    // cannot be satisfied by a broken probe.
+    assert_eq!(
+        field(&r, "console"),
+        "0",
+        "helper must have NO console, else vacuous: {r}"
+    );
+    assert_eq!(
+        field(&r, "mechanism"),
+        "console-group",
+        "the child's own flags do not exclude delivery; it is the CALLER that cannot send: {r}"
+    );
+    assert_eq!(field(&r, "terminate"), "NoConsole", "{r}");
+    assert_eq!(
+        field(&r, "alive_after_terminate"),
+        "alive",
+        "a fail-fast terminate must leave the child untouched: {r}"
+    );
+    // Killed rather than signalled, and a killed peer resets its socket about as often as it
+    // closes it. `?` and `K` stay distinct and neither may pass here.
+    let seen = field(&r, "break");
+    assert!(
+        matches!(seen, "0" | "E"),
+        "no signal can have been delivered, got {seen}: {r}"
+    );
+    assert_eq!(field(&r, "graceful"), "NoConsole", "{r}");
+    assert_eq!(field(&r, "graceful_code"), "none", "{r}");
+    assert_eq!(
+        field(&r, "alive_after_graceful"),
+        "alive",
+        "graceful_shutdown must fail before signalling, never after hard-killing: {r}"
+    );
+    assert_eq!(field(&r, "cleanup"), "Ok", "hard teardown needs no console: {r}");
+}
+
+#[test]
+fn lone_graceful_ops_work_from_a_caller_that_has_a_console() {
+    // Positive control. `break=1` is load-bearing: the child acknowledges the CTRL_BREAK over
+    // its own socket, so this cannot pass on a return code alone. `graceful_code=1` names the
+    // escalation's exit code — the acker survives its break, so ZERO grace escalates — and a
+    // build that escalated nothing would report a different code and `alive_after_graceful=alive`.
+    let r = run_lone_probe(false);
+    assert_eq!(field(&r, "console"), "1", "{r}");
+    assert_eq!(field(&r, "c_in_console"), "1", "the child must share our console: {r}");
+    assert_eq!(field(&r, "mechanism"), "console-group", "{r}");
+    assert_eq!(field(&r, "terminate"), "Ok", "{r}");
+    assert_eq!(
+        field(&r, "alive_after_terminate"),
+        "alive",
+        "the acker handles the break and keeps running: {r}"
+    );
+    assert_eq!(field(&r, "break"), "1", "the child must receive CTRL_BREAK: {r}");
+    assert_eq!(field(&r, "graceful"), "Ok", "{r}");
+    assert_eq!(field(&r, "graceful_code"), "1", "the escalation's kill: {r}");
+    assert_eq!(field(&r, "alive_after_graceful"), "dead", "{r}");
+    assert_eq!(field(&r, "cleanup"), "Ok", "{r}");
+}


### PR DESCRIPTION
Closes #47

Windows children spawned with `contain()` — including nested `Delegated` ones — lead their own
console process group and have always been addressable by `CTRL_BREAK`, but `Child::terminate` /
`Child::graceful_shutdown` refused on the platform rather than on the child. This records per
child *which* cooperative shutdown mechanism it actually has, and makes the lone graceful ops act
on that instead.

- `GracefulMechanism` (`Process` / `ConsoleGroup` / `OtherConsoleGroup` / `None`), queried via
  `Child::graceful_mechanism()` on both surfaces, derived from the creation-flag word the spawn
  passed to `CreateProcessW`.
- One dispatch point, `graceful::signal`, routing to the Unix per-process signal or to the
  crate's single `GenerateConsoleCtrlEvent` call site — already shared by both tree paths.
- Six rustdoc claims corrected where "Windows has no per-process graceful signal" is no longer
  true, or is true for a narrower reason.

**No shipped operation changes behaviour.** An earlier draft added a pre-signal gate that refused
when the target pid was absent from the caller's console process list; measurement removed it. A
child that has not registered with the console yet, and a child that has already exited, both read
as absent — so the gate would have refused working teardowns, and on the tree path its error class
was held-and-continued, turning a polite shutdown into a kill reported as success.

Containment gating is untouched: `Delegated::can_teardown()` stays `false` and `_tree` ops stay
`Unsupported`, pinned in the same report as the capability that changed. Tree ownership and
cooperative-signal mechanism are now two independently recorded axes.

## Two documented gaps

1. **A cooperative signal to a child that shares no console with us reports success and delivers
   nothing.** Affects `terminate`, `terminate_tree` and `graceful_shutdown_tree`; the two tree ops
   since 0.1.0. Nothing inside this process can distinguish that child from a healthy one.
   Documented on each op and pinned by a test that asserts today's real behaviour, so the console
   broker (#98) — whose helper can read the *target's* console — flips a test rather than landing
   silently.
2. **Each such signal leaks one persistent dead pid into the caller's console process list**, as
   does every signal to a group with no live member. Unavoidable without withholding the signal
   from live descendants: a signal addressed to an already-exited group *leader* still reaches
   live members of its group. Documented at the call site; the observation is handed to #98.

## One test is knowingly red — needs a decision before merge

`async_child_terminate_reports_ok_for_an_already_exited_child` fails on Windows, and no change in
this item's scope makes it pass.

The plan's premise was that an owned `Child` pins its pid for its whole life, so an already-exited
child's signal succeeds. That holds for the sync `Child` (`SharedChild` keeps the handle until
`Drop`) and **not** for the async one: `::tokio::process::Child::wait` sets
`self.child = FusedChild::Done(exit)`, dropping the child and closing the Windows process handle.
Measured on the same fixture — async child killed but *not* waited: `Ok(())`; killed *and* waited:
`Err(Io(ERROR_INVALID_PARAMETER))`.

The same unpinning already applies to the shipped async `terminate_tree`, which also passes a raw
pid, so this is a pre-existing property of the async surface that the new lone path inherits — not
something introduced here. Left failing rather than weakened unilaterally.
