### PR TITLE
test: scope the sweep's group-signal probe to its own marker handle

### DIFF
--- a/src/containment/fdmarker_tests.rs
+++ b/src/containment/fdmarker_tests.rs
@@ -925,13 +925,13 @@ fn sweep_pass_refires_the_group_signal_on_a_later_pass_that_confirms_a_new_live_
     // A stand-in for the sibling record this assertion must ignore, emitted inside the window
     // it scans so the scoping below is proven on every run rather than argued: `log_capture` is
     // one process-global buffer, and every `kill_tree()` on a contained macOS child logs this
-    // same sentence under ITS OWN handle on its second pass. Safe to inject because no other
-    // test in this crate asserts on this sentence at all — only this one does, and only for
-    // `handle`.
+    // same sentence under ITS OWN handle on its second pass. Keyed on `0`, which `install`
+    // refuses as a write-end handle, so it is provably not `handle` and provably not any live
+    // marker's — the decoy cannot become the contamination it stands in for.
     log::debug!(
         "fd marker {:#x}: skipping this pass's group signal — no live member confirmed this \
          pass's pgid, so it may have been recycled",
-        handle.wrapping_add(1)
+        0u64
     );
 
     // Pass 2: T's own holder scan on THIS pass confirms a live member of `pgid` (T itself), so

--- a/src/containment/fdmarker_tests.rs
+++ b/src/containment/fdmarker_tests.rs
@@ -918,8 +918,21 @@ fn sweep_pass_refires_the_group_signal_on_a_later_pass_that_confirms_a_new_live_
     // assertion below is on the termination signal, not on `!success()`.
     await_member_ready(&mut q_child);
 
+    let handle = prepared.handle;
     let marker = super::Marker::new(prepared, None, Some(pgid), false);
     let mark = crate::log_capture::mark();
+
+    // A stand-in for the sibling record this assertion must ignore, emitted inside the window
+    // it scans so the scoping below is proven on every run rather than argued: `log_capture` is
+    // one process-global buffer, and every `kill_tree()` on a contained macOS child logs this
+    // same sentence under ITS OWN handle on its second pass. Safe to inject because no other
+    // test in this crate asserts on this sentence at all — only this one does, and only for
+    // `handle`.
+    log::debug!(
+        "fd marker {:#x}: skipping this pass's group signal — no live member confirmed this \
+         pass's pgid, so it may have been recycled",
+        handle.wrapping_add(1)
+    );
 
     // Pass 2: T's own holder scan on THIS pass confirms a live member of `pgid` (T itself), so
     // the gate must open and the group signal must re-fire, reaching Q via killpg.
@@ -931,8 +944,15 @@ fn sweep_pass_refires_the_group_signal_on_a_later_pass_that_confirms_a_new_live_
         false,
     );
 
+    // Keyed on THIS marker's handle, per the module docs' rule: the bare sentence is emitted by
+    // every other marker's sweep too, so an unscoped probe reads a concurrent sibling's teardown
+    // as this pass's own skip. `handle` names a pipe object that cannot be reissued while this
+    // test holds the read end, so no simultaneously-live marker can share it.
     assert!(
-        !crate::log_capture::contains_since(mark, "skipping this pass's group signal"),
+        !crate::log_capture::contains_since(
+            mark,
+            &format!("fd marker {handle:#x}: skipping this pass's group signal")
+        ),
         "pass 2 must not skip the group signal: a live, getpgid-confirmed member (T) was just \
          found in this pass's own holder scan"
     );


### PR DESCRIPTION
Closes #108.

`main` went red on darwin/arm64 in [run 32084121809](https://github.com/bindreams/cosca/actions/runs/32084121809) on the negative log assertion in `sweep_pass_refires_the_group_signal_on_a_later_pass_that_confirms_a_new_live_member`. The gate is correct and the group signal did fire; the assertion's **probe** was the defect.

`log_capture` is one process-global buffer, so `contains_since` sees records from every thread. The probe was the bare sentence `"skipping this pass's group signal"`, which every contained macOS child's `kill_tree()` writes on its second pass under its own handle — so a sibling's teardown landing in the window satisfied it. In the failing run [`wait_tree_timeout_reports_members_remain_before_the_deadline`](https://github.com/bindreams/cosca/blob/d8fb546db1c0747c1828eaa06e911252267568ee/src/child/lifecycle_tests.rs#L69-L85) finished its `kill_tree()` 6 ms after this assertion fired. `spawn_lock` is held only across spawns, never across teardown, so the whole-body `test_spawn_lock()` does not exclude it.

The probe now carries this marker's own handle, the discriminator the [module docs already require](https://github.com/bindreams/cosca/blob/d8fb546db1c0747c1828eaa06e911252267568ee/src/containment/fdmarker_tests.rs#L4-L15) and every other log assertion in the crate already uses. A pipe handle cannot be reissued while the test holds the read end, so no simultaneously-live marker shares it.

A decoy record carrying the same sentence under a different handle is emitted inside the scanned window, so the scoping is proven on every run instead of only when the race happens to land. Verified as a mutation: against the decoy the old bare probe matches (the assertion would fire) and the handle-scoped one does not — checked for both a same-length and a carry-extending handle.

The gate itself is untouched.
