### PR TITLE
feat(windows): creation-flags hatch and portable window suppression

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -299,7 +299,16 @@ impl Child {
     /// child that owns a console can politely signal its own group-leading children.
     ///
     /// **And success here does not prove the event was delivered.** A root that shares no
-    /// console with the caller is reported as success and reaches nobody.
+    /// console with the caller is reported as success and reaches nobody — including a root
+    /// spawned with [`no_window`](crate::Command::no_window) or
+    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
+    /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
+    /// the *route* from this process, never an authority on whether a signal will arrive. It is
+    /// also not "this child cannot be shut down politely" — a process attached to the child's own
+    /// console can deliver the event. The cooperative op returns `Ok` and delivers nothing; the
+    /// forced ops ([`kill`](Child::kill) / [`kill_tree`](Child::kill_tree), and the escalation
+    /// half of [`graceful_shutdown_tree`](Child::graceful_shutdown_tree)) are unaffected.
     ///
     /// **And it needs the caller to have a console.** The event is deliverable only within
     /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything

--- a/src/child.rs
+++ b/src/child.rs
@@ -301,7 +301,7 @@ impl Child {
     /// **And success here does not prove the event was delivered.** A root that shares no
     /// console with the caller is reported as success and reaches nobody — including a root
     /// spawned with [`no_window`](crate::Command::no_window) or
-    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// `detached()`, which gets a console of its own. Such a root is
     /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
     /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
     /// the *route* from this process, never an authority on whether a signal will arrive. It is

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -146,7 +146,16 @@ impl Child {
     /// child that owns a console can politely signal its own group-leading children.
     ///
     /// **And success here does not prove the event was delivered.** A root that shares no
-    /// console with the caller is reported as success and reaches nobody.
+    /// console with the caller is reported as success and reaches nobody — including a root
+    /// spawned with [`no_window`](crate::Command::no_window) or
+    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
+    /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
+    /// the *route* from this process, never an authority on whether a signal will arrive. It is
+    /// also not "this child cannot be shut down politely" — a process attached to the child's own
+    /// console can deliver the event. The cooperative op returns `Ok` and delivers nothing; the
+    /// forced ops ([`kill`](Child::kill) / [`kill_tree`](Child::kill_tree), and the escalation
+    /// half of [`graceful_shutdown_tree`](Child::graceful_shutdown_tree)) are unaffected.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned

--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -148,7 +148,7 @@ impl Child {
     /// **And success here does not prove the event was delivered.** A root that shares no
     /// console with the caller is reported as success and reaches nobody — including a root
     /// spawned with [`no_window`](crate::Command::no_window) or
-    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// `detached()`, which gets a console of its own. Such a root is
     /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
     /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
     /// the *route* from this process, never an authority on whether a signal will arrive. It is

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -94,11 +94,32 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     spawn_unelevated(cmd, kill_on_drop)
 }
 
+/// The one authority for Windows backend routing: does `cmd` go to the raw `CreateProcessW`
+/// backend rather than std? Both routers read this — the sync one below and the async mirror in
+/// `crate::tokio::spawn` — so the rule cannot be two copies that drift.
+///
+/// **Call it before `std::mem::take(cmd.fds_mut())`.** It reads `cmd.fds()`; after the take the
+/// map is empty and the fd term silently evaluates false.
+///
+/// Pinned by `spawn_tests::routes_to_raw_backend_answers_for_executables_and_high_descriptors`,
+/// which is also what makes the backend names in `tests/windows_creation_flags.rs` true for its
+/// argv legs (an argv-only command reports the same `argv[0]` whichever backend spawned it).
+#[cfg(windows)]
+pub(crate) fn routes_to_raw_backend(cmd: &Command) -> bool {
+    cmd.executable_path().is_some() || cmd.fds().keys().any(|slot| slot.raw() >= 3)
+}
+
 /// The non-elevated spawn core: resolve stdio, wire program/args, spawn, attach,
 /// read identity, adopt. Shared by the ordinary path and the elevation paths'
 /// already-elevated / derived-command continuations (which must spawn without
 /// re-entering the elevation branch).
 pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<Child, Error> {
+    // Read the routing rule BEFORE the take, which empties the map the rule reads. Evaluated
+    // after, it would collapse to "does it have an executable()", and a high-descriptor-only
+    // command would take the std path — whose fd >= 3 collection is unix-only, so the
+    // descriptors would be dropped with no error and no panic.
+    #[cfg(windows)]
+    let to_raw_backend = routes_to_raw_backend(cmd);
     let fds = std::mem::take(cmd.fds_mut());
 
     // Windows routing. The raw `CreateProcessW` backend owns the cases std cannot
@@ -106,11 +127,8 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
     // (fd >= 3) via the MSVCRT `lpReserved2` fd-table. It handles both uncontained and
     // CONTAINED children (Job Object / TreeWalk).
     #[cfg(windows)]
-    {
-        let has_high_fd = fds.keys().any(|slot| slot.raw() >= 3);
-        if cmd.executable_path().is_some() || has_high_fd {
-            return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
-        }
+    if to_raw_backend {
+        return windows_raw::spawn_raw(cmd, fds, kill_on_drop);
     }
     let mut std_cmd = build_std_command(cmd)?;
 

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -184,9 +184,10 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         let prepared = crate::containment::prepare(
             &mut std_cmd,
             &cmd.contain_request(),
+            cmd.flags_request(),
             &reserved,
             cmd.fd_marker_suppressed(),
-        );
+        )?;
 
         // On Unix, hand n>=3 child ends to command-fds. This installs a pre_exec hook
         // that dup2's each OwnedFd to its target number post-fork. It is registered
@@ -218,9 +219,10 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         let prepared = crate::containment::prepare(
             &mut std_cmd,
             &cmd.contain_request(),
+            cmd.flags_request(),
             &reserved,
             cmd.fd_marker_suppressed(),
-        );
+        )?;
 
         // On Unix, hand n>=3 child ends to command-fds. See the macOS branch above for why
         // this is registered LAST (after `prepare`).

--- a/src/child/spawn.rs
+++ b/src/child/spawn.rs
@@ -267,7 +267,13 @@ pub(crate) fn spawn_unelevated(cmd: &mut Command, kill_on_drop: bool) -> Result<
         // own handle-inheritance marking must not overlap a raw spawn on another thread.
         let c = {
             let _guard = spawn_lock();
-            std_cmd.spawn().map_err(Error::Io)?
+            // Classified at the SYSCALL, not around the whole spawn: an access-denied from stdio
+            // resolution or the post-spawn attach has nothing to do with a breakaway request.
+            let spawned = std_cmd.spawn().map_err(Error::Io);
+            #[cfg(windows)]
+            let spawned =
+                spawned.map_err(|e| crate::command::flags::classify_spawn_syscall_error(e, *cmd.flags_request()));
+            spawned?
         };
         (prepared, c)
     };

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -35,8 +35,8 @@ use std::path::PathBuf;
 use windows::Win32::Foundation::{CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT};
 use windows::Win32::System::Threading::{
     DeleteProcThreadAttributeList, InitializeProcThreadAttributeList, OpenProcess, UpdateProcThreadAttribute,
-    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_TERMINATE,
-    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_TERMINATE, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, STARTF_USESTDHANDLES,
+    STARTUPINFOEXW,
 };
 
 use crate::child::proc_handle::ProcHandle;
@@ -70,15 +70,22 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     // the defaults (`contain_flags` 0, a `mode: None`/`is_root: false` `Prepared`); a Strongest root
     // spawns CREATE_SUSPENDED and is job-assigned + resumed in `attach_or_fault`.
     let req = cmd.contain_request();
-    let (contain_flags, is_root, marker_env) = if req.mode.is_some() {
-        let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
-        let is_root = !crate::containment::dispatch::is_nested(marker_present);
+    let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
+    let is_root = !crate::containment::dispatch::is_nested(marker_present);
+    // Composed and validated BEFORE `clear_std_handle_inheritance`, which is a process-global
+    // `SetHandleInformation` on THIS process's std handles that nothing undoes: a refused spawn
+    // must not have mutated the parent. The gate itself is unchanged — the call stays inside the
+    // containment condition, only below the refusal.
+    let plan = crate::command::flags::windows_spawn(
+        &req,
+        *cmd.flags_request(),
+        is_root,
+        crate::command::flags::SpawnBackend::Raw,
+    )?;
+    let marker_env = plan.marker_env;
+    if req.mode.is_some() {
         crate::containment::windows::clear_std_handle_inheritance();
-        let setup = crate::containment::dispatch::windows_contain_setup(&req, is_root);
-        (setup.creation_flags, is_root, setup.marker_env)
-    } else {
-        (0u32, false, false)
-    };
+    }
 
     // Append the inherited root marker AFTER the user's env ops so it survives a user `env_clear()`
     // (mirrors the std path setting the marker after the user's env).
@@ -124,7 +131,9 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let all_handles: &[HANDLE] = &table.handles;
     let attr = AttributeList::build(all_handles)?;
     si.lpAttributeList = attr.as_ptr();
-    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
+    // The complete word, composed above by the ONE function all three backends share — the two
+    // structural bits this backend cannot spawn without included. Nothing ORs into it here.
+    let flags = plan.creation_flags;
 
     // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
     // the attribute list BEFORE the guard releases on EVERY path. An early `?` here would drop the
@@ -154,8 +163,9 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let prepared = crate::containment::Prepared {
         mode: req.mode,
         is_root,
-        // From the FINAL flag word this backend passed to CreateProcessW, not from
-        // `contain_flags` alone: the derivation must read what the OS was actually given.
+        // From the COMPOSED word, which carries the caller's flags as well as the containment
+        // decision: a derivation reading only the containment half would report an in-process
+        // route for a child this spawn deliberately put in another console.
         graceful: crate::containment::windows::mechanism_from_flags(flags),
     };
     let raw_handle = proc.as_raw_handle();

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -74,8 +74,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let is_root = !crate::containment::dispatch::is_nested(marker_present);
     // Composed and validated BEFORE `clear_std_handle_inheritance`, which is a process-global
     // `SetHandleInformation` on THIS process's std handles that nothing undoes: a refused spawn
-    // must not have mutated the parent. The gate itself is unchanged — the call stays inside the
-    // containment condition, only below the refusal.
+    // must not have mutated the parent.
     let plan = crate::command::flags::windows_spawn(
         &req,
         *cmd.flags_request(),

--- a/src/child/spawn/windows_raw.rs
+++ b/src/child/spawn/windows_raw.rs
@@ -149,6 +149,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
             &env_block,
             &cwd_w,
             flags,
+            *cmd.flags_request(),
         );
         drop(child_ends); // close the child ends inside the lock, on success AND error
         drop(attr); // DeleteProcThreadAttributeList before the guard releases
@@ -226,6 +227,9 @@ pub(crate) fn build_fd_table(child_ends: &BTreeMap<Fd, ChildEnd>) -> Result<crt_
 /// Mark each listed handle inheritable, then spawn. Returns a Result WITHOUT `?`-ing so the caller
 /// can close the child ends + attribute list before releasing the spawn lock on either arm.
 /// `pub(crate)`: the async raw backend reuses the inheritable-mark + `create_process` window.
+// `CreateProcessW`'s own parameter list, plus the request its failure is classified against.
+// Bundling them would only rename the same values one call site deep.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_step(
     handles: &[HANDLE],
     app: Option<&[u16]>,
@@ -234,11 +238,15 @@ pub(crate) fn spawn_step(
     env: &Option<Vec<u16>>,
     cwd: &Option<Vec<u16>>,
     flags: u32,
+    request: crate::command::flags::FlagsRequest,
 ) -> Result<(OwnedHandle, u32), Error> {
     for &h in handles {
         set_inherit(h)?;
     }
+    // Only the syscall's own Result is classified — the inherit loop above stays outside, since
+    // an access-denied from `SetHandleInformation` is not a breakaway denial.
     proc::create_process(app, cmdline, si, env, cwd, flags)
+        .map_err(|e| crate::command::flags::classify_spawn_syscall_error(e, request))
 }
 
 /// Kill + reap a just-spawned child whose post-spawn attach/identity read failed, so a failed spawn

--- a/src/child/spawn_tests.rs
+++ b/src/child/spawn_tests.rs
@@ -174,3 +174,43 @@ fn a_refused_raw_spawn_does_not_clear_our_handle_inheritance() {
     );
     child.wait().expect("reap");
 }
+
+/// The std-path counterpart of the test above. The std backend reaches the same process-global
+/// mutation through `containment::prepare`, which composes and validates the creation-flag word
+/// at its top — a separate ordering the raw backends' tests cannot see.
+///
+/// Argv-only and no `executable()`, asserted through `routes_to_raw_backend` so a future routing
+/// change cannot quietly turn this into a third raw-backend test.
+#[cfg(windows)]
+#[test]
+fn a_refused_std_spawn_does_not_clear_our_handle_inheritance() {
+    use crate::containment::windows::observe;
+
+    let mut refused = Command::new();
+    refused
+        .args(["cmd", "/C", "exit 0"])
+        .contain()
+        .creation_flags(windows::Win32::System::Threading::CREATE_SUSPENDED.0);
+    assert!(
+        !super::routes_to_raw_backend(&refused),
+        "this leg is only a std-path proof while the command stays off the raw backend"
+    );
+    observe::take_inheritance_cleared();
+    let err = refused.spawn().expect_err("a reserved bit must be refused");
+    assert!(matches!(err, Error::Unsupported { .. }), "got {err:?}");
+    assert!(
+        !observe::take_inheritance_cleared(),
+        "the refusal ran after the mutation it was supposed to precede"
+    );
+
+    let mut allowed = Command::new();
+    allowed.args(["cmd", "/C", "exit 0"]).contain();
+    let child = allowed
+        .spawn()
+        .expect("the same command without the reserved bit spawns");
+    assert!(
+        observe::take_inheritance_cleared(),
+        "the seam must record a real call, else the negative leg above proves nothing"
+    );
+    child.wait().expect("reap");
+}

--- a/src/child/spawn_tests.rs
+++ b/src/child/spawn_tests.rs
@@ -89,3 +89,88 @@ fn elevated_pipe_is_rejected_deterministically_regardless_of_privilege() {
         Err(crate::error::Error::Unsupported { .. })
     ));
 }
+
+// ===== Windows backend routing =====
+
+/// The rule both Windows routers read, in both directions and for all four shapes.
+///
+/// `tests/windows_creation_flags.rs` names a backend in every test name; its `executable()` legs
+/// carry their own behavioural proof (the child's `argv[0]`), but its argv legs have none — an
+/// argv-only command would report the same `argv[0]` whichever backend spawned it. Their
+/// std-path claim rests on this rule, which is now one function rather than two copies.
+///
+/// The **high-descriptor-only** shape is the branch with no coverage anywhere today: every
+/// shipped Windows high-descriptor test also sets an explicit `executable()`, which
+/// short-circuits the rule before the fd term is ever evaluated.
+#[cfg(windows)]
+#[test]
+fn routes_to_raw_backend_answers_for_executables_and_high_descriptors() {
+    use crate::stdio::Stdio;
+
+    let mut argv_only = Command::new();
+    argv_only.args(["cmd", "/C", "exit 0"]);
+    assert!(
+        !super::routes_to_raw_backend(&argv_only),
+        "an argv-only command stays on the std path"
+    );
+
+    let mut exe_only = Command::new();
+    exe_only.executable("cmd").args(["cmd", "/C", "exit 0"]);
+    assert!(super::routes_to_raw_backend(&exe_only), "an executable() routes to raw");
+
+    let mut high_fd_only = Command::new();
+    high_fd_only.args(["cmd", "/C", "exit 0"]);
+    high_fd_only.fd(3, Stdio::pipe_out()).unwrap();
+    assert!(
+        super::routes_to_raw_backend(&high_fd_only),
+        "a descriptor >= 3 routes to raw even with no executable(): std cannot carry it, and the \
+         std path's fd >= 3 collection is unix-only, so it would be dropped in silence"
+    );
+
+    let mut both = Command::new();
+    both.executable("cmd").args(["cmd", "/C", "exit 0"]);
+    both.fd(3, Stdio::pipe_out()).unwrap();
+    assert!(super::routes_to_raw_backend(&both));
+}
+
+/// A refused spawn must not have mutated this process first. `clear_std_handle_inheritance` is a
+/// real, process-global, un-undone `SetHandleInformation` on our own std handles, so running it
+/// before the refusal would leave a disposition-less side effect behind.
+///
+/// The two legs differ by one bit and are one `#[test]` so their order is guaranteed; `cargo
+/// test` gives each test its own thread, so the thread-local seam starts clean. The positive leg
+/// is what stops the negative one passing on a seam that was never wired.
+///
+/// The real handle flags are deliberately NOT measured instead: the mutation is process-global
+/// and permanent, so any earlier contained spawn in this binary would already have made that
+/// observation meaningless.
+#[cfg(windows)]
+#[test]
+fn a_refused_raw_spawn_does_not_clear_our_handle_inheritance() {
+    use crate::containment::windows::observe;
+
+    let mut refused = Command::new();
+    refused
+        .executable("cmd")
+        .args(["cmd", "/C", "exit 0"])
+        .contain()
+        .creation_flags(windows::Win32::System::Threading::CREATE_SUSPENDED.0);
+    observe::take_inheritance_cleared();
+    let err = refused.spawn().expect_err("a reserved bit must be refused");
+    assert!(matches!(err, Error::Unsupported { .. }), "got {err:?}");
+    assert!(
+        !observe::take_inheritance_cleared(),
+        "the refusal ran after the mutation it was supposed to precede"
+    );
+
+    let mut allowed = Command::new();
+    allowed.executable("cmd").args(["cmd", "/C", "exit 0"]).contain();
+    let child = allowed
+        .spawn()
+        .expect("the same command without the reserved bit spawns");
+    assert!(
+        observe::take_inheritance_cleared(),
+        "the seam must record a real call, else the negative leg above proves nothing"
+    );
+    child.wait().expect("reap");
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -8,9 +8,12 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+use crate::command::flags::FlagsRequest;
 use crate::containment::{ContainMode, ContainRequest, Nesting};
 use crate::error::Error;
 use crate::stdio::{Fd, ResolvedStdio, Stdio};
+
+pub(crate) mod flags;
 
 /// A process to be configured and (later) spawned.
 #[derive(Debug)]
@@ -24,6 +27,7 @@ pub struct Command {
     contain: ContainRequest,
     elevation: crate::elevation::ElevationRequest,
     fd_marker_suppressed: bool,
+    flags: FlagsRequest,
 }
 
 /// An environment variable operation, recorded in order.
@@ -46,6 +50,7 @@ impl Default for Command {
             contain: ContainRequest::default(),
             elevation: crate::elevation::ElevationRequest::default(),
             fd_marker_suppressed: false,
+            flags: FlagsRequest::default(),
         }
     }
 }
@@ -223,6 +228,100 @@ impl Command {
 
     pub(crate) fn contain_request(&self) -> ContainRequest {
         self.contain
+    }
+
+    // ---- creation-flag intents ---------------------------------------
+
+    /// Do not put a console window on the user's screen for this child.
+    ///
+    /// # The intent sits above the mechanisms
+    ///
+    /// Windows offers two unrelated launch mechanisms and this request is lowered onto whichever
+    /// one a given spawn uses, because a flags-shaped API would honour it on one path and
+    /// silently ignore it on the other:
+    ///
+    /// | Platform / path | Lowered to |
+    /// | --- | --- |
+    /// | Windows, no [`elevate`](Self::elevate) | `CREATE_NO_WINDOW` in `dwCreationFlags` |
+    /// | Windows, `elevate()` from an **already-elevated** caller | `CREATE_NO_WINDOW` — the ordinary backends, unchanged |
+    /// | Windows, `elevate()` where a **consent prompt is used** | the launch's show-command becomes `SW_HIDE` |
+    /// | Unix | nothing; a documented no-op |
+    ///
+    /// The request means the same thing everywhere; only how far the closest available mechanism
+    /// carries it differs. Where the creation flag carries it, it concerns the child's
+    /// **console** and nothing else. Where a consent prompt is used there is no console-only
+    /// knob, so the show-command is the shell's initial show state for the whole launched
+    /// application — a graphical child's own main window is affected too, and may override it.
+    /// Note the condition: an already-elevated caller gets the ordinary creation flag, so
+    /// "elevation was requested" is not what selects the wider reach.
+    ///
+    /// A child that would not have had a console anyway — a windows-subsystem image, for
+    /// instance — needs no suppression and is not an error; the request is already satisfied.
+    /// Nothing is logged either.
+    ///
+    /// # Consequence for cooperative shutdown
+    ///
+    /// The child gets a console of its own rather than joining this process's, so a console-group
+    /// signal sent from this process cannot reach it. Not requesting this does not establish the
+    /// reverse — whether a child shares this process's console also depends on the child image's
+    /// subsystem and on what the child does with its own console. What cosca recorded about the
+    /// route is reported per child by
+    /// [`Child::graceful_mechanism`](crate::Child::graceful_mechanism); it is a statement about
+    /// the route, never an authority on whether a signal will arrive.
+    pub fn no_window(&mut self) -> &mut Command {
+        self.flags.no_window = true;
+        self
+    }
+
+    /// Spawn the child with `DETACHED_PROCESS`: it gets no console at all.
+    ///
+    /// This removes the child's **console**, not its stdio — with [`Stdio::inherit`] a detached
+    /// child still writes to the handles it inherited. It also does not leave a job; that is
+    /// [`breakaway_from_job`](Self::breakaway_from_job).
+    ///
+    /// Same one-directional console consequence as [`no_window`](Self::no_window): a
+    /// console-group signal sent from this process cannot reach such a child, while *not*
+    /// detaching establishes nothing about the reverse.
+    #[cfg(windows)]
+    pub fn detached(&mut self) -> &mut Command {
+        self.flags.detached = true;
+        self
+    }
+
+    /// Add arbitrary bits to this spawn's `dwCreationFlags`, for flags cosca does not name.
+    ///
+    /// **Replaces, it does not accumulate** — matching
+    /// [`std::os::windows::process::CommandExt::creation_flags`]. Calling it twice leaves the
+    /// second word, and `creation_flags(0)` is how a word set earlier is cleared. Or-in would
+    /// make a bit unclearable, which is the one thing a raw hatch must never do.
+    ///
+    /// # Reserved bits
+    ///
+    /// Bits whose consequences cosca must manage are refused at spawn with
+    /// [`Error::Unsupported`], naming every offending flag and its replacement. Validation is at
+    /// spawn rather than here because a pairwise rule enforced in a setter would give a verdict
+    /// that depends on builder call order.
+    ///
+    /// | Flag | Why reserved | Instead |
+    /// | --- | --- | --- |
+    /// | `CREATE_SUSPENDED` | cosca suspends and resumes a contained root itself | none yet |
+    /// | `CREATE_NEW_PROCESS_GROUP` | load-bearing for `CTRL_BREAK` delivery to the contained root | [`contain`](Self::contain) |
+    /// | `CREATE_NEW_CONSOLE` | measured: the child gets its own *visible* console window, overriding a requested window suppression | none |
+    /// | `CREATE_UNICODE_ENVIRONMENT` | both backends supply it structurally, so a caller can neither set nor clear it meaningfully | none |
+    /// | `EXTENDED_STARTUPINFO_PRESENT` | it announces a structure only the spawn backend can supply | none |
+    /// | `DETACHED_PROCESS` | carries a console consequence cosca must record | [`detached`](Self::detached) |
+    /// | `CREATE_NO_WINDOW` | same | [`no_window`](Self::no_window) |
+    /// | `CREATE_BREAKAWAY_FROM_JOB` | same, plus the failure classification the raw bit would lose | [`breakaway_from_job`](Self::breakaway_from_job) |
+    /// | `DEBUG_PROCESS` | makes the spawner a debugger; the child stops on debug events nothing services, so `wait`/`wait_tree` would hang | none |
+    /// | `DEBUG_ONLY_THIS_PROCESS` | same | none |
+    #[cfg(windows)]
+    pub fn creation_flags(&mut self, flags: u32) -> &mut Command {
+        self.flags.raw = flags;
+        self
+    }
+
+    pub(crate) fn flags_request(&self) -> &FlagsRequest {
+        &self.flags
     }
 
     /// Run this child elevated (admin/root). Sugar for `Backend::Auto` +

--- a/src/command.rs
+++ b/src/command.rs
@@ -257,7 +257,6 @@ impl Command {
     ///
     /// A child that would not have had a console anyway — a windows-subsystem image, for
     /// instance — needs no suppression and is not an error; the request is already satisfied.
-    /// Nothing is logged either.
     ///
     /// # Consequence for cooperative shutdown
     ///
@@ -344,7 +343,7 @@ impl Command {
     ///
     /// | Flag | Why reserved | Instead |
     /// | --- | --- | --- |
-    /// | `CREATE_SUSPENDED` | cosca suspends and resumes a contained root itself | none yet |
+    /// | `CREATE_SUSPENDED` | cosca suspends and resumes a contained root itself | none; a suspended-spawn window is being designed in [cosca#49](https://github.com/bindreams/cosca/issues/49) |
     /// | `CREATE_NEW_PROCESS_GROUP` | load-bearing for `CTRL_BREAK` delivery to the contained root | [`contain`](Self::contain) |
     /// | `CREATE_NEW_CONSOLE` | measured: the child gets its own *visible* console window, overriding a requested window suppression | none |
     /// | `CREATE_UNICODE_ENVIRONMENT` | both backends supply it structurally, so a caller can neither set nor clear it meaningfully | none |

--- a/src/command.rs
+++ b/src/command.rs
@@ -268,6 +268,13 @@ impl Command {
     /// route is reported per child by
     /// [`Child::graceful_mechanism`](crate::Child::graceful_mechanism); it is a statement about
     /// the route, never an authority on whether a signal will arrive.
+    ///
+    /// This is not "such a child cannot be shut down politely" — a process attached to the child's
+    /// own console can deliver the event. Nor does cosca report an error for one: the cooperative
+    /// ops ([`terminate`](crate::Child::terminate),
+    /// [`terminate_tree`](crate::Child::terminate_tree)) return `Ok` and deliver nothing, which is
+    /// the gap this crate documents rather than the behaviour it wants. The forced ops
+    /// ([`kill`](crate::Child::kill) / [`kill_tree`](crate::Child::kill_tree)) are unaffected.
     pub fn no_window(&mut self) -> &mut Command {
         self.flags.no_window = true;
         self
@@ -281,7 +288,8 @@ impl Command {
     ///
     /// Same one-directional console consequence as [`no_window`](Self::no_window): a
     /// console-group signal sent from this process cannot reach such a child, while *not*
-    /// detaching establishes nothing about the reverse.
+    /// detaching establishes nothing about the reverse — and the cooperative ops return `Ok` and
+    /// deliver nothing rather than reporting an error.
     #[cfg(windows)]
     pub fn detached(&mut self) -> &mut Command {
         self.flags.detached = true;

--- a/src/command.rs
+++ b/src/command.rs
@@ -288,6 +288,38 @@ impl Command {
         self
     }
 
+    /// Spawn the child with `CREATE_BREAKAWAY_FROM_JOB`, so it starts outside whatever job object
+    /// this process belongs to.
+    ///
+    /// The bit is emitted from the request alone — cosca never reads the ambient job first. A
+    /// pre-spawn reading could go stale in the gap, and omitting the bit on a "not in a job"
+    /// reading would silently leave the child in a job the caller asked it to escape. Where the
+    /// ambient job forbids breakaway the OS refuses the spawn, and that refusal is classified
+    /// afterwards as [`Error::Containment`](crate::error::Error::Containment).
+    ///
+    /// # What it does not promise
+    ///
+    /// - Breakaway leaves the immediate job and each job up the parent chain **until one forbids
+    ///   it**, so under nesting the child can still end up inside an ancestor job. cosca does not
+    ///   promise the child ends up in no job at all.
+    /// - **It cannot succeed from inside a cosca-contained tree.** cosca's own containment job
+    ///   sets neither breakaway limit, and a member process cannot relax the limits of the job
+    ///   that holds it — so for a child that was itself spawned by cosca with
+    ///   [`contain`](Self::contain), this request can only fail.
+    /// - The resulting error names the **first** thing the OS refused. The breakaway denial is
+    ///   evaluated before the image is resolved, so removing the request may reveal a different
+    ///   failure rather than making the spawn work.
+    ///
+    /// Combining it with any `contain*()` is [`Error::Unsupported`](crate::error::Error::Unsupported):
+    /// a nested contained spawn's containment IS "the child inherits the ancestor's job", and
+    /// breaking away from it would leave cosca reporting a teardown owner that no longer owns
+    /// anything.
+    #[cfg(windows)]
+    pub fn breakaway_from_job(&mut self) -> &mut Command {
+        self.flags.breakaway_from_job = true;
+        self
+    }
+
     /// Add arbitrary bits to this spawn's `dwCreationFlags`, for flags cosca does not name.
     ///
     /// **Replaces, it does not accumulate** — matching

--- a/src/command/flags.rs
+++ b/src/command/flags.rs
@@ -65,6 +65,7 @@ pub(crate) enum SpawnBackend {
 
 /// Everything cosca decided about a Windows spawn before it happens.
 #[cfg(windows)]
+#[derive(Debug)]
 pub(crate) struct WindowsSpawn {
     /// The complete word cosca supplies to the backend — see the module doc for why that is not
     /// the word the OS receives.
@@ -183,6 +184,21 @@ pub(crate) fn windows_spawn(
         });
     }
 
+    // Pure, so there is no staleness to race: both operands are recorded on the builder. For a
+    // NESTED contained spawn cosca's containment IS "the child inherits the ancestor's job", and
+    // breaking away leaves it while `Containment::Delegated` still claims the root will tear it
+    // down — a report that is simply false. A root contained spawn is arguably safe, but making
+    // the verdict depend on root-ness would mean the identical `Command` succeeds in one process
+    // and fails in a nested one.
+    if flags.breakaway_from_job && contain.mode.is_some() {
+        return Err(Error::Unsupported {
+            op: "breakaway_from_job() with contain()".into(),
+            platform: "windows",
+            detail: "cosca's containment is a job object the child must be inside for the tree                      teardown it reports to be true, and a nested contained spawn's containment IS                      inheriting the ancestor's job. Drop one of the two."
+                .into(),
+        });
+    }
+
     let setup = crate::containment::dispatch::windows_contain_setup(contain, is_root);
     let mut creation_flags = setup.creation_flags | flags.raw;
     if flags.no_window {
@@ -204,6 +220,69 @@ pub(crate) fn windows_spawn(
         creation_flags,
         marker_env: setup.marker_env,
     })
+}
+
+/// Classify a Windows spawn-syscall failure. Pure — the OS's error and the ambient job's verdict
+/// are both parameters — so every arm is unit-testable without the OS producing the configuration.
+///
+/// It runs on the error path of a spawn SYSCALL and nowhere else. Everything above a syscall
+/// (stdio resolution, executable resolution, handle-inherit calls, the attribute list, the
+/// post-spawn attach) can fail access-denied for reasons that have nothing to do with a breakaway
+/// request, and the soundness argument below holds only for the error the spawn call itself
+/// returned.
+///
+/// **Why naming the request is sound.** With a forbidding ambient job, an emitted
+/// `CREATE_BREAKAWAY_FROM_JOB` *guarantees* an access-denied failure, so the request is a
+/// sufficient cause of the failure the caller just got — honest even if the image's own ACL would
+/// also have denied the spawn, since fixing the named cause is necessary either way.
+///
+/// **Why the message claims only FIRST.** Measured: the breakaway denial is evaluated before the
+/// image is resolved — a spawn of a path that does not exist, inside a forbidding job, fails
+/// access-denied rather than file-not-found. So a genuine "no such program" is masked, and the
+/// detail says what was measured and stops there.
+///
+/// Two error encodings reach here and both are accepted: the std path returns the bare Win32
+/// code, while the raw backends convert a `windows::core::Error` whose `raw_os_error` is the
+/// HRESULT.
+#[cfg(windows)]
+pub(crate) fn classify_spawn_denial(
+    err: Error,
+    flags: FlagsRequest,
+    job: crate::containment::windows::JobBreakaway,
+) -> Error {
+    use crate::containment::windows::JobBreakaway;
+    use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
+
+    if !flags.breakaway_from_job {
+        return err;
+    }
+    let Error::Io(io) = &err else {
+        return err;
+    };
+    let win32 = ERROR_ACCESS_DENIED.0 as i32;
+    let hresult = windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0).0;
+    if !matches!(io.raw_os_error(), Some(c) if c == win32 || c == hresult) {
+        return err;
+    }
+    // Never assert a cause the process just measured to be false, or could not measure at all.
+    if job != JobBreakaway::Forbidden {
+        return err;
+    }
+    Error::Containment {
+        detail: "the spawn was refused with ACCESS_DENIED, and this process's job object sets                  neither JOB_OBJECT_LIMIT_BREAKAWAY_OK nor JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,                  so it forbids the breakaway_from_job() this spawn requested. Windows evaluates                  that check before it resolves the image, so this is the FIRST thing refused and                  not necessarily the only problem: dropping the request may reveal a different                  failure rather than making the spawn work. Only whoever created that job can                  permit breakaway — and if this process was itself spawned by cosca with                  contain(), the job is cosca's own, which sets neither limit and whose limits a                  member process cannot relax."
+            .into(),
+    }
+}
+
+/// The one impure adapter, called at the Windows spawn syscalls and nowhere else, so no spawn
+/// path grows a probe call of its own.
+///
+/// The probe therefore runs on every failed Windows spawn syscall, not only breakaway ones. That
+/// is deliberate: two syscalls on an already-failing spawn are irrelevant, and gating the probe
+/// would move part of the decision out of the pure function above and into untested glue.
+#[cfg(windows)]
+pub(crate) fn classify_spawn_syscall_error(err: Error, flags: FlagsRequest) -> Error {
+    classify_spawn_denial(err, flags, crate::containment::windows::probe_job_breakaway())
 }
 
 #[cfg(all(test, windows))]

--- a/src/command/flags.rs
+++ b/src/command/flags.rs
@@ -73,7 +73,6 @@ pub(crate) struct WindowsSpawn {
     /// Whether this spawn must set the inherited root marker so descendants join THIS group.
     /// Read by the raw backends, which build their own environment block; the std path applies
     /// the marker through the portable path `prepare` shares with Unix.
-    #[cfg_attr(not(windows), allow(dead_code))]
     pub marker_env: bool,
 }
 

--- a/src/command/flags.rs
+++ b/src/command/flags.rs
@@ -1,0 +1,203 @@
+//! The creation-flag request a caller records on a [`Command`](crate::Command), and the one
+//! function that turns it into the `dwCreationFlags` word cosca supplies to a Windows spawn.
+//!
+//! # What the composed word is, and is not
+//!
+//! [`windows_spawn`] returns **what cosca supplies** for a given backend — never what
+//! `CreateProcessW` receives. On the std backend those differ: std stores the word verbatim and
+//! then ORs `CREATE_UNICODE_ENVIRONMENT` into it at spawn, plus `EXTENDED_STARTUPINFO_PRESENT`
+//! when it holds a proc-thread attribute list. No predicate may read the returned word as a fact
+//! about the child, with one argued exception: `mechanism_from_flags` reads only four bits that
+//! std neither adds nor removes.
+//!
+//! # What the flags settle about the child's console
+//!
+//! Measured on Windows 11: a plain console-subsystem child joins the spawner's console;
+//! `CREATE_NO_WINDOW` gives it a *windowless console of its own*; `DETACHED_PROCESS` gives it
+//! none; `CREATE_NEW_CONSOLE` gives it a visible one, overriding a requested suppression.
+//!
+//! The reading is **one-directional**. A suppressing or detaching flag being present is enough
+//! to know the child is not in this process's console. The converse is false: the image's
+//! subsystem decides console membership too — a windows-subsystem image never attaches to its
+//! spawner's console whatever the word says — and a child may free or reallocate its own console
+//! after it starts. Nothing here describes whether a signal would be *delivered*; that is not
+//! knowable from inside this process.
+
+#[cfg(windows)]
+use crate::containment::ContainRequest;
+#[cfg(windows)]
+use crate::error::Error;
+#[cfg(windows)]
+use windows::Win32::System::Threading::{
+    CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED,
+    CREATE_UNICODE_ENVIRONMENT, DEBUG_ONLY_THIS_PROCESS, DEBUG_PROCESS, DETACHED_PROCESS, EXTENDED_STARTUPINFO_PRESENT,
+};
+
+/// What a caller asked for, recorded on the builder and validated at spawn.
+///
+/// Validation is deliberately not in the setters: a pairwise rule enforced there would give a
+/// verdict that depends on builder call order.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct FlagsRequest {
+    /// "Do not put a console window on the user's screen" — the one portable intent. Lowered to
+    /// a creation flag on the ordinary Windows backends, to a show-command on the consent-prompt
+    /// elevation launch, and to nothing at all on Unix.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub no_window: bool,
+    #[cfg(windows)]
+    pub detached: bool,
+    #[cfg(windows)]
+    pub breakaway_from_job: bool,
+    /// The raw hatch. `0` is indistinguishable from never calling `creation_flags`, which is
+    /// correct: a zero word requests no bits, so there is nothing to refuse and nothing to emit.
+    #[cfg(windows)]
+    pub raw: u32,
+}
+
+/// Which Windows spawn mechanism the word is being composed for. The raw `CreateProcessW`
+/// backend needs two structural bits it cannot spawn without; std supplies its own.
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpawnBackend {
+    Std,
+    Raw,
+}
+
+/// Everything cosca decided about a Windows spawn before it happens.
+#[cfg(windows)]
+pub(crate) struct WindowsSpawn {
+    /// The complete word cosca supplies to the backend — see the module doc for why that is not
+    /// the word the OS receives.
+    pub creation_flags: u32,
+}
+
+/// A bit `creation_flags` refuses, and what to reach for instead.
+#[cfg(windows)]
+struct Reserved {
+    bit: u32,
+    name: &'static str,
+    remedy: &'static str,
+}
+
+/// The reserved set, in ascending bit order so a multi-bit refusal reads in a stable sequence.
+#[cfg(windows)]
+fn reserved_table() -> [Reserved; 10] {
+    [
+        Reserved {
+            bit: DEBUG_PROCESS.0,
+            name: "DEBUG_PROCESS",
+            remedy: "no replacement: it makes the spawner a debugger, and the child stops on debug \
+                     events nothing here services, so wait()/wait_tree() would hang",
+        },
+        Reserved {
+            bit: DEBUG_ONLY_THIS_PROCESS.0,
+            name: "DEBUG_ONLY_THIS_PROCESS",
+            remedy: "no replacement: same reason as DEBUG_PROCESS",
+        },
+        Reserved {
+            bit: CREATE_SUSPENDED.0,
+            name: "CREATE_SUSPENDED",
+            remedy: "no replacement yet: cosca suspends and resumes a contained root itself, so a \
+                     caller's suspend would be resumed silently on a contained spawn and never \
+                     resumed at all on an uncontained one",
+        },
+        Reserved {
+            bit: DETACHED_PROCESS.0,
+            name: "DETACHED_PROCESS",
+            remedy: "use detached()",
+        },
+        Reserved {
+            bit: CREATE_NEW_CONSOLE.0,
+            name: "CREATE_NEW_CONSOLE",
+            remedy: "no replacement: measured to give the child its own VISIBLE console window, \
+                     overriding a requested window suppression",
+        },
+        Reserved {
+            bit: CREATE_NEW_PROCESS_GROUP.0,
+            name: "CREATE_NEW_PROCESS_GROUP",
+            remedy: "use contain(), which is what makes the child's group addressable",
+        },
+        Reserved {
+            bit: CREATE_UNICODE_ENVIRONMENT.0,
+            name: "CREATE_UNICODE_ENVIRONMENT",
+            remedy: "no replacement: both backends supply it structurally — the raw one always \
+                     builds a UTF-16 environment block, and std ORs the bit in regardless of what \
+                     it was given",
+        },
+        Reserved {
+            bit: EXTENDED_STARTUPINFO_PRESENT.0,
+            name: "EXTENDED_STARTUPINFO_PRESENT",
+            remedy: "no replacement: it announces a structure only the spawn backend can supply",
+        },
+        Reserved {
+            bit: CREATE_BREAKAWAY_FROM_JOB.0,
+            name: "CREATE_BREAKAWAY_FROM_JOB",
+            remedy: "use breakaway_from_job(), which also classifies the failure a forbidding \
+                     ambient job produces",
+        },
+        Reserved {
+            bit: CREATE_NO_WINDOW.0,
+            name: "CREATE_NO_WINDOW",
+            remedy: "use no_window()",
+        },
+    ]
+}
+
+/// The reserved bits present in `raw`, in ascending bit order.
+#[cfg(windows)]
+fn reserved_bits_in(raw: u32) -> Vec<Reserved> {
+    let mut hits: Vec<Reserved> = reserved_table().into_iter().filter(|r| raw & r.bit != 0).collect();
+    hits.sort_by_key(|r| r.bit);
+    hits
+}
+
+/// Compose the `dwCreationFlags` word cosca supplies to `backend` for this spawn, and refuse the
+/// combinations cosca cannot honour.
+///
+/// Pure: `contain`, `flags` and `is_root` are all recorded state, so the verdict never depends on
+/// process state that could change between the reading and the spawn. Every rule that *does* need
+/// to know about the ambient job is a post-failure classifier instead.
+#[cfg(windows)]
+pub(crate) fn windows_spawn(
+    contain: &ContainRequest,
+    flags: FlagsRequest,
+    is_root: bool,
+    backend: SpawnBackend,
+) -> Result<WindowsSpawn, Error> {
+    let offending = reserved_bits_in(flags.raw);
+    if !offending.is_empty() {
+        let named = offending
+            .iter()
+            .map(|r| format!("{} ({})", r.name, r.remedy))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(Error::Unsupported {
+            op: "creation_flags".into(),
+            platform: "windows",
+            detail: format!("creation flags cosca manages itself cannot be set through the raw hatch: {named}"),
+        });
+    }
+
+    let setup = crate::containment::dispatch::windows_contain_setup(contain, is_root);
+    let mut creation_flags = setup.creation_flags | flags.raw;
+    if flags.no_window {
+        creation_flags |= CREATE_NO_WINDOW.0;
+    }
+    if flags.detached {
+        creation_flags |= DETACHED_PROCESS.0;
+    }
+    // Emitted from the request alone. The flag is a documented no-op when this process is in no
+    // job, so omitting it on a "not in a job" reading buys nothing and costs the caller's request
+    // if the reading goes stale before the spawn.
+    if flags.breakaway_from_job {
+        creation_flags |= CREATE_BREAKAWAY_FROM_JOB.0;
+    }
+    if backend == SpawnBackend::Raw {
+        creation_flags |= CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0;
+    }
+    Ok(WindowsSpawn { creation_flags })
+}
+
+#[cfg(all(test, windows))]
+#[path = "flags_tests.rs"]
+mod flags_tests;

--- a/src/command/flags.rs
+++ b/src/command/flags.rs
@@ -69,6 +69,11 @@ pub(crate) struct WindowsSpawn {
     /// The complete word cosca supplies to the backend — see the module doc for why that is not
     /// the word the OS receives.
     pub creation_flags: u32,
+    /// Whether this spawn must set the inherited root marker so descendants join THIS group.
+    /// Read by the raw backends, which build their own environment block; the std path applies
+    /// the marker through the portable path `prepare` shares with Unix.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub marker_env: bool,
 }
 
 /// A bit `creation_flags` refuses, and what to reach for instead.
@@ -195,7 +200,10 @@ pub(crate) fn windows_spawn(
     if backend == SpawnBackend::Raw {
         creation_flags |= CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0;
     }
-    Ok(WindowsSpawn { creation_flags })
+    Ok(WindowsSpawn {
+        creation_flags,
+        marker_env: setup.marker_env,
+    })
 }
 
 #[cfg(all(test, windows))]

--- a/src/command/flags.rs
+++ b/src/command/flags.rs
@@ -102,9 +102,10 @@ fn reserved_table() -> [Reserved; 10] {
         Reserved {
             bit: CREATE_SUSPENDED.0,
             name: "CREATE_SUSPENDED",
-            remedy: "no replacement yet: cosca suspends and resumes a contained root itself, so a \
-                     caller's suspend would be resumed silently on a contained spawn and never \
-                     resumed at all on an uncontained one",
+            remedy: "no replacement today, a suspended-spawn window is being designed in cosca#49: \
+                     cosca suspends and resumes a contained root itself, so a caller's suspend \
+                     would be resumed silently on a contained spawn and never resumed at all on \
+                     an uncontained one",
         },
         Reserved {
             bit: DETACHED_PROCESS.0,
@@ -193,7 +194,9 @@ pub(crate) fn windows_spawn(
         return Err(Error::Unsupported {
             op: "breakaway_from_job() with contain()".into(),
             platform: "windows",
-            detail: "cosca's containment is a job object the child must be inside for the tree                      teardown it reports to be true, and a nested contained spawn's containment IS                      inheriting the ancestor's job. Drop one of the two."
+            detail: "cosca's containment is a job object the child must be inside for the tree \
+                     teardown it reports to be true, and a nested contained spawn's containment IS \
+                     inheriting the ancestor's job. Drop one of the two."
                 .into(),
         });
     }
@@ -268,7 +271,15 @@ pub(crate) fn classify_spawn_denial(
         return err;
     }
     Error::Containment {
-        detail: "the spawn was refused with ACCESS_DENIED, and this process's job object sets                  neither JOB_OBJECT_LIMIT_BREAKAWAY_OK nor JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,                  so it forbids the breakaway_from_job() this spawn requested. Windows evaluates                  that check before it resolves the image, so this is the FIRST thing refused and                  not necessarily the only problem: dropping the request may reveal a different                  failure rather than making the spawn work. Only whoever created that job can                  permit breakaway — and if this process was itself spawned by cosca with                  contain(), the job is cosca's own, which sets neither limit and whose limits a                  member process cannot relax."
+        detail: "the spawn was refused with ACCESS_DENIED, and this process's job object sets \
+                 neither JOB_OBJECT_LIMIT_BREAKAWAY_OK nor JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK, \
+                 so it forbids the breakaway_from_job() this spawn requested. Windows evaluates \
+                 that check before it resolves the image, so this is the FIRST thing refused and \
+                 not necessarily the only problem: dropping the request may reveal a different \
+                 failure rather than making the spawn work. Only whoever created that job can \
+                 permit breakaway — and if this process was itself spawned by cosca with \
+                 contain(), the job is cosca's own, which sets neither limit and whose limits a \
+                 member process cannot relax."
             .into(),
     }
 }

--- a/src/command/flags_tests.rs
+++ b/src/command/flags_tests.rs
@@ -235,3 +235,120 @@ fn the_composed_word_reports_a_different_mechanism_for_each_containment_shape() 
         "window suppression puts the child's group in a console of its own"
     );
 }
+
+// ===== breakaway: the pre-spawn rule and the post-failure classifier =====
+
+use crate::containment::windows::JobBreakaway;
+
+fn breakaway() -> FlagsRequest {
+    FlagsRequest {
+        breakaway_from_job: true,
+        ..Default::default()
+    }
+}
+
+/// `ERROR_ACCESS_DENIED` in the two encodings that reach the classifier: the std path returns the
+/// bare Win32 code, the raw backends convert a `windows::core::Error` whose `raw_os_error` is the
+/// HRESULT. Derived from the documented `HRESULT_FROM_WIN32` mapping, not from this crate's own
+/// output, so a bug in that conversion cannot make the test agree with itself.
+fn access_denied_encodings() -> [i32; 2] {
+    let win32 = windows::Win32::Foundation::ERROR_ACCESS_DENIED.0 as i32;
+    [win32, windows::core::HRESULT::from_win32(win32 as u32).0]
+}
+
+fn io_err(code: i32) -> Error {
+    Error::Io(std::io::Error::from_raw_os_error(code))
+}
+
+/// Breaking away while contained is refused for a ROOT and a NESTED request alike, so the verdict
+/// is order- and root-independent: making it depend on root-ness would mean the identical
+/// `Command` succeeds in one process and fails in a nested one.
+#[test]
+fn breakaway_with_containment_is_refused() {
+    for is_root in [true, false] {
+        let err = windows_spawn(&contained(), breakaway(), is_root, SpawnBackend::Std)
+            .expect_err("breakaway plus containment is refused");
+        assert!(
+            matches!(err, Error::Unsupported { .. }),
+            "is_root={is_root}: got {err:?}"
+        );
+    }
+}
+
+/// F1: with a forbidding ambient job, an emitted breakaway bit GUARANTEES an access-denied
+/// failure, so the request is a sufficient cause of the failure the caller just got.
+///
+/// The detail names the measured limit, the request, and the first-refusal qualifier. It must not
+/// claim the request was the spawn's only problem: the breakaway check runs before the image is
+/// resolved, so a genuine "no such program" is masked by it.
+#[test]
+fn a_forbidding_job_turns_access_denied_into_a_typed_containment_error() {
+    for code in access_denied_encodings() {
+        let out = super::classify_spawn_denial(io_err(code), breakaway(), JobBreakaway::Forbidden);
+        let Error::Containment { detail } = out else {
+            panic!("encoding {code:#x}: expected Containment, got {out:?}");
+        };
+        assert!(detail.contains("JOB_OBJECT_LIMIT_BREAKAWAY_OK"), "{detail}");
+        assert!(detail.contains("breakaway_from_job()"), "{detail}");
+        assert!(detail.contains("FIRST"), "{detail}");
+    }
+}
+
+/// F2. Measured (Windows 11 26100, 2026-08-18): a silent-breakaway job ACCEPTS the flag, so no
+/// breakaway request can reach the classifier from such a job at all. The verdict exists solely
+/// to stop that job being misread as `Forbidden`, whose message would be wrong about the world —
+/// a silent-breakaway job does not forbid children from leaving, it removes them itself.
+#[test]
+fn the_silent_breakaway_verdict_keeps_the_raw_io_error() {
+    for code in access_denied_encodings() {
+        let out = super::classify_spawn_denial(io_err(code), breakaway(), JobBreakaway::SilentBreakaway);
+        assert!(matches!(out, Error::Io(_)), "encoding {code:#x}: got {out:?}");
+    }
+}
+
+/// F3: the typed variant must never assert a cause the process just measured to be false — nor
+/// one it could not measure at all.
+#[test]
+fn a_contradicted_or_unmeasurable_probe_keeps_the_raw_io_error() {
+    for job in [JobBreakaway::Permitted, JobBreakaway::NotInJob, JobBreakaway::Unknown] {
+        for code in access_denied_encodings() {
+            let out = super::classify_spawn_denial(io_err(code), breakaway(), job);
+            assert!(matches!(out, Error::Io(_)), "{job:?}/{code:#x}: got {out:?}");
+        }
+    }
+}
+
+/// F4: an unrelated failure code stays itself whatever the ambient job looks like.
+#[test]
+fn an_unrelated_failure_code_is_never_reclassified() {
+    let not_found = windows::Win32::Foundation::ERROR_FILE_NOT_FOUND.0 as i32;
+    for job in [
+        JobBreakaway::Forbidden,
+        JobBreakaway::Permitted,
+        JobBreakaway::SilentBreakaway,
+        JobBreakaway::NotInJob,
+        JobBreakaway::Unknown,
+    ] {
+        let out = super::classify_spawn_denial(io_err(not_found), breakaway(), job);
+        assert!(matches!(out, Error::Io(_)), "{job:?}: got {out:?}");
+    }
+}
+
+/// F4, the other half: an access-denied spawn with NO breakaway request is never blamed on a job.
+/// Without this, an unrelated denial would be rewritten into a containment error naming a flag
+/// that was never submitted to anything.
+#[test]
+fn a_spawn_denial_without_a_breakaway_request_is_never_reclassified() {
+    for job in [
+        JobBreakaway::Forbidden,
+        JobBreakaway::Permitted,
+        JobBreakaway::SilentBreakaway,
+        JobBreakaway::NotInJob,
+        JobBreakaway::Unknown,
+    ] {
+        for code in access_denied_encodings() {
+            let out = super::classify_spawn_denial(io_err(code), FlagsRequest::default(), job);
+            assert!(matches!(out, Error::Io(_)), "{job:?}/{code:#x}: got {out:?}");
+        }
+    }
+}

--- a/src/command/flags_tests.rs
+++ b/src/command/flags_tests.rs
@@ -275,7 +275,7 @@ fn breakaway_with_containment_is_refused() {
     }
 }
 
-/// F1: with a forbidding ambient job, an emitted breakaway bit GUARANTEES an access-denied
+/// With a forbidding ambient job, an emitted breakaway bit GUARANTEES an access-denied
 /// failure, so the request is a sufficient cause of the failure the caller just got.
 ///
 /// The detail names the measured limit, the request, and the first-refusal qualifier. It must not
@@ -294,7 +294,7 @@ fn a_forbidding_job_turns_access_denied_into_a_typed_containment_error() {
     }
 }
 
-/// F2. Measured (Windows 11 26100, 2026-08-18): a silent-breakaway job ACCEPTS the flag, so no
+/// Measured (Windows 11 26100, 2026-08-18): a silent-breakaway job ACCEPTS the flag, so no
 /// breakaway request can reach the classifier from such a job at all. The verdict exists solely
 /// to stop that job being misread as `Forbidden`, whose message would be wrong about the world —
 /// a silent-breakaway job does not forbid children from leaving, it removes them itself.
@@ -306,7 +306,7 @@ fn the_silent_breakaway_verdict_keeps_the_raw_io_error() {
     }
 }
 
-/// F3: the typed variant must never assert a cause the process just measured to be false — nor
+/// The typed variant must never assert a cause the process just measured to be false — nor
 /// one it could not measure at all.
 #[test]
 fn a_contradicted_or_unmeasurable_probe_keeps_the_raw_io_error() {
@@ -318,7 +318,7 @@ fn a_contradicted_or_unmeasurable_probe_keeps_the_raw_io_error() {
     }
 }
 
-/// F4: an unrelated failure code stays itself whatever the ambient job looks like.
+/// An unrelated failure code stays itself whatever the ambient job looks like.
 #[test]
 fn an_unrelated_failure_code_is_never_reclassified() {
     let not_found = windows::Win32::Foundation::ERROR_FILE_NOT_FOUND.0 as i32;
@@ -334,7 +334,7 @@ fn an_unrelated_failure_code_is_never_reclassified() {
     }
 }
 
-/// F4, the other half: an access-denied spawn with NO breakaway request is never blamed on a job.
+/// The other half: an access-denied spawn with NO breakaway request is never blamed on a job.
 /// Without this, an unrelated denial would be rewritten into a containment error naming a flag
 /// that was never submitted to anything.
 #[test]

--- a/src/command/flags_tests.rs
+++ b/src/command/flags_tests.rs
@@ -1,0 +1,237 @@
+//! Truth tables for the composed creation-flag word. Pure: nothing here spawns anything, so
+//! every rule is pinned across the whole request space rather than at the shapes a live spawn
+//! happens to take.
+#![cfg(windows)]
+
+use windows::Win32::System::Threading::{
+    CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED,
+    CREATE_UNICODE_ENVIRONMENT, DEBUG_ONLY_THIS_PROCESS, DEBUG_PROCESS, DETACHED_PROCESS, EXTENDED_STARTUPINFO_PRESENT,
+    IDLE_PRIORITY_CLASS,
+};
+
+use super::{windows_spawn, FlagsRequest, SpawnBackend};
+use crate::containment::{ContainMode, ContainRequest, Nesting};
+use crate::error::Error;
+
+fn uncontained() -> ContainRequest {
+    ContainRequest {
+        mode: None,
+        nesting: Nesting::Mark,
+    }
+}
+
+fn contained() -> ContainRequest {
+    ContainRequest {
+        mode: Some(ContainMode::Strongest),
+        nesting: Nesting::Mark,
+    }
+}
+
+fn word(contain: &ContainRequest, flags: FlagsRequest, is_root: bool, backend: SpawnBackend) -> u32 {
+    windows_spawn(contain, flags, is_root, backend)
+        .expect("this request shape is allowed")
+        .creation_flags
+}
+
+fn refusal(flags: FlagsRequest) -> String {
+    match windows_spawn(&uncontained(), flags, false, SpawnBackend::Std) {
+        Ok(w) => panic!("expected a refusal, got the word {:#x}", w.creation_flags),
+        Err(Error::Unsupported { detail, .. }) => detail,
+        Err(other) => panic!("expected Unsupported, got {other:?}"),
+    }
+}
+
+/// A caller's raw word reaches an uncontained spawn untouched. This is also the shape
+/// `prepare`'s `mode.is_none()` early return used to drop entirely.
+#[test]
+fn an_uncontained_std_request_carries_only_the_callers_flags() {
+    let flags = FlagsRequest {
+        raw: IDLE_PRIORITY_CLASS.0,
+        ..Default::default()
+    };
+    assert_eq!(
+        word(&uncontained(), flags, false, SpawnBackend::Std),
+        IDLE_PRIORITY_CLASS.0,
+        "an uncontained std spawn supplies nothing of its own"
+    );
+}
+
+/// The containment decision and the caller's intent are ORed, not chosen between: a `Strongest`
+/// root keeps its suspend and its process group while also getting the caller's suppression.
+#[test]
+fn contained_root_flags_and_caller_flags_compose() {
+    let flags = FlagsRequest {
+        no_window: true,
+        ..Default::default()
+    };
+    assert_eq!(
+        word(&contained(), flags, true, SpawnBackend::Std),
+        CREATE_SUSPENDED.0 | CREATE_NEW_PROCESS_GROUP.0 | CREATE_NO_WINDOW.0,
+    );
+}
+
+/// The two bits the raw `CreateProcessW` backend cannot spawn without are supplied by
+/// `windows_spawn` for that backend and by nothing else, so no backend ORs anything on
+/// afterwards.
+///
+/// **This pins a cosca-side difference only.** Per `library/std/src/sys/process/windows.rs`, std
+/// ORs `CREATE_UNICODE_ENVIRONMENT` into whatever word it was given at spawn time, so this test
+/// does not say the OS receives a `Std` word without it — only that cosca does not supply it.
+#[test]
+fn cosca_supplies_the_structural_bits_only_on_the_raw_backend() {
+    let flags = FlagsRequest {
+        no_window: true,
+        ..Default::default()
+    };
+    let std_word = word(&contained(), flags, true, SpawnBackend::Std);
+    let raw_word = word(&contained(), flags, true, SpawnBackend::Raw);
+    assert_eq!(
+        raw_word ^ std_word,
+        CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0,
+        "the backends differ by exactly the two structural bits",
+    );
+}
+
+/// Both intents are emitted; neither normalizes the other away. Measured: a child with both
+/// behaves as detached, and cosca reports what it asked for rather than second-guessing it.
+#[test]
+fn detached_and_no_window_both_appear() {
+    let flags = FlagsRequest {
+        detached: true,
+        no_window: true,
+        ..Default::default()
+    };
+    let w = word(&uncontained(), flags, false, SpawnBackend::Std);
+    assert_eq!(w, DETACHED_PROCESS.0 | CREATE_NO_WINDOW.0);
+}
+
+/// The breakaway bit is emitted from the request alone, never from a reading of the ambient job:
+/// a probe taken before the spawn could go stale in the gap, and omitting the bit would silently
+/// leave the child in a job the caller asked it to escape. Asserted for both backends and both
+/// root-nesses so no backend can drop it.
+#[test]
+fn a_breakaway_request_always_emits_the_bit() {
+    let flags = FlagsRequest {
+        breakaway_from_job: true,
+        ..Default::default()
+    };
+    for backend in [SpawnBackend::Std, SpawnBackend::Raw] {
+        for is_root in [true, false] {
+            let w = word(&uncontained(), flags, is_root, backend);
+            assert_ne!(
+                w & CREATE_BREAKAWAY_FROM_JOB.0,
+                0,
+                "{backend:?}/is_root={is_root} dropped the breakaway request"
+            );
+        }
+    }
+}
+
+/// An uncontained word does not depend on the root marker at all, which is what licenses
+/// `prepare` composing the word once, above its containment branch.
+#[test]
+fn an_uncontained_word_ignores_is_root() {
+    let flags = FlagsRequest {
+        no_window: true,
+        raw: IDLE_PRIORITY_CLASS.0,
+        ..Default::default()
+    };
+    assert_eq!(
+        word(&uncontained(), flags, true, SpawnBackend::Std),
+        word(&uncontained(), flags, false, SpawnBackend::Std),
+    );
+}
+
+/// Every reserved bit is refused, and the refusal names the bit symbolically — a caller who
+/// passed `0x0800_0000` should not have to look up which flag that was.
+///
+/// The list is written out here rather than read from the production table, so dropping a row
+/// from that table fails this test instead of silently un-reserving a bit.
+#[test]
+fn each_reserved_bit_is_refused_by_name() {
+    let reserved = [
+        (DEBUG_PROCESS.0, "DEBUG_PROCESS"),
+        (DEBUG_ONLY_THIS_PROCESS.0, "DEBUG_ONLY_THIS_PROCESS"),
+        (CREATE_SUSPENDED.0, "CREATE_SUSPENDED"),
+        (DETACHED_PROCESS.0, "DETACHED_PROCESS"),
+        (CREATE_NEW_CONSOLE.0, "CREATE_NEW_CONSOLE"),
+        (CREATE_NEW_PROCESS_GROUP.0, "CREATE_NEW_PROCESS_GROUP"),
+        (CREATE_UNICODE_ENVIRONMENT.0, "CREATE_UNICODE_ENVIRONMENT"),
+        (EXTENDED_STARTUPINFO_PRESENT.0, "EXTENDED_STARTUPINFO_PRESENT"),
+        (CREATE_BREAKAWAY_FROM_JOB.0, "CREATE_BREAKAWAY_FROM_JOB"),
+    ];
+    for (bit, name) in reserved {
+        let detail = refusal(FlagsRequest {
+            raw: bit,
+            ..Default::default()
+        });
+        assert!(detail.contains(name), "refusal for {bit:#x} must name {name}: {detail}");
+    }
+}
+
+/// Two reserved bits at once name both, so a caller fixes one call instead of iterating through
+/// a refusal per bit.
+#[test]
+fn several_reserved_bits_are_all_named() {
+    let detail = refusal(FlagsRequest {
+        raw: CREATE_SUSPENDED.0 | CREATE_NO_WINDOW.0,
+        ..Default::default()
+    });
+    assert!(detail.contains("CREATE_SUSPENDED"), "{detail}");
+    assert!(detail.contains("CREATE_NO_WINDOW"), "{detail}");
+}
+
+/// The two bits the raw backend supplies structurally are themselves reserved, so a caller can
+/// never set one and have it doubled — or clear one the backend cannot spawn without.
+#[test]
+fn the_structural_bits_are_reserved() {
+    for (bit, name) in [
+        (CREATE_UNICODE_ENVIRONMENT.0, "CREATE_UNICODE_ENVIRONMENT"),
+        (EXTENDED_STARTUPINFO_PRESENT.0, "EXTENDED_STARTUPINFO_PRESENT"),
+    ] {
+        let detail = refusal(FlagsRequest {
+            raw: bit,
+            ..Default::default()
+        });
+        assert!(detail.contains(name), "{detail}");
+    }
+}
+
+/// The three containment shapes must not all report the same cooperative-signal mechanism: an
+/// uncontained spawn leads no group, while both contained shapes do. Asserted on the COMPOSED
+/// word, which is the only word any spawn path derives a mechanism from.
+#[test]
+fn the_composed_word_reports_a_different_mechanism_for_each_containment_shape() {
+    use crate::containment::windows::mechanism_from_flags;
+    use crate::graceful::GracefulMechanism;
+
+    let none = FlagsRequest::default();
+    assert_eq!(
+        mechanism_from_flags(word(&uncontained(), none, true, SpawnBackend::Std)),
+        GracefulMechanism::None,
+        "an uncontained spawn passes no group flag, so it leads no group"
+    );
+    assert_eq!(
+        mechanism_from_flags(word(&contained(), none, true, SpawnBackend::Std)),
+        GracefulMechanism::ConsoleGroup,
+        "a Strongest root spawns suspended into its own group"
+    );
+    assert_eq!(
+        mechanism_from_flags(word(&contained(), none, false, SpawnBackend::Std)),
+        GracefulMechanism::ConsoleGroup,
+        "a nested spawn leads its own group too"
+    );
+    assert_eq!(
+        mechanism_from_flags(word(
+            &contained(),
+            FlagsRequest {
+                no_window: true,
+                ..Default::default()
+            },
+            true,
+            SpawnBackend::Std
+        )),
+        GracefulMechanism::OtherConsoleGroup,
+        "window suppression puts the child's group in a console of its own"
+    );
+}

--- a/src/command/flags_tests.rs
+++ b/src/command/flags_tests.rs
@@ -41,8 +41,8 @@ fn refusal(flags: FlagsRequest) -> String {
     }
 }
 
-/// A caller's raw word reaches an uncontained spawn untouched. This is also the shape
-/// `prepare`'s `mode.is_none()` early return used to drop entirely.
+/// A caller's raw word reaches an uncontained spawn untouched — the shape `prepare` composes
+/// the word for above its `mode.is_none()` early return.
 #[test]
 fn an_uncontained_std_request_carries_only_the_callers_flags() {
     let flags = FlagsRequest {
@@ -146,7 +146,8 @@ fn an_uncontained_word_ignores_is_root() {
 /// passed `0x0800_0000` should not have to look up which flag that was.
 ///
 /// The list is written out here rather than read from the production table, so dropping a row
-/// from that table fails this test instead of silently un-reserving a bit.
+/// from that table fails this test instead of silently un-reserving a bit. The length equality
+/// closes the other direction: a row ADDED to that table cannot land uncovered.
 #[test]
 fn each_reserved_bit_is_refused_by_name() {
     let reserved = [
@@ -159,7 +160,13 @@ fn each_reserved_bit_is_refused_by_name() {
         (CREATE_UNICODE_ENVIRONMENT.0, "CREATE_UNICODE_ENVIRONMENT"),
         (EXTENDED_STARTUPINFO_PRESENT.0, "EXTENDED_STARTUPINFO_PRESENT"),
         (CREATE_BREAKAWAY_FROM_JOB.0, "CREATE_BREAKAWAY_FROM_JOB"),
+        (CREATE_NO_WINDOW.0, "CREATE_NO_WINDOW"),
     ];
+    assert_eq!(
+        reserved.len(),
+        super::reserved_table().len(),
+        "mirror every production reserved row here, or the new one ships untested"
+    );
     for (bit, name) in reserved {
         let detail = refusal(FlagsRequest {
             raw: bit,
@@ -268,10 +275,10 @@ fn breakaway_with_containment_is_refused() {
     for is_root in [true, false] {
         let err = windows_spawn(&contained(), breakaway(), is_root, SpawnBackend::Std)
             .expect_err("breakaway plus containment is refused");
-        assert!(
-            matches!(err, Error::Unsupported { .. }),
-            "is_root={is_root}: got {err:?}"
-        );
+        let Error::Unsupported { detail, .. } = &err else {
+            panic!("is_root={is_root}: got {err:?}");
+        };
+        crate::error::assert_detail_is_not_hard_wrapped(detail);
     }
 }
 
@@ -291,6 +298,7 @@ fn a_forbidding_job_turns_access_denied_into_a_typed_containment_error() {
         assert!(detail.contains("JOB_OBJECT_LIMIT_BREAKAWAY_OK"), "{detail}");
         assert!(detail.contains("breakaway_from_job()"), "{detail}");
         assert!(detail.contains("FIRST"), "{detail}");
+        crate::error::assert_detail_is_not_hard_wrapped(&detail);
     }
 }
 
@@ -332,6 +340,29 @@ fn an_unrelated_failure_code_is_never_reclassified() {
         let out = super::classify_spawn_denial(io_err(not_found), breakaway(), job);
         assert!(matches!(out, Error::Io(_)), "{job:?}: got {out:?}");
     }
+}
+
+/// The classifier's opening `let-else` returns every non-`Io` error unchanged, in the one
+/// configuration that would otherwise rewrite it — a breakaway request plus a forbidding job. A
+/// broadening of that pattern would reclassify one error kind as another in silence.
+#[test]
+fn a_non_io_error_is_returned_unchanged() {
+    let out = super::classify_spawn_denial(
+        Error::Unsupported {
+            op: "some op".into(),
+            platform: "windows",
+            detail: "some detail".into(),
+        },
+        breakaway(),
+        JobBreakaway::Forbidden,
+    );
+    let Error::Unsupported { op, platform, detail } = &out else {
+        panic!("a non-Io error must pass through unchanged, got {out:?}");
+    };
+    assert_eq!(
+        (op.as_str(), *platform, detail.as_str()),
+        ("some op", "windows", "some detail")
+    );
 }
 
 /// The other half: an access-denied spawn with NO breakaway request is never blamed on a job.

--- a/src/command_tests.rs
+++ b/src/command_tests.rs
@@ -257,3 +257,48 @@ fn suppress_fd_marker_sets_the_flag_a_fresh_command_does_not_have() {
     derived.suppress_fd_marker();
     assert!(derived.fd_marker_suppressed());
 }
+
+// ===== creation flags =====
+
+/// `no_window()` is the one portable flag intent: it records the same request on every platform,
+/// and only the lowering differs (a creation flag / a show-command / nothing at all).
+#[test]
+fn no_window_is_recorded_on_every_platform() {
+    let mut cmd = Command::new();
+    assert!(!cmd.flags_request().no_window, "the default requests nothing");
+    cmd.no_window();
+    assert!(cmd.flags_request().no_window);
+}
+
+#[cfg(windows)]
+#[test]
+fn detached_and_raw_flags_are_recorded() {
+    let mut cmd = Command::new();
+    let before = *cmd.flags_request();
+    assert!(!before.detached);
+    assert_eq!(before.raw, 0);
+    cmd.detached().creation_flags(0x0000_0040);
+    let after = *cmd.flags_request();
+    assert!(after.detached);
+    assert_eq!(after.raw, 0x0000_0040);
+}
+
+/// `creation_flags` REPLACES, matching `std::os::windows::process::CommandExt::creation_flags`
+/// (`self.flags = flags;`). Or-in would make a bit unclearable, which is the one thing a raw
+/// hatch must never do — so `creation_flags(0)` is the documented way to clear a word set
+/// earlier, and this test would fail under an or-in implementation at both later calls.
+#[cfg(windows)]
+#[test]
+fn repeated_creation_flags_calls_replace_rather_than_accumulate() {
+    let mut cmd = Command::new();
+    cmd.creation_flags(0x0000_0040);
+    assert_eq!(cmd.flags_request().raw, 0x0000_0040);
+    cmd.creation_flags(0x0000_0080);
+    assert_eq!(
+        cmd.flags_request().raw,
+        0x0000_0080,
+        "the second call replaces the first"
+    );
+    cmd.creation_flags(0);
+    assert_eq!(cmd.flags_request().raw, 0, "zero clears a word set earlier");
+}

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -350,9 +350,9 @@ pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> Wind
 /// Windows can honour.
 ///
 /// Fallible only on Windows, where the composed creation-flag word may name a reserved bit. The
-/// composition runs at the very top, before anything is mutated, so a refusal leaves nothing to
-/// unwind — and above the uncontained early return, which is what used to drop a caller's flags
-/// on an uncontained spawn.
+/// composition runs at the very top — before anything is mutated, so a refusal leaves nothing to
+/// unwind, and above the uncontained early return, so an uncontained spawn carries the caller's
+/// flags too.
 pub(crate) fn prepare(
     std_cmd: &mut std::process::Command,
     req: &ContainRequest,
@@ -483,10 +483,9 @@ pub(crate) fn prepare(
         None
     };
 
-    // Windows: stop the child inheriting this process's std handles. Gated on containment
-    // exactly as before, and below the composition above so a refused spawn has mutated nothing.
-    // The creation-flag word itself is applied at the top, since an uncontained spawn never
-    // reaches this point.
+    // Windows: stop the child inheriting this process's std handles. Contained spawns only, and
+    // below the composition above so a refused spawn has mutated nothing. The creation-flag word
+    // itself is applied at the top, since an uncontained spawn never reaches this point.
     #[cfg(windows)]
     crate::containment::windows::clear_std_handle_inheritance();
 

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -317,8 +317,6 @@ pub(crate) struct WindowsContain {
     pub creation_flags: u32,
     /// Whether this spawn must set the inherited root marker so descendants join THIS group.
     pub marker_env: bool,
-    /// The cooperative-signal mechanism `creation_flags` implies, derived from that same word.
-    pub graceful: crate::graceful::GracefulMechanism,
 }
 
 /// Decide the Windows pre-spawn containment flags + marker for `req`/`is_root`. Pure — directly
@@ -329,7 +327,6 @@ pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> Wind
         return WindowsContain {
             creation_flags: 0,
             marker_env: false,
-            graceful: crate::containment::windows::mechanism_from_flags(0),
         };
     };
     let creation_flags = if is_root && !matches!(mode, ContainMode::TreeWalk) {
@@ -343,36 +340,58 @@ pub(crate) fn windows_contain_setup(req: &ContainRequest, is_root: bool) -> Wind
     WindowsContain {
         creation_flags,
         marker_env: is_root && req.nesting == Nesting::Mark,
-        graceful: crate::containment::windows::mechanism_from_flags(creation_flags),
     }
 }
 
 /// Phase 1 (before spawn): env-marker root detection + pre-spawn OS setup.
 ///
 /// `reserved_fds` and `marker_suppressed` drive the macOS fd-marker install only; every
-/// other platform ignores them.
+/// other platform ignores them. `flags` is the caller's creation-flag request, which only
+/// Windows can honour.
+///
+/// Fallible only on Windows, where the composed creation-flag word may name a reserved bit. The
+/// composition runs at the very top, before anything is mutated, so a refusal leaves nothing to
+/// unwind — and above the uncontained early return, which is what used to drop a caller's flags
+/// on an uncontained spawn.
 pub(crate) fn prepare(
     std_cmd: &mut std::process::Command,
     req: &ContainRequest,
+    #[cfg_attr(not(windows), allow(unused_variables))] flags: &crate::command::flags::FlagsRequest,
     #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] reserved_fds: &[i32],
     #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] marker_suppressed: bool,
-) -> Prepared {
+) -> Result<Prepared, Error> {
     let mode = req.mode;
+    // Read once, above every branch, so the word is composed exactly once per spawn and no two
+    // compositions can disagree. This is this process's own environment variable — read-only and
+    // constant for the run — so reading it for an uncontained spawn too is unobservable.
+    let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
+    let is_root = !is_nested(marker_present);
+
+    #[cfg(windows)]
+    let graceful = {
+        use std::os::windows::process::CommandExt;
+        let spawn =
+            crate::command::flags::windows_spawn(req, *flags, is_root, crate::command::flags::SpawnBackend::Std)?;
+        std_cmd.creation_flags(spawn.creation_flags);
+        // Sound for THIS derivation and no other: `mechanism_from_flags` reads only
+        // CREATE_NEW_PROCESS_GROUP / DETACHED_PROCESS / CREATE_NEW_CONSOLE / CREATE_NO_WINDOW,
+        // and std adds and removes none of them. The word is what cosca supplies, never what
+        // `CreateProcessW` receives — see `crate::command::flags`.
+        crate::containment::windows::mechanism_from_flags(spawn.creation_flags)
+    };
+
     if mode.is_none() {
-        return Prepared {
+        return Ok(Prepared {
             mode: None,
             is_root: false,
             #[cfg(target_os = "linux")]
             cgroup_leaf: None,
             #[cfg(target_os = "macos")]
             marker: None,
-            // An uncontained spawn passes no creation flags, so it leads no group of its own.
             #[cfg(windows)]
-            graceful: crate::containment::windows::mechanism_from_flags(0),
-        };
+            graceful,
+        });
     }
-    let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
-    let is_root = !is_nested(marker_present);
     if is_root && req.nesting == Nesting::Mark {
         // Set AFTER any user env ops (env_clear) have been applied to std_cmd by
         // the spawn engine, so the marker survives env_clear. `env` appends.
@@ -389,20 +408,20 @@ pub(crate) fn prepare(
                 UnixSetup::Session => {
                     // Session: setsid only — no process_group(0) (would EPERM).
                     crate::containment::unix::set_session(std_cmd);
-                    return Prepared {
+                    return Ok(Prepared {
                         mode,
                         is_root,
                         cgroup_leaf: None, // cgroup not used for Session
-                    };
+                    });
                 }
                 UnixSetup::None => {
                     // TreeWalk: NO process group / setsid / cgroup — teardown is
                     // by identity so we can catch process-group escapees.
-                    return Prepared {
+                    return Ok(Prepared {
                         mode,
                         is_root,
                         cgroup_leaf: None,
-                    };
+                    });
                 }
                 UnixSetup::ProcessGroup => {
                     // Strongest: set a new process group + try cgroup.
@@ -428,17 +447,17 @@ pub(crate) fn prepare(
                     });
                 }
             }
-            return Prepared {
+            return Ok(Prepared {
                 mode,
                 is_root,
                 cgroup_leaf: leaf,
-            };
+            });
         }
-        return Prepared {
+        return Ok(Prepared {
             mode,
             is_root,
             cgroup_leaf: None,
-        };
+        });
     }
 
     // Non-Linux Unix: process group or session (mutually exclusive).
@@ -464,21 +483,15 @@ pub(crate) fn prepare(
         None
     };
 
-    // Windows: clear handle inheritance + apply creation_flags. The flag/marker decision
-    // lives in `windows_contain_setup` (shared with the raw `CreateProcessW` backend); the
-    // root marker itself is applied above (shared with the Unix path), so only the creation
-    // flags are applied here.
+    // Windows: stop the child inheriting this process's std handles. Gated on containment
+    // exactly as before, and below the composition above so a refused spawn has mutated nothing.
+    // The creation-flag word itself is applied at the top, since an uncontained spawn never
+    // reaches this point.
     #[cfg(windows)]
-    let graceful = {
-        use std::os::windows::process::CommandExt;
-        crate::containment::windows::clear_std_handle_inheritance();
-        let setup = windows_contain_setup(req, is_root);
-        std_cmd.creation_flags(setup.creation_flags);
-        setup.graceful
-    };
+    crate::containment::windows::clear_std_handle_inheritance();
 
     #[allow(unreachable_code)]
-    Prepared {
+    Ok(Prepared {
         mode,
         is_root,
         #[cfg(target_os = "linux")]
@@ -487,7 +500,7 @@ pub(crate) fn prepare(
         marker,
         #[cfg(windows)]
         graceful,
-    }
+    })
 }
 
 /// Phase 2 (after spawn, before SharedChild::new): attach the mechanism and bundle it with the

--- a/src/containment/dispatch_tests.rs
+++ b/src/containment/dispatch_tests.rs
@@ -318,9 +318,11 @@ fn prepare_places_the_marker_above_the_callers_reserved_fds() {
             mode: Some(ContainMode::Strongest),
             nesting: Nesting::Mark,
         },
+        &crate::command::flags::FlagsRequest::default(),
         &[3, 4, 5, 6, 7, 8, 9, 10],
         false,
-    );
+    )
+    .expect("prepare is infallible off Windows");
     let marker = prepared.marker.as_ref().expect("a contained macOS root gets a marker");
     assert!(
         marker.fd > 10,
@@ -349,9 +351,11 @@ fn a_failed_marker_install_leaves_prepare_without_one() {
             mode: Some(ContainMode::Strongest),
             nesting: Nesting::Mark,
         },
+        &crate::command::flags::FlagsRequest::default(),
         &[],
         false,
-    );
+    )
+    .expect("prepare is infallible off Windows");
     assert!(prepared.marker.is_none(), "the forced failure must yield no marker");
 }
 
@@ -367,9 +371,11 @@ fn prepare_installs_no_marker_for_an_elevation_derived_spawn() {
             mode: Some(ContainMode::Strongest),
             nesting: Nesting::Mark,
         },
+        &crate::command::flags::FlagsRequest::default(),
         &[],
         true,
-    );
+    )
+    .expect("prepare is infallible off Windows");
     assert!(
         prepared.marker.is_none(),
         "an elevated spawn must not claim marker containment"
@@ -459,41 +465,6 @@ fn wait_drained_reports_members_remain_then_all_markers_closed() {
             .wait_drained(None)
             .expect("unbounded wait after the holder exits"),
         TreeDrain::AllMarkersClosed
-    );
-}
-
-/// The three shapes `windows_contain_setup` can produce must not all agree: an uncontained
-/// spawn leads no group, while both contained shapes do. Lives here rather than in
-/// `windows_tests.rs` because `windows_contain_setup` is defined in this module.
-#[cfg(windows)]
-#[test]
-fn windows_contain_setup_records_the_mechanism_of_the_flags_it_chose() {
-    use super::windows_contain_setup;
-    use crate::containment::{ContainMode, ContainRequest, Nesting};
-    use crate::graceful::GracefulMechanism;
-
-    let uncontained = ContainRequest {
-        mode: None,
-        nesting: Nesting::Mark,
-    };
-    let contained = ContainRequest {
-        mode: Some(ContainMode::Strongest),
-        nesting: Nesting::Mark,
-    };
-    assert_eq!(
-        windows_contain_setup(&uncontained, true).graceful,
-        GracefulMechanism::None,
-        "an uncontained spawn passes no flags, so it leads no group"
-    );
-    assert_eq!(
-        windows_contain_setup(&contained, true).graceful,
-        GracefulMechanism::ConsoleGroup,
-        "a Strongest root spawns suspended into its own group"
-    );
-    assert_eq!(
-        windows_contain_setup(&contained, false).graceful,
-        GracefulMechanism::ConsoleGroup,
-        "a nested spawn leads its own group too"
     );
 }
 

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -210,6 +210,8 @@ pub(crate) fn mechanism_from_flags(creation_flags: u32) -> crate::graceful::Grac
 /// Clear the inherit flag on the parent's std handles before spawning. Prevents
 /// the child from inheriting the test runner's console handles. Best-effort.
 pub(crate) fn clear_std_handle_inheritance() {
+    #[cfg(test)]
+    observe::record_inheritance_cleared();
     for std_handle in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
         // SAFETY: standard Win32 call; handle is not closed.
         unsafe {
@@ -371,6 +373,26 @@ pub(crate) fn terminate(pid: u32) -> Result<(), crate::error::Error> {
             io::Error::from(e),
             caller_has_console(),
         )),
+    }
+}
+
+/// Test-only: record that `clear_std_handle_inheritance` ran on THIS thread, so a test can prove
+/// a refused spawn did not mutate this process first. Take semantics, mirroring `fault`.
+///
+/// The real handle flags cannot serve as the observation: the mutation is process-global and
+/// permanent, so any earlier contained spawn in the same test binary would already have made it
+/// meaningless.
+#[cfg(test)]
+pub(crate) mod observe {
+    use std::cell::Cell;
+    thread_local! {
+        static INHERITANCE_CLEARED: Cell<bool> = const { Cell::new(false) };
+    }
+    pub(crate) fn record_inheritance_cleared() {
+        INHERITANCE_CLEARED.with(|f| f.set(true));
+    }
+    pub(crate) fn take_inheritance_cleared() -> bool {
+        INHERITANCE_CLEARED.with(|f| f.replace(false))
     }
 }
 

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -318,6 +318,78 @@ pub(crate) fn classify_ctrl_event_failure(pid: u32, err: io::Error, console: io:
     crate::error::Error::Io(err)
 }
 
+/// What this process's ambient job object says about a child breaking away from it.
+///
+/// `Unknown` exists for the same reason `identity::Resolved::Unknown` does: cosca must not assert
+/// a cause it could not measure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JobBreakaway {
+    NotInJob,
+    Permitted,
+    /// The job removes new children itself, without them asking — so it does not FORBID
+    /// breakaway, and a message saying it does would be wrong about the world.
+    SilentBreakaway,
+    Forbidden,
+    Unknown,
+}
+
+/// Read this process's ambient job's breakaway limits.
+///
+/// Impure, and called only to CLASSIFY a spawn failure that already happened — never to gate one
+/// before it. Spawning does not disturb job membership, but membership changes on its own (a
+/// process can be assigned to a job at any moment), so a pre-spawn guard would decide the outcome
+/// from state that may already be stale, while a post-failure confirmation at worst withholds a
+/// typed error. Same impure-probe / pure-classifier split as `caller_has_console` /
+/// `classify_ctrl_event_failure`.
+///
+/// `Permitted` takes precedence over `SilentBreakaway`, because a job setting both does honour
+/// the flag.
+pub(crate) fn probe_job_breakaway() -> JobBreakaway {
+    use windows::Win32::System::JobObjects::{
+        IsProcessInJob, JobObjectBasicLimitInformation, QueryInformationJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT, JOB_OBJECT_LIMIT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,
+    };
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    #[cfg(test)]
+    if fault::take_force_job_probe_error() {
+        return JobBreakaway::Unknown;
+    }
+
+    let mut in_job = windows::core::BOOL(0);
+    // SAFETY: standard Win32; `in_job` is a valid out-param, and `None` asks "in ANY job".
+    if unsafe { IsProcessInJob(GetCurrentProcess(), None, &mut in_job) }.is_err() {
+        return JobBreakaway::Unknown;
+    }
+    if !in_job.as_bool() {
+        return JobBreakaway::NotInJob;
+    }
+
+    let mut info = JOBOBJECT_BASIC_LIMIT_INFORMATION::default();
+    // SAFETY: standard Win32; `info` is a valid, correctly-sized out-param, and `None` asks about
+    // the calling process's own job. The query class returns the BASIC structure even though the
+    // matching setter needs the extended one — an asymmetry in the API, not a mistake here.
+    let queried = unsafe {
+        QueryInformationJobObject(
+            None,
+            JobObjectBasicLimitInformation,
+            std::ptr::addr_of_mut!(info).cast(),
+            size_of::<JOBOBJECT_BASIC_LIMIT_INFORMATION>() as u32,
+            None,
+        )
+    };
+    if queried.is_err() {
+        return JobBreakaway::Unknown;
+    }
+    if info.LimitFlags & JOB_OBJECT_LIMIT_BREAKAWAY_OK != JOB_OBJECT_LIMIT(0) {
+        return JobBreakaway::Permitted;
+    }
+    if info.LimitFlags & JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK != JOB_OBJECT_LIMIT(0) {
+        return JobBreakaway::SilentBreakaway;
+    }
+    JobBreakaway::Forbidden
+}
+
 /// Send `CTRL_BREAK_EVENT` to the process group rooted at `pid`.
 /// The child was spawned with `CREATE_NEW_PROCESS_GROUP`, making it the leader;
 /// targeting its `pid` reaches the whole group without affecting the parent's console.
@@ -407,6 +479,17 @@ pub(crate) mod fault {
     }
     pub(crate) fn set_force_console_probe_error(on: bool) {
         FORCE_CONSOLE_PROBE_ERROR.with(|f| f.set(on));
+    }
+    thread_local! {
+        static FORCE_JOB_PROBE_ERROR: Cell<bool> = const { Cell::new(false) };
+    }
+    /// Force the NEXT `probe_job_breakaway` on THIS thread to report `Unknown`: neither Win32
+    /// call it makes can be made to fail on a live system.
+    pub(crate) fn set_force_job_probe_error(on: bool) {
+        FORCE_JOB_PROBE_ERROR.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_job_probe_error() -> bool {
+        FORCE_JOB_PROBE_ERROR.with(|f| f.replace(false))
     }
     pub(crate) fn take_force_console_probe_error() -> bool {
         FORCE_CONSOLE_PROBE_ERROR.with(|f| f.replace(false))

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -259,3 +259,55 @@ mod mechanism_from_flags_tests {
         assert_eq!(mechanism_from_flags(CREATE_NO_WINDOW.0), GracefulMechanism::None);
     }
 }
+
+// ===== job breakaway probe =====
+
+/// The `Unknown` arm exists so cosca never asserts a cause it could not measure. Neither Win32
+/// call in the probe can be made to fail on a live system, so the seam is the only route to that
+/// arm's production — and without the seam the probe reports a real verdict, which is what makes
+/// this assertion about the arm rather than about the constant.
+#[test]
+fn probe_reports_unknown_when_the_query_fails() {
+    use crate::containment::windows::{fault, probe_job_breakaway, JobBreakaway};
+    assert_ne!(
+        probe_job_breakaway(),
+        JobBreakaway::Unknown,
+        "unarmed, the probe must reach a real verdict"
+    );
+    fault::set_force_job_probe_error(true);
+    assert_eq!(probe_job_breakaway(), JobBreakaway::Unknown);
+    assert_ne!(
+        probe_job_breakaway(),
+        JobBreakaway::Unknown,
+        "take semantics: the fault applies to exactly one call"
+    );
+}
+
+/// A RELATIONSHIP, never an absolute: whether CI runs test processes inside a job object is not
+/// ours to control. It fails if the probe's first branch is inverted, which is the bug that would
+/// make every ambient job read as "no job" and silently disable the typed containment error.
+#[test]
+fn probe_agrees_with_an_independent_is_process_in_job_measurement() {
+    use crate::containment::windows::{probe_job_breakaway, JobBreakaway};
+    use windows::Win32::System::JobObjects::IsProcessInJob;
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    let mut in_job = windows::core::BOOL(0);
+    // SAFETY: standard Win32; `in_job` is a valid out-param and `None` asks "in ANY job".
+    unsafe { IsProcessInJob(GetCurrentProcess(), None, &mut in_job) }.expect("IsProcessInJob");
+
+    let verdict = probe_job_breakaway();
+    if in_job.as_bool() {
+        assert_ne!(
+            verdict,
+            JobBreakaway::NotInJob,
+            "this process IS in a job, so the probe must not report otherwise"
+        );
+    } else {
+        assert_eq!(
+            verdict,
+            JobBreakaway::NotInJob,
+            "this process is in no job, so the probe must say so"
+        );
+    }
+}

--- a/src/elevation/windows.rs
+++ b/src/elevation/windows.rs
@@ -151,7 +151,54 @@ pub(crate) fn reject_unsupported_config(cmd: &Command) -> Result<(), Error> {
             "a Job Object cannot span the integrity boundary of a runas child (deferred)",
         );
     }
+    // `ShellExecuteEx` accepts no creation flags at all, so every flag intent except window
+    // suppression has no mechanism here and is refused rather than silently dropped. Stated over
+    // the RECORDED state, not "a method was called": `creation_flags(0)` requests nothing.
+    let flags = cmd.flags_request();
+    if flags.detached {
+        return unsupported(
+            "detached() + elevate on Windows",
+            "the runas launch takes a show-command and no creation flags, so DETACHED_PROCESS              cannot be expressed. Elevate without it, or spawn unelevated.",
+        );
+    }
+    if flags.breakaway_from_job {
+        return unsupported(
+            "breakaway_from_job() + elevate on Windows",
+            "the runas launch takes a show-command and no creation flags, so              CREATE_BREAKAWAY_FROM_JOB cannot be expressed — and the runas child is created by a              system service, not by this process's job.",
+        );
+    }
+    if flags.raw != 0 {
+        return unsupported(
+            "creation_flags() + elevate on Windows",
+            "the runas launch takes a show-command and no creation flags, so an arbitrary              dwCreationFlags word cannot be expressed. no_window() is the one flag intent that              survives here, lowered to the launch's show-command.",
+        );
+    }
     Ok(())
+}
+
+/// The show-command the consent launch uses, from the caller's flag request.
+///
+/// Pure, so the selection is unit-testable without a UAC prompt.
+///
+/// **Reached only when a consent prompt is actually used.** `runas` returns
+/// `Transition::RunAsIs => RunasOutcome::AlreadyElevated` before it builds the
+/// `SHELLEXECUTEINFOW`, and `spawn_elevated`'s `AlreadyElevated` arm falls through to
+/// `spawn_unelevated` — so an already-elevated caller's `.elevate().no_window()` is carried by
+/// `CREATE_NO_WINDOW` on the ordinary backends and never touches this function.
+///
+/// The two lowerings differ observably for a graphical child: the show-command is the shell's
+/// initial show state for the whole launched application, where the creation flag concerns the
+/// child's console only.
+#[cfg(windows)]
+pub(crate) fn runas_show_command(
+    flags: &crate::command::flags::FlagsRequest,
+) -> windows::Win32::UI::WindowsAndMessaging::SHOW_WINDOW_CMD {
+    use windows::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_SHOWNORMAL};
+    if flags.no_window {
+        SW_HIDE
+    } else {
+        SW_SHOWNORMAL
+    }
 }
 
 // ===== ShellExecuteEx("runas") launch =====
@@ -166,7 +213,6 @@ use windows::Win32::Foundation::{RPC_E_CHANGED_MODE, S_FALSE, S_OK};
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
 use windows::Win32::System::Threading::{GetProcessId, TerminateProcess};
 use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
-use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
 use crate::child::proc_handle::ProcHandle;
 use crate::child::spawn::windows_raw::RawChild;
@@ -304,7 +350,7 @@ pub(crate) fn launch_runas_with_host(cmd: &mut Command, host: &Host) -> Result<R
             lpFile: PCWSTR(file_w.as_ptr()),
             lpParameters: PCWSTR(params_w.as_ptr()),
             lpDirectory: dir.as_ref().map_or(PCWSTR::null(), |d| PCWSTR(d.as_ptr())),
-            nShow: SW_SHOWNORMAL.0,
+            nShow: runas_show_command(cmd.flags_request()).0,
             ..Default::default()
         };
         ShellExecuteExW(&mut info).map_err(|e| {

--- a/src/elevation/windows.rs
+++ b/src/elevation/windows.rs
@@ -158,19 +158,24 @@ pub(crate) fn reject_unsupported_config(cmd: &Command) -> Result<(), Error> {
     if flags.detached {
         return unsupported(
             "detached() + elevate on Windows",
-            "the runas launch takes a show-command and no creation flags, so DETACHED_PROCESS              cannot be expressed. Elevate without it, or spawn unelevated.",
+            "the runas launch takes a show-command and no creation flags, so DETACHED_PROCESS \
+             cannot be expressed. Elevate without it, or spawn unelevated.",
         );
     }
     if flags.breakaway_from_job {
         return unsupported(
             "breakaway_from_job() + elevate on Windows",
-            "the runas launch takes a show-command and no creation flags, so              CREATE_BREAKAWAY_FROM_JOB cannot be expressed — and the runas child is created by a              system service, not by this process's job.",
+            "the runas launch takes a show-command and no creation flags, so \
+             CREATE_BREAKAWAY_FROM_JOB cannot be expressed — and the runas child is created by a \
+             system service, not by this process's job.",
         );
     }
     if flags.raw != 0 {
         return unsupported(
             "creation_flags() + elevate on Windows",
-            "the runas launch takes a show-command and no creation flags, so an arbitrary              dwCreationFlags word cannot be expressed. no_window() is the one flag intent that              survives here, lowered to the launch's show-command.",
+            "the runas launch takes a show-command and no creation flags, so an arbitrary \
+             dwCreationFlags word cannot be expressed. no_window() is the one flag intent that \
+             survives here, lowered to the launch's show-command.",
         );
     }
     Ok(())

--- a/src/elevation/windows_tests.rs
+++ b/src/elevation/windows_tests.rs
@@ -134,3 +134,67 @@ fn already_elevated_inherit_only_is_run_as_is() {
         Ok(super::RunasOutcome::AlreadyElevated)
     ));
 }
+
+// ===== creation-flag intents on the consent-prompt path =====
+
+/// `ShellExecuteEx` takes a show-command and no creation-flag word, so this is the only knob the
+/// consent launch has for the window-suppression intent. Two inputs, two values: a constant
+/// implementation fails one of the pair.
+#[test]
+fn runas_hides_the_window_when_no_window_is_requested() {
+    use crate::command::flags::FlagsRequest;
+    use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
+    let flags = FlagsRequest {
+        no_window: true,
+        ..Default::default()
+    };
+    assert_eq!(super::runas_show_command(&flags), SW_HIDE);
+}
+
+#[test]
+fn runas_shows_the_window_by_default() {
+    use crate::command::flags::FlagsRequest;
+    use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+    assert_eq!(super::runas_show_command(&FlagsRequest::default()), SW_SHOWNORMAL);
+}
+
+/// The consent launch accepts no creation flags at all, so a raw word is refused rather than
+/// silently dropped. Stated over the RECORDED state, not "a method was called": `creation_flags(0)`
+/// requests nothing, so there is nothing to refuse.
+#[test]
+fn elevation_rejects_raw_creation_flags() {
+    let mut c = Command::new();
+    c.args(["whoami"]).elevate().creation_flags(0x0000_0040);
+    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+}
+
+#[test]
+fn elevation_accepts_a_zero_creation_flags_word() {
+    let mut c = Command::new();
+    c.args(["whoami"]).elevate().creation_flags(0);
+    assert!(super::reject_unsupported_config(&c).is_ok());
+}
+
+#[test]
+fn elevation_rejects_detached() {
+    let mut c = Command::new();
+    c.args(["whoami"]).elevate().detached();
+    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+}
+
+#[test]
+fn elevation_rejects_breakaway() {
+    let mut c = Command::new();
+    c.args(["whoami"]).elevate().breakaway_from_job();
+    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+}
+
+/// The one flag intent that survives the gate — which is the whole of the elevated half of the
+/// window-suppression feature. Without this leg, a future tightening could take it away again in
+/// silence, and the three rejections above would all still pass.
+#[test]
+fn elevation_accepts_no_window() {
+    let mut c = Command::new();
+    c.args(["whoami"]).elevate().no_window();
+    assert!(super::reject_unsupported_config(&c).is_ok());
+}

--- a/src/elevation/windows_tests.rs
+++ b/src/elevation/windows_tests.rs
@@ -38,6 +38,14 @@ fn is_unsupported<T>(r: Result<T, Error>) -> bool {
     matches!(r, Err(Error::Unsupported { .. }))
 }
 
+/// The refusal's `detail`, for the tests that assert on the message and not only the variant.
+fn unsupported_detail<T: std::fmt::Debug>(r: Result<T, Error>) -> String {
+    match r {
+        Err(Error::Unsupported { detail, .. }) => detail,
+        other => panic!("expected Unsupported, got {other:?}"),
+    }
+}
+
 #[test]
 fn piped_stdio_is_unsupported() {
     let mut c = Command::new();
@@ -165,7 +173,8 @@ fn runas_shows_the_window_by_default() {
 fn elevation_rejects_raw_creation_flags() {
     let mut c = Command::new();
     c.args(["whoami"]).elevate().creation_flags(0x0000_0040);
-    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+    let detail = unsupported_detail(super::reject_unsupported_config(&c));
+    crate::error::assert_detail_is_not_hard_wrapped(&detail);
 }
 
 #[test]
@@ -179,14 +188,16 @@ fn elevation_accepts_a_zero_creation_flags_word() {
 fn elevation_rejects_detached() {
     let mut c = Command::new();
     c.args(["whoami"]).elevate().detached();
-    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+    let detail = unsupported_detail(super::reject_unsupported_config(&c));
+    crate::error::assert_detail_is_not_hard_wrapped(&detail);
 }
 
 #[test]
 fn elevation_rejects_breakaway() {
     let mut c = Command::new();
     c.args(["whoami"]).elevate().breakaway_from_job();
-    assert!(is_unsupported(super::reject_unsupported_config(&c)));
+    let detail = unsupported_detail(super::reject_unsupported_config(&c));
+    crate::error::assert_detail_is_not_hard_wrapped(&detail);
 }
 
 /// The one flag intent that survives the gate — which is the whole of the elevated half of the

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,6 +166,19 @@ pub enum Error {
     },
 }
 
+/// Test-only: assert a user-facing `detail` carries no run of two or more spaces.
+///
+/// A hard-wrapped string literal that loses its `\` line-continuation bakes the source
+/// indentation into the value, and both a variant match and a substring check read right past
+/// it. This is the one assertion that sees it.
+#[cfg(test)]
+pub(crate) fn assert_detail_is_not_hard_wrapped(detail: &str) {
+    assert!(
+        !detail.contains("  "),
+        "a run of two or more spaces means a hard-wrapped literal lost its `\\` continuation: {detail:?}"
+    );
+}
+
 #[cfg(test)]
 #[path = "error_tests.rs"]
 mod error_tests;

--- a/src/error.rs
+++ b/src/error.rs
@@ -171,7 +171,9 @@ pub enum Error {
 /// A hard-wrapped string literal that loses its `\` line-continuation bakes the source
 /// indentation into the value, and both a variant match and a substring check read right past
 /// it. This is the one assertion that sees it.
-#[cfg(test)]
+// Windows-gated with its callers: every refusal detail it guards is behind `cfg(windows)`, so
+// off Windows it would be a `pub(crate)` item with no caller, which `-D warnings` rejects.
+#[cfg(all(test, windows))]
 pub(crate) fn assert_detail_is_not_hard_wrapped(detail: &str) {
     assert!(
         !detail.contains("  "),

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -443,7 +443,16 @@ impl Child {
     /// child that owns a console can politely signal its own group-leading children.
     ///
     /// **And success here does not prove the event was delivered.** A root that shares no
-    /// console with the caller is reported as success and reaches nobody.
+    /// console with the caller is reported as success and reaches nobody — including a root
+    /// spawned with [`no_window`](crate::Command::no_window) or
+    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
+    /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
+    /// the *route* from this process, never an authority on whether a signal will arrive. It is
+    /// also not "this child cannot be shut down politely" — a process attached to the child's own
+    /// console can deliver the event. The cooperative op returns `Ok` and delivers nothing; the
+    /// forced ops ([`kill`](Child::kill) / [`kill_tree`](Child::kill_tree), and the escalation
+    /// half of [`graceful_shutdown_tree`](Child::graceful_shutdown_tree)) are unaffected.
     ///
     /// **And it needs the caller to have a console.** The event is deliverable only within
     /// the *calling* process's console, so a GUI-subsystem binary, a service, or anything

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -445,7 +445,7 @@ impl Child {
     /// **And success here does not prove the event was delivered.** A root that shares no
     /// console with the caller is reported as success and reaches nobody — including a root
     /// spawned with [`no_window`](crate::Command::no_window) or
-    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// `detached()`, which gets a console of its own. Such a root is
     /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
     /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
     /// the *route* from this process, never an authority on whether a signal will arrive. It is

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -177,7 +177,7 @@ impl Child {
     /// **And success here does not prove the event was delivered.** A root that shares no
     /// console with the caller is reported as success and reaches nobody — including a root
     /// spawned with [`no_window`](crate::Command::no_window) or
-    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// `detached()`, which gets a console of its own. Such a root is
     /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
     /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
     /// the *route* from this process, never an authority on whether a signal will arrive. It is

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -175,7 +175,16 @@ impl Child {
     /// child that owns a console can politely signal its own group-leading children.
     ///
     /// **And success here does not prove the event was delivered.** A root that shares no
-    /// console with the caller is reported as success and reaches nobody.
+    /// console with the caller is reported as success and reaches nobody — including a root
+    /// spawned with [`no_window`](crate::Command::no_window) or
+    /// [`detached`](crate::Command::detached), which gets a console of its own. Such a root is
+    /// reported as [`GracefulMechanism::OtherConsoleGroup`](crate::GracefulMechanism::OtherConsoleGroup)
+    /// by [`graceful_mechanism`](Child::graceful_mechanism): that is what cosca recorded about
+    /// the *route* from this process, never an authority on whether a signal will arrive. It is
+    /// also not "this child cannot be shut down politely" — a process attached to the child's own
+    /// console can deliver the event. The cooperative op returns `Ok` and delivers nothing; the
+    /// forced ops ([`kill`](Child::kill) / [`kill_tree`](Child::kill_tree), and the escalation
+    /// half of [`graceful_shutdown_tree`](Child::graceful_shutdown_tree)) are unaffected.
     ///
     /// **The caller must also have a console.** The event is deliverable only within the
     /// *calling* process's console, so a GUI-subsystem binary, a service, or anything spawned

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -125,6 +125,15 @@ impl Command {
         self
     }
 
+    /// Spawn outside this process's job object — mirrors
+    /// [`breakaway_from_job`](crate::Command::breakaway_from_job), including everything it does
+    /// not promise.
+    #[cfg(windows)]
+    pub fn breakaway_from_job(&mut self) -> &mut Command {
+        self.inner.breakaway_from_job();
+        self
+    }
+
     /// Add arbitrary `dwCreationFlags` bits — mirrors
     /// [`creation_flags`](crate::Command::creation_flags), including its reserved-bit table and
     /// its replace-not-accumulate semantics.

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -110,6 +110,30 @@ impl Command {
         self
     }
 
+    /// Do not put a console window on the user's screen — mirrors
+    /// [`no_window`](crate::Command::no_window), including the per-path lowering and the
+    /// one-directional console consequence documented there.
+    pub fn no_window(&mut self) -> &mut Command {
+        self.inner.no_window();
+        self
+    }
+
+    /// Spawn with `DETACHED_PROCESS` — mirrors [`detached`](crate::Command::detached).
+    #[cfg(windows)]
+    pub fn detached(&mut self) -> &mut Command {
+        self.inner.detached();
+        self
+    }
+
+    /// Add arbitrary `dwCreationFlags` bits — mirrors
+    /// [`creation_flags`](crate::Command::creation_flags), including its reserved-bit table and
+    /// its replace-not-accumulate semantics.
+    #[cfg(windows)]
+    pub fn creation_flags(&mut self, flags: u32) -> &mut Command {
+        self.inner.creation_flags(flags);
+        self
+    }
+
     /// Run the child elevated — mirrors [`cosca::Command::elevate`](crate::Command::elevate).
     pub fn elevate(&mut self) -> &mut Command {
         self.inner.elevate();

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -106,6 +106,11 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         }
     }
 
+    // Read the routing rule BEFORE the take, for the reason spelled out at
+    // `crate::child::spawn::routes_to_raw_backend`: after it, a high-descriptor-only command
+    // would take the std path and lose its descriptors in silence.
+    #[cfg(windows)]
+    let to_raw_backend = crate::child::spawn::routes_to_raw_backend(cmd);
     let mut fds = std::mem::take(cmd.fds_mut());
 
     // Route the cases tokio's `Command` cannot express to the raw `CreateProcessW` backend:
@@ -114,7 +119,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     // contained and uncontained via its own async containment; everything else stays on
     // the std/tokio path, whose `prepare` applies containment for argv/commandline spawns.
     #[cfg(windows)]
-    if cmd.executable_path().is_some() || fds.keys().any(|f| f.raw() >= 3) {
+    if to_raw_backend {
         // Attach the report on the AlreadyElevated fall-through too — an already-elevated
         // `executable()` command routes here (fd >= 3 on an elevated child is already rejected by
         // the Windows gate), and dropping the raw child without the report would lose its elevation

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -353,7 +353,13 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         // `CreateProcessW` spawn on another thread (mirrors the sync std path).
         let c = {
             let _guard = crate::child::spawn::spawn_lock();
-            tcmd.spawn().map_err(Error::Io)?
+            // Classified at the SYSCALL — see the sync std path for why the whole spawn tree is
+            // the wrong domain for this attribution.
+            let spawned = tcmd.spawn().map_err(Error::Io);
+            #[cfg(windows)]
+            let spawned =
+                spawned.map_err(|e| crate::command::flags::classify_spawn_syscall_error(e, *cmd.flags_request()));
+            spawned?
         };
         (prepared, c)
     };

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -275,9 +275,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         let prepared = crate::containment::prepare(
             tcmd.as_std_mut(),
             &cmd.contain_request(),
+            cmd.flags_request(),
             &reserved,
             cmd.fd_marker_suppressed(),
-        );
+        )?;
 
         // fd >= 3 merge SOURCES: their dup'd ends join the resolved fd >= 3 collection below
         // (the pre-pass removed those slots from `fds`, so the numbers cannot collide).
@@ -309,9 +310,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
         let prepared = crate::containment::prepare(
             tcmd.as_std_mut(),
             &cmd.contain_request(),
+            cmd.flags_request(),
             &reserved,
             cmd.fd_marker_suppressed(),
-        );
+        )?;
 
         // fd >= 3 merge SOURCES: their dup'd ends join the resolved fd >= 3 collection below
         // (the pre-pass removed those slots from `fds`, so the numbers cannot collide).

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -361,6 +361,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
             &env_block,
             &cwd_w,
             flags,
+            *cmd.flags_request(),
         );
         drop(child_ends); // close the child ends inside the lock, on success AND error
         drop(attr); // DeleteProcThreadAttributeList before the guard releases

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 
 use windows::Win32::Foundation::{ERROR_ACCESS_DENIED, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Threading::{
-    TerminateProcess, WaitForSingleObject, CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, INFINITE,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    TerminateProcess, WaitForSingleObject, INFINITE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
 };
 
 use crate::child::spawn::windows_raw as sync_raw;
@@ -285,15 +284,22 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     // (flags 0, `mode: None`/`is_root: false`); a Strongest root spawns CREATE_SUSPENDED and is
     // job-assigned + resumed in `attach_or_fault`.
     let req = cmd.contain_request();
-    let (contain_flags, is_root, marker_env) = if req.mode.is_some() {
-        let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
-        let is_root = !crate::containment::dispatch::is_nested(marker_present);
+    let marker_present = std::env::var_os(crate::containment::NESTED_ENV).is_some();
+    let is_root = !crate::containment::dispatch::is_nested(marker_present);
+    // Composed and validated BEFORE `clear_std_handle_inheritance`, which is a process-global
+    // `SetHandleInformation` on THIS process's std handles that nothing undoes: a refused spawn
+    // must not have mutated the parent. The gate itself is unchanged — the call stays inside the
+    // containment condition, only below the refusal.
+    let plan = crate::command::flags::windows_spawn(
+        &req,
+        *cmd.flags_request(),
+        is_root,
+        crate::command::flags::SpawnBackend::Raw,
+    )?;
+    let marker_env = plan.marker_env;
+    if req.mode.is_some() {
         crate::containment::windows::clear_std_handle_inheritance();
-        let setup = crate::containment::dispatch::windows_contain_setup(&req, is_root);
-        (setup.creation_flags, is_root, setup.marker_env)
-    } else {
-        (0u32, false, false)
-    };
+    }
 
     // Append the inherited root marker AFTER the user's env ops so it survives a user `env_clear()`
     // (mirrors the sync path).
@@ -337,7 +343,9 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let all_handles: &[HANDLE] = &table.handles;
     let attr = AttributeList::build(all_handles)?;
     si.lpAttributeList = attr.as_ptr();
-    let flags = CREATE_UNICODE_ENVIRONMENT.0 | EXTENDED_STARTUPINFO_PRESENT.0 | contain_flags;
+    // The complete word, composed above by the ONE function all three backends share — the two
+    // structural bits this backend cannot spawn without included. Nothing ORs into it here.
+    let flags = plan.creation_flags;
 
     // UNDER THE LOCK: mark the listed child ends inheritable, spawn, then CLOSE the child ends and
     // the attribute list BEFORE the guard releases on EVERY path (mirrors the sync raw backend —
@@ -368,8 +376,9 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let prepared = crate::containment::Prepared {
         mode: req.mode,
         is_root,
-        // From the FINAL flag word this backend passed to CreateProcessW, not from
-        // `contain_flags` alone: the derivation must read what the OS was actually given.
+        // From the COMPOSED word, which carries the caller's flags as well as the containment
+        // decision: a derivation reading only the containment half would report an in-process
+        // route for a child this spawn deliberately put in another console.
         graceful: crate::containment::windows::mechanism_from_flags(flags),
     };
     let raw_handle = proc.as_raw_handle();

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -288,8 +288,7 @@ pub(crate) fn spawn_raw(cmd: &Command, fds: BTreeMap<Fd, ResolvedStdio>, kill_on
     let is_root = !crate::containment::dispatch::is_nested(marker_present);
     // Composed and validated BEFORE `clear_std_handle_inheritance`, which is a process-global
     // `SetHandleInformation` on THIS process's std handles that nothing undoes: a refused spawn
-    // must not have mutated the parent. The gate itself is unchanged — the call stays inside the
-    // containment condition, only below the refusal.
+    // must not have mutated the parent.
     let plan = crate::command::flags::windows_spawn(
         &req,
         *cmd.flags_request(),

--- a/src/tokio/spawn/windows_raw_tests.rs
+++ b/src/tokio/spawn/windows_raw_tests.rs
@@ -58,3 +58,40 @@ async fn async_wait_drop_cancels_and_child_stays_waitable() {
         .await
         .expect("a fresh wait resolves after the cancelled one");
 }
+
+/// The async twin of `a_refused_raw_spawn_does_not_clear_our_handle_inheritance`. Not padding:
+/// the async raw backend has its own copy of the ordering, which the sync test cannot see.
+///
+/// `#[tokio::test]` is single-threaded, which matters — the seam is per *thread*, so a
+/// multi-thread runtime could move the spawn off this test's thread.
+#[cfg(windows)]
+#[tokio::test]
+async fn an_async_refused_raw_spawn_does_not_clear_our_handle_inheritance() {
+    use crate::containment::windows::observe;
+    use crate::error::Error;
+
+    let mut refused = Command::new();
+    refused
+        .executable("cmd")
+        .args(["cmd", "/C", "exit 0"])
+        .contain()
+        .creation_flags(windows::Win32::System::Threading::CREATE_SUSPENDED.0);
+    observe::take_inheritance_cleared();
+    let err = refused.spawn().expect_err("a reserved bit must be refused");
+    assert!(matches!(err, Error::Unsupported { .. }), "got {err:?}");
+    assert!(
+        !observe::take_inheritance_cleared(),
+        "the refusal ran after the mutation it was supposed to precede"
+    );
+
+    let mut allowed = Command::new();
+    allowed.executable("cmd").args(["cmd", "/C", "exit 0"]).contain();
+    let mut child = allowed
+        .spawn()
+        .expect("the same command without the reserved bit spawns");
+    assert!(
+        observe::take_inheritance_cleared(),
+        "the seam must record a real call, else the negative leg above proves nothing"
+    );
+    child.wait().await.expect("reap");
+}

--- a/testbin/breakaway.rs
+++ b/testbin/breakaway.rs
@@ -1,0 +1,273 @@
+//! The `report-breakaway <report-addr> <shape> <vehicle>` mode: build one job-object shape,
+//! assign THIS process to it, spawn a child through one of three vehicles, and report where the
+//! child landed.
+//!
+//! It lives in a short-lived helper because assigning a process to a job is irreversible — the
+//! test binary cannot do it and keep running its other tests.
+//!
+//! The `limits` field is the helper's OWN reading of the job it built, taken through
+//! `QueryInformationJobObject`. It is not cosca's verdict: this binary compiles as its own crate,
+//! so the library's `pub(crate)` probe is not visible to it. That independence is the point — a
+//! shape that was not built the way the test names it fails loudly instead of measuring something
+//! else.
+
+use std::io::{Read, Write};
+use std::mem::size_of;
+use std::net::{TcpListener, TcpStream};
+
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, IsProcessInJob, JobObjectBasicLimitInformation,
+    JobObjectExtendedLimitInformation, QueryInformationJobObject, SetInformationJobObject,
+    JOBOBJECT_BASIC_LIMIT_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT,
+    JOB_OBJECT_LIMIT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,
+};
+use windows::Win32::System::Threading::{
+    GetCurrentProcess, OpenProcess, CREATE_BREAKAWAY_FROM_JOB, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+/// A job with `limits`, with THIS process assigned to it. `None` when either step failed, which
+/// the caller reports as its own token rather than proceeding to measure a job it did not build.
+///
+/// The breakaway limits are **extended**-limit flags: setting them through
+/// `JobObjectBasicLimitInformation` returns `ERROR_INVALID_PARAMETER`, at runtime and not at
+/// compile time. The read side is asymmetric on purpose — the query class returns the basic
+/// structure, the setter needs the extended one.
+fn job_with_self(limits: JOB_OBJECT_LIMIT) -> Option<HANDLE> {
+    // SAFETY: standard Win32; `info` is fully initialised (zeroed by default()), and the handle
+    // stays owned by this short-lived process.
+    unsafe {
+        let job = CreateJobObjectW(None, windows::core::PCWSTR::null()).ok()?;
+        if limits.0 != 0 {
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = limits;
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(info).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .ok()?;
+        }
+        AssignProcessToJobObject(job, GetCurrentProcess()).ok()?;
+        Some(job)
+    }
+}
+
+/// This process's current (innermost) job limits, as a whitespace-free token.
+fn own_limits_token() -> &'static str {
+    let mut info = JOBOBJECT_BASIC_LIMIT_INFORMATION::default();
+    // SAFETY: standard Win32; `info` is a valid, correctly-sized out-param. `None` asks about the
+    // calling process's own job.
+    let ok = unsafe {
+        QueryInformationJobObject(
+            None,
+            JobObjectBasicLimitInformation,
+            std::ptr::addr_of_mut!(info).cast(),
+            size_of::<JOBOBJECT_BASIC_LIMIT_INFORMATION>() as u32,
+            None,
+        )
+    };
+    if ok.is_err() {
+        return "query-failed";
+    }
+    let breakaway = info.LimitFlags & JOB_OBJECT_LIMIT_BREAKAWAY_OK != JOB_OBJECT_LIMIT(0);
+    let silent = info.LimitFlags & JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK != JOB_OBJECT_LIMIT(0);
+    match (breakaway, silent) {
+        (true, true) => "both",
+        (true, false) => "breakaway-ok",
+        (false, true) => "silent-breakaway-ok",
+        (false, false) => "none",
+    }
+}
+
+/// Is `handle` in `job`? `None` when the query failed.
+fn in_job(handle: HANDLE, job: Option<HANDLE>) -> Option<bool> {
+    let mut result = windows::core::BOOL(0);
+    // SAFETY: standard Win32; `handle` pins a live process, `result` is a valid out-param.
+    unsafe { IsProcessInJob(handle, job, &mut result) }.ok()?;
+    Some(result.as_bool())
+}
+
+fn tri(v: Option<bool>) -> &'static str {
+    match v {
+        Some(true) => "1",
+        Some(false) => "0",
+        None => "?",
+    }
+}
+
+/// The child every vehicle spawns: `control-block`, which tags its socket and then blocks. The
+/// tag read is the real edge proving the child started — a "successful" spawn into an image that
+/// never ran would otherwise look identical.
+struct Spawned {
+    outcome: String,
+    /// Kept alive across the measurement so the pid cannot be recycled, and so the child is torn
+    /// down when this helper exits.
+    _child: Option<ChildHandle>,
+    /// The child's control socket, held open so the child stays blocked on its read.
+    _ctrl: Option<TcpStream>,
+    pid: Option<u32>,
+}
+
+/// Both variants exist to be HELD: keeping the value alive is what keeps the child's pid from
+/// being recycled while it is measured, and what tears the child down when this helper exits.
+enum ChildHandle {
+    Raw(std::process::Child),
+    Cosca(#[allow(dead_code)] cosca::Child),
+}
+
+impl Drop for ChildHandle {
+    fn drop(&mut self) {
+        if let ChildHandle::Raw(c) = self {
+            let _ = c.kill();
+            let _ = c.wait();
+        }
+    }
+}
+
+/// Encode a spawn outcome as ONE whitespace-free token.
+fn raw_outcome(e: &std::io::Error) -> String {
+    match e.raw_os_error() {
+        Some(code) => format!("Io-{code}"),
+        None => "Io-unknown".to_string(),
+    }
+}
+
+fn cosca_outcome(e: &cosca::error::Error) -> String {
+    match e {
+        cosca::error::Error::Containment { .. } => "Containment".to_string(),
+        cosca::error::Error::Io(io) => raw_outcome(io),
+        cosca::error::Error::Unsupported { .. } => "Unsupported".to_string(),
+        other => format!("Other-{}", other.to_string().replace(char::is_whitespace, "_")),
+    }
+}
+
+fn spawn_child(vehicle: &str, request: bool, listener: &TcpListener, addr: &str) -> Spawned {
+    let exe = std::env::current_exe().expect("current_exe");
+    let (outcome, child, pid) = match vehicle {
+        "raw" => {
+            use std::os::windows::process::CommandExt;
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args(["control-block", addr, "C"]).creation_flags(if request {
+                CREATE_BREAKAWAY_FROM_JOB.0
+            } else {
+                0
+            });
+            match cmd.spawn() {
+                Ok(c) => {
+                    let pid = c.id();
+                    ("Ok".to_string(), Some(ChildHandle::Raw(c)), Some(pid))
+                }
+                Err(e) => (raw_outcome(&e), None, None),
+            }
+        }
+        "argv" | "exec" => {
+            let mut cmd = cosca::Command::new();
+            if vehicle == "exec" {
+                cmd.executable(&exe).args(["cosca_testbin", "control-block", addr, "C"]);
+            } else {
+                cmd.args([exe.to_string_lossy().as_ref(), "control-block", addr, "C"]);
+            }
+            if request {
+                cmd.breakaway_from_job();
+            }
+            match cmd.spawn() {
+                Ok(c) => {
+                    let pid = c.id().pid();
+                    ("Ok".to_string(), Some(ChildHandle::Cosca(c)), Some(pid))
+                }
+                Err(e) => (cosca_outcome(&e), None, None),
+            }
+        }
+        other => panic!("unknown breakaway vehicle {other:?}"),
+    };
+    // The real edge: the child connected and tagged, so it is running and its job membership is
+    // settled. No timer anywhere.
+    let ctrl = child.as_ref().map(|_| {
+        let (mut sock, _) = listener.accept().expect("accept the child's control socket");
+        let mut tag = [0u8; 1];
+        sock.read_exact(&mut tag).expect("read the child's tag");
+        assert_eq!(&tag, b"C", "wrong child tag");
+        sock
+    });
+    Spawned {
+        outcome,
+        _child: child,
+        _ctrl: ctrl,
+        pid,
+    }
+}
+
+/// Connect to `report_addr` FIRST, so a panic below reaches the test as socket EOF rather than a
+/// hang, then report and block until the test closes the socket.
+pub fn run(report_addr: &str, shape: &str, vehicle: &str) {
+    let mut sock: TcpStream = std::net::TcpStream::connect(report_addr).expect("connect report socket");
+
+    let request = !shape.ends_with("no-request");
+    let (outer, inner) = match shape {
+        "permit" | "permit-no-request" => (None, job_with_self(JOB_OBJECT_LIMIT_BREAKAWAY_OK)),
+        "forbid" => (None, job_with_self(JOB_OBJECT_LIMIT(0))),
+        "silent" | "silent-no-request" => (None, job_with_self(JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)),
+        "nested" => {
+            // A: forbids breakaway. B: permits it, and becomes a CHILD job of A because this
+            // process is already in A when it is assigned. A child that breaks away from B must
+            // then stop at A.
+            let a = job_with_self(JOB_OBJECT_LIMIT(0));
+            let b = if a.is_some() {
+                job_with_self(JOB_OBJECT_LIMIT_BREAKAWAY_OK)
+            } else {
+                None
+            };
+            (a, b)
+        }
+        other => panic!("unknown breakaway shape {other:?}"),
+    };
+
+    // A failed build is its own token, never swallowed: otherwise the helper would measure a
+    // limit-less job while the test believed it built a permitting one.
+    let limits = if inner.is_none() {
+        "set-failed"
+    } else {
+        own_limits_token()
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind the child's control listener");
+    let child_addr = listener.local_addr().unwrap().to_string();
+    let spawned = if inner.is_some() {
+        spawn_child(vehicle, request, &listener, &child_addr)
+    } else {
+        Spawned {
+            outcome: "not-attempted".to_string(),
+            _child: None,
+            _ctrl: None,
+            pid: None,
+        }
+    };
+
+    // Windows cannot recycle a pid while a handle to the process is open, and the live child
+    // value above holds one, so this handle cannot answer about an unrelated process.
+    let child_handle = spawned.pid.and_then(|pid| {
+        // SAFETY: standard Win32; the live child value pins `pid`.
+        unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()
+    });
+    let (in_inner, in_outer, in_any) = match child_handle {
+        Some(h) => (in_job(h, inner), in_job(h, outer), in_job(h, None)),
+        None => (None, None, None),
+    };
+    // `outer` is only meaningful for the nested shape; every other shape reports `?`.
+    let in_outer = if outer.is_some() { in_outer } else { None };
+
+    let line = format!(
+        "limits={limits} spawn={} in_inner={} in_outer={} in_any={}\n",
+        spawned.outcome,
+        tri(in_inner),
+        tri(in_outer),
+        tri(in_any),
+    );
+    sock.write_all(line.as_bytes()).expect("write report");
+    sock.flush().expect("flush report");
+
+    let mut buf = [0u8; 1];
+    let _ = sock.read(&mut buf);
+}

--- a/testbin/console_identity.rs
+++ b/testbin/console_identity.rs
@@ -1,0 +1,99 @@
+//! The `report-console-identity` mode, shared by the console-subsystem testbin and the
+//! GUI-subsystem fixture: only the image's subsystem differs between them, and that difference
+//! is the whole point of running the same probe from both.
+//!
+//! Every fact is measured BY THIS PROCESS ABOUT ITSELF, after it is running — console
+//! registration is not synchronous with the spawner's `CreateProcess` returning, so a fact
+//! measured from the parent at that instant reads "absent" for every flag word.
+
+use std::io::{Read, Write};
+
+use windows::Win32::Foundation::{SetLastError, ERROR_INVALID_HANDLE, WIN32_ERROR};
+use windows::Win32::System::Console::{GetConsoleProcessList, GetConsoleWindow};
+use windows::Win32::UI::WindowsAndMessaging::IsWindowVisible;
+
+/// Percent-escape everything outside `[A-Za-z0-9._-]`, so an unbounded value stays ONE
+/// whitespace-free token in a whitespace-delimited record. `argv[0]` is a filesystem path, and a
+/// user profile or checkout directory containing a space would otherwise split the record.
+fn escape(value: &str) -> String {
+    let mut out = String::new();
+    for b in value.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-') {
+            out.push(*b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// This process's own console process list, or `None` when there is none / the probe failed.
+///
+/// Grows to whatever count the API reports rather than capping: a too-small buffer makes it
+/// return the REQUIRED count without filling, which a fixed cap would silently read as "absent".
+/// The last error is cleared first so a zero return is attributable to THIS call.
+fn console_pids() -> Option<Vec<u32>> {
+    let mut buf = vec![0u32; 16];
+    loop {
+        // SAFETY: both calls are standard Win32; `buf` is a valid writable slice.
+        let n = unsafe {
+            SetLastError(WIN32_ERROR(0));
+            GetConsoleProcessList(&mut buf)
+        } as usize;
+        if n == 0 {
+            return None;
+        }
+        if n <= buf.len() {
+            buf.truncate(n);
+            return Some(buf);
+        }
+        buf.resize(n, 0);
+    }
+}
+
+/// Connect to `report_addr` FIRST (so a panic below reaches the test as socket EOF, never a
+/// hang), report this process's console identity, then block on the same socket until the test
+/// closes it — which is what makes the report describe a live process without any timer.
+///
+/// `caller_pid` is the spawning process's pid, whose presence in THIS process's console list is
+/// the `sees_caller` field.
+///
+/// Every field is one whitespace-free token, because the report is parsed by splitting on
+/// whitespace. `console` is three-way — `1` has one, `0` a MEASURED absence
+/// (`ERROR_INVALID_HANDLE`), `?` the probe itself failed — so a broken probe can never satisfy
+/// a test's `console=0` guard.
+pub fn run(report_addr: &str, caller_pid: u32) {
+    let mut sock = std::net::TcpStream::connect(report_addr).expect("connect report socket");
+
+    let pids = console_pids();
+    let (console, sees_caller) = match &pids {
+        Some(list) => ("1", if list.contains(&caller_pid) { "1" } else { "0" }),
+        // A zero return is also how this API reports failure, so the two are told apart by the
+        // code THIS call set: a console-less process gets ERROR_INVALID_HANDLE.
+        None if std::io::Error::last_os_error().raw_os_error() == Some(ERROR_INVALID_HANDLE.0 as i32) => ("0", "?"),
+        None => ("?", "?"),
+    };
+
+    // SAFETY: standard Win32 calls; `GetConsoleWindow` returns null when there is no console
+    // window, and `IsWindowVisible` tolerates any handle value (returning false for null).
+    let (hwnd, visible) = unsafe {
+        let h = GetConsoleWindow();
+        if h.is_invalid() {
+            ("0", "0")
+        } else {
+            ("1", if IsWindowVisible(h).as_bool() { "1" } else { "0" })
+        }
+    };
+
+    let argv0 = std::env::args().next().unwrap_or_default();
+    let line = format!(
+        "pid={} console={console} sees_caller={sees_caller} hwnd={hwnd} visible={visible} argv0={}\n",
+        std::process::id(),
+        escape(&argv0),
+    );
+    sock.write_all(line.as_bytes()).expect("write report");
+    sock.flush().expect("flush report");
+
+    let mut buf = [0u8; 1];
+    let _ = sock.read(&mut buf); // blocks until the test closes the socket
+}

--- a/testbin/gui.rs
+++ b/testbin/gui.rs
@@ -5,13 +5,32 @@
 //! can construct a child whose flags say "in our console" while the OS says otherwise. The
 //! crate attribute is inert everywhere else, and a `[[bin]]` target cannot be `cfg`-ed out, so
 //! this binary compiles and behaves identically on every platform.
+//!
+//! It also serves `report-console-identity`, sharing that mode's body with the
+//! console-subsystem testbin so the two differ in exactly one thing: the image's subsystem.
 #![cfg_attr(windows, windows_subsystem = "windows")]
+
+/// The `report-console-identity` mode, shared verbatim with `testbin/main.rs`.
+#[cfg(windows)]
+#[path = "console_identity.rs"]
+mod console_identity;
 
 use std::io::{Read, Write};
 
 fn main() {
-    let addr = std::env::args().nth(1).expect("argv[1]: the control address");
-    let mut sock = std::net::TcpStream::connect(&addr).expect("connect control socket");
+    let first = std::env::args().nth(1).expect("argv[1]: a mode or the control address");
+    #[cfg(windows)]
+    if first == "report-console-identity" {
+        let addr = std::env::args().nth(2).expect("argv[2]: the report address");
+        let caller_pid: u32 = std::env::args()
+            .nth(3)
+            .expect("argv[3]: the spawning process's pid")
+            .parse()
+            .expect("argv[3] parses as a pid");
+        console_identity::run(&addr, caller_pid);
+        return;
+    }
+    let mut sock = std::net::TcpStream::connect(&first).expect("connect control socket");
     sock.write_all(b"G").expect("write tag");
     sock.flush().expect("flush tag");
     // Blocks until the socket closes (our death, or the test dropping its end).

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -12,6 +12,11 @@ use std::process::exit;
 #[path = "console_identity.rs"]
 mod console_identity;
 
+/// The `report-breakaway` mode: job-object shapes and the three spawn vehicles.
+#[cfg(windows)]
+#[path = "breakaway.rs"]
+mod breakaway;
+
 /// Borrow a std stream's raw descriptor as an UNBUFFERED `File`. `ManuallyDrop` keeps the
 /// real descriptor open (a plain `File` drop would close it — double-close on exit).
 /// Callers must pass one of this process's std descriptors, which live for the whole run.
@@ -866,6 +871,10 @@ fn main() {
             .unwrap();
             report_sock.write_all(line.as_bytes()).unwrap();
             report_sock.flush().unwrap();
+        }
+        #[cfg(windows)]
+        "report-breakaway" => {
+            breakaway::run(&args[2], &args[3], &args[4]);
         }
         #[cfg(windows)]
         "report-console-identity" => {

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -7,6 +7,11 @@ use std::io::BufRead;
 use std::io::{Read, Write};
 use std::process::exit;
 
+/// The `report-console-identity` mode, shared verbatim with the GUI-subsystem fixture.
+#[cfg(windows)]
+#[path = "console_identity.rs"]
+mod console_identity;
+
 /// Borrow a std stream's raw descriptor as an UNBUFFERED `File`. `ManuallyDrop` keeps the
 /// real descriptor open (a plain `File` drop would close it — double-close on exit).
 /// Callers must pass one of this process's std descriptors, which live for the whole run.
@@ -861,6 +866,11 @@ fn main() {
             .unwrap();
             report_sock.write_all(line.as_bytes()).unwrap();
             report_sock.flush().unwrap();
+        }
+        #[cfg(windows)]
+        "report-console-identity" => {
+            let caller_pid: u32 = args[3].parse().expect("argv[3]: the spawning process's pid");
+            console_identity::run(&args[2], caller_pid);
         }
         #[cfg(windows)]
         "report-console-terminate" => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -130,6 +130,44 @@ pub fn in_our_console(pid: u32) -> Option<bool> {
     }
 }
 
+/// Exact-key extraction from a `key=value` report line. Substring matching would be unsafe:
+/// `console=0` shares its value alphabet with every other field.
+#[cfg(windows)]
+pub fn report_field<'a>(report: &'a str, key: &str) -> &'a str {
+    report
+        .split_ascii_whitespace()
+        .find_map(|kv| kv.strip_prefix(key)?.strip_prefix('='))
+        .unwrap_or_else(|| panic!("no field {key} in report: {report}"))
+}
+
+/// The escaping `report-console-identity` applies to its `argv0` field, so a test can state its
+/// expectation in plain text. ONE definition for every test crate that asserts on that field: two
+/// copies could drift apart and agree on the wrong answer.
+#[cfg(windows)]
+pub fn escape_report_field(value: &str) -> String {
+    let mut out = String::new();
+    for b in value.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-') {
+            out.push(*b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Read exactly the one report line a `report-console-identity` child writes before it blocks. A
+/// child that panicked after connecting reaches us as EOF (an empty line), which fails the
+/// caller's field lookup loudly instead of hanging.
+#[cfg(windows)]
+pub fn read_report_line(sock: &TcpStream) -> String {
+    use std::io::BufRead;
+    let mut reader = std::io::BufReader::new(sock.try_clone().expect("clone report socket"));
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read report line");
+    line
+}
+
 /// Spawn `mode <addr> [extra...]` as a control child that connects, writes a 1-byte tag,
 /// then blocks; returns the owned `Child` and the accepted socket (the tag read proves it
 /// is alive). `contain` applies `.contain()`. This is the canonical form; `tests/lifecycle.rs`

--- a/tests/windows_breakaway.rs
+++ b/tests/windows_breakaway.rs
@@ -1,0 +1,182 @@
+//! Windows: what a job object's breakaway limits do to a child that asks to escape, and how
+//! cosca classifies the refusal.
+//!
+//! The first six tests characterize the OS through a raw `std::process::Command`, with no cosca
+//! involved, because two classifier arms depend on facts Win32 does not document: what a
+//! silent-breakaway job does with the flag, and where a child lands under job nesting. Only then
+//! do the cosca legs assert cosca's own behaviour.
+//!
+//! Every job shape is CONSTRUCTED by a short-lived helper that assigns itself to it — assigning a
+//! process to a job is irreversible, so this cannot happen in the test binary — which makes each
+//! assertion deterministic whatever ambient job a CI runner holds. The helper reports its own
+//! independent reading of the job's limits, so a shape that was not built the way the test names
+//! it fails loudly instead of measuring something else.
+#![cfg(windows)]
+
+use std::net::TcpListener;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{read_report_line, report_field, testbin};
+
+/// Run the `report-breakaway` helper for one job shape and one spawn vehicle, and return its
+/// report line. The helper blocks on the report socket until this function drops it, so every
+/// field describes a live measurement.
+fn breakaway_report(shape: &str, vehicle: &str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind report listener");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = std::process::Command::new(testbin());
+    cmd.args(["report-breakaway", addr.as_str(), shape, vehicle]);
+    let mut helper = {
+        let _guard = cosca::test_spawn_lock();
+        cmd.spawn().expect("spawn breakaway helper")
+    };
+    let (sock, _) = listener.accept().expect("accept report socket");
+    let report = read_report_line(&sock);
+    drop(sock);
+    helper.wait().expect("reap breakaway helper");
+    report
+}
+
+/// `ERROR_ACCESS_DENIED`, as the helper encodes a raw `io::Error`.
+const RAW_ACCESS_DENIED: &str = "Io-5";
+
+#[test]
+fn a_permitting_job_lets_a_raw_flag_child_break_away() {
+    let r = breakaway_report("permit", "raw");
+    assert_eq!(report_field(&r, "limits"), "breakaway-ok", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Ok", "{r}");
+    assert_eq!(
+        report_field(&r, "in_inner"),
+        "0",
+        "the child must have left the job: {r}"
+    );
+}
+
+/// The negative control for the row above: without the flag, the same child in the same job
+/// STAYS. Without it, `in_inner == 0` there could hold for a reason unrelated to the request.
+#[test]
+fn a_child_without_the_raw_flag_stays_in_the_permitting_job() {
+    let r = breakaway_report("permit-no-request", "raw");
+    assert_eq!(report_field(&r, "limits"), "breakaway-ok", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "in_inner"), "1", "{r}");
+    assert_eq!(report_field(&r, "in_any"), "1", "{r}");
+}
+
+/// The fact the typed containment error rests on.
+#[test]
+fn a_forbidding_job_denies_the_raw_flag() {
+    let r = breakaway_report("forbid", "raw");
+    assert_eq!(report_field(&r, "limits"), "none", "wrong job shape: {r}");
+    assert_eq!(
+        report_field(&r, "spawn"),
+        RAW_ACCESS_DENIED,
+        "a forbidding job denies the flag with ACCESS_DENIED: {r}"
+    );
+}
+
+/// Breakaway leaves the immediate job and climbs the parent chain until a job forbids it, so a
+/// successful breakaway under nesting can still leave the child inside an ancestor.
+///
+/// The nesting is CONSTRUCTED, not observed, so `in_outer == 1` is deterministic — and it is the
+/// half a partial breakaway can fail. Asserting only `in_inner == 0` would pass under any
+/// breakaway at all.
+#[test]
+fn nested_breakaway_climbs_to_the_first_forbidding_job() {
+    let r = breakaway_report("nested", "raw");
+    assert_eq!(report_field(&r, "limits"), "breakaway-ok", "wrong inner job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Ok", "{r}");
+    assert_eq!(
+        report_field(&r, "in_inner"),
+        "0",
+        "the child left the permitting job: {r}"
+    );
+    assert_eq!(
+        report_field(&r, "in_outer"),
+        "1",
+        "and stopped at the forbidding one above it: {r}"
+    );
+    assert_eq!(report_field(&r, "in_any"), "1", "{r}");
+}
+
+/// A silent-breakaway job keeps new children out ON ITS OWN, without the child requesting
+/// anything. Paired with `a_child_without_the_raw_flag_stays_in_the_permitting_job`'s
+/// `in_inner == 1`, this is a discriminating measurement: the same no-request child lands inside
+/// one job and outside the other, so the difference is attributable to the limit.
+#[test]
+fn a_child_without_the_raw_flag_already_leaves_a_silent_breakaway_job() {
+    let r = breakaway_report("silent-no-request", "raw");
+    assert_eq!(
+        report_field(&r, "limits"),
+        "silent-breakaway-ok",
+        "wrong job shape: {r}"
+    );
+    assert_eq!(report_field(&r, "spawn"), "Ok", "{r}");
+    assert_eq!(report_field(&r, "in_inner"), "0", "{r}");
+}
+
+/// Whether a silent-breakaway job also refuses the explicit FLAG is undocumented, and the spawn
+/// outcome is the only thing this shape can measure about the request: `in_inner == 0` holds here
+/// with or without the flag (the control above measures exactly that), so asserting it would be a
+/// test that cannot fail.
+///
+/// Measured on Windows 11 26100, 2026-08-18: the spawn **succeeds**. That selects the classifier
+/// arm for `SilentBreakaway` — it keeps the raw error, because no breakaway request can reach the
+/// classifier from such a job at all. The verdict exists solely to stop a silent-breakaway job
+/// being misread as one that forbids breakaway, whose message would be wrong about the world.
+#[test]
+fn a_silent_breakaway_job_accepts_the_raw_flag() {
+    let r = breakaway_report("silent", "raw");
+    assert_eq!(
+        report_field(&r, "limits"),
+        "silent-breakaway-ok",
+        "wrong job shape: {r}"
+    );
+    assert_eq!(
+        report_field(&r, "spawn"),
+        "Ok",
+        "a silent-breakaway job does not refuse the flag: {r}"
+    );
+}
+
+// ===== the same shapes through cosca =====
+//
+// The `argv` legs are the point of this section: the routing rule sends an `executable()` to the
+// raw backend, so a helper written in the existing testbin style would exercise only that one —
+// and the std path is the one most spawns take. What makes each leg's NAME true is
+// `child::spawn::spawn_tests::routes_to_raw_backend_answers_for_executables_and_high_descriptors`
+// for these exact two builder shapes; the `control-block` child reports no backend evidence of
+// its own, so no assertion here restates the routing rule.
+
+#[test]
+fn cosca_breaks_a_child_away_via_the_std_backend() {
+    let r = breakaway_report("permit", "argv");
+    assert_eq!(report_field(&r, "limits"), "breakaway-ok", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Ok", "{r}");
+    assert_eq!(report_field(&r, "in_inner"), "0", "{r}");
+}
+
+#[test]
+fn cosca_breaks_a_child_away_via_the_raw_backend() {
+    let r = breakaway_report("permit", "exec");
+    assert_eq!(report_field(&r, "limits"), "breakaway-ok", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Ok", "{r}");
+    assert_eq!(report_field(&r, "in_inner"), "0", "{r}");
+}
+
+/// The raw vehicle gets `Io-5` for this shape (`a_forbidding_job_denies_the_raw_flag`); cosca
+/// turns the same refusal into a typed error naming the job's limit and the remedy.
+#[test]
+fn a_forbidding_job_yields_a_typed_containment_error_via_the_std_backend() {
+    let r = breakaway_report("forbid", "argv");
+    assert_eq!(report_field(&r, "limits"), "none", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Containment", "{r}");
+}
+
+#[test]
+fn a_forbidding_job_yields_a_typed_containment_error_via_the_raw_backend() {
+    let r = breakaway_report("forbid", "exec");
+    assert_eq!(report_field(&r, "limits"), "none", "wrong job shape: {r}");
+    assert_eq!(report_field(&r, "spawn"), "Containment", "{r}");
+}

--- a/tests/windows_console_identity.rs
+++ b/tests/windows_console_identity.rs
@@ -1,0 +1,270 @@
+//! Windows: which console does a child get under each creation flag, measured BY THE CHILD.
+//!
+//! Console registration is not synchronous with `CreateProcess` returning, so a parent that
+//! enumerates its own console list immediately after spawning reads "absent" for every flag
+//! word — including one with no detaching flag at all. Every membership fact here is therefore
+//! reported by the child about itself, after it has written its report line, so it is provably
+//! running and registered. Do not "simplify" this into a parent-side enumeration.
+//!
+//! The matrix is discriminating because of its control leg: the no-flags row asserts the
+//! caller's pid IS in the child's list, under the identical handshake as every absence below.
+#![cfg(windows)]
+
+use std::io::{BufRead, BufReader};
+use std::net::{TcpListener, TcpStream};
+use std::os::windows::process::CommandExt;
+
+#[path = "common/mod.rs"]
+mod common;
+
+/// Raw winbase.h values: `CommandExt::creation_flags` takes a plain `u32`.
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// A running `report-console-identity` child plus the report line it wrote. The child blocks on
+/// the same socket until [`Probe::end`] closes it, so every field describes a LIVE process.
+struct Probe {
+    child: std::process::Child,
+    sock: TcpStream,
+    report: String,
+}
+
+impl Probe {
+    fn field(&self, key: &str) -> &str {
+        field(&self.report, key)
+    }
+
+    fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn end(mut self) {
+        drop(self.sock);
+        let _ = self.child.kill();
+        self.child.wait().expect("reap identity probe child");
+    }
+}
+
+/// Exact-key field extraction: substring matching is unsafe here because `console=0` is a
+/// substring of nothing but `sees_caller=0` shares its value alphabet with every other field.
+fn field<'a>(report: &'a str, key: &str) -> &'a str {
+    report
+        .split_ascii_whitespace()
+        .find_map(|kv| kv.strip_prefix(key)?.strip_prefix('='))
+        .unwrap_or_else(|| panic!("no field {key} in report: {report}"))
+}
+
+/// The escaping `report-console-identity` applies to `argv0`, reproduced here so a test can
+/// state its expectation in plain text. Everything outside `[A-Za-z0-9._-]` becomes `%XX`,
+/// because `argv[0]` is unbounded caller data in a whitespace-delimited record and a checkout
+/// path containing a space would otherwise split it.
+fn escape_field(value: &str) -> String {
+    let mut out = String::new();
+    for b in value.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-') {
+            out.push(*b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Bind a report listener, spawn `exe` in `report-console-identity` mode with exactly `flags`
+/// through a RAW `std::process::Command` (cosca cannot express these flags in Task 1), and read
+/// the one report line the child writes before it blocks.
+fn probe_raw(exe: &str, argv_head: &[&str], flags: u32) -> Probe {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind report listener");
+    let addr = listener.local_addr().unwrap().to_string();
+    let me = std::process::id().to_string();
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(argv_head)
+        .args(["report-console-identity", addr.as_str(), me.as_str()])
+        .creation_flags(flags);
+    let child = {
+        let _guard = cosca::test_spawn_lock();
+        cmd.spawn().expect("spawn identity probe child")
+    };
+    let (sock, _) = listener.accept().expect("accept report socket");
+    let report = read_report(&sock);
+    Probe { child, sock, report }
+}
+
+/// Read exactly the one report line. A child that panicked after connecting reaches us as EOF
+/// (an empty line), which fails the caller's field lookup loudly instead of hanging.
+fn read_report(sock: &TcpStream) -> String {
+    let mut reader = BufReader::new(sock.try_clone().expect("clone report socket"));
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read report line");
+    line
+}
+
+/// The CONTROL leg. A console-subsystem child spawned with no flags joins the caller's console,
+/// and reports the caller's own pid in its list. Every `sees_caller=0` below is discriminating
+/// only because this one reads `1` under identical timing — a timing artefact, a wrong argv
+/// index or a broken probe fails here first.
+#[test]
+fn plain_child_joins_the_callers_console() {
+    let p = probe_raw(env!("CARGO_BIN_EXE_cosca_testbin"), &[], 0);
+    assert_eq!(
+        p.field("console"),
+        "1",
+        "a plain console child has a console: {}",
+        p.report
+    );
+    assert_eq!(
+        p.field("sees_caller"),
+        "1",
+        "a plain console child shares OUR console: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// `CREATE_NO_WINDOW` gives the child its OWN (windowless) console — it does not merely hide a
+/// window. That is what takes such a child out of reach of an in-process console-group signal.
+#[test]
+fn no_window_child_gets_its_own_console() {
+    let p = probe_raw(env!("CARGO_BIN_EXE_cosca_testbin"), &[], CREATE_NO_WINDOW);
+    assert_eq!(
+        p.field("console"),
+        "1",
+        "CREATE_NO_WINDOW still gives a console: {}",
+        p.report
+    );
+    assert_eq!(
+        p.field("sees_caller"),
+        "0",
+        "CREATE_NO_WINDOW's console is not ours: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// `DETACHED_PROCESS`: no console at all. A MEASURED absence (`0`), not the probe-failure token
+/// (`?`), so a broken probe fails this rather than satisfying it.
+#[test]
+fn detached_child_gets_no_console() {
+    let p = probe_raw(env!("CARGO_BIN_EXE_cosca_testbin"), &[], DETACHED_PROCESS);
+    assert_eq!(p.field("console"), "0", "a detached child has no console: {}", p.report);
+    p.end();
+}
+
+/// Adding `CREATE_NO_WINDOW` to `DETACHED_PROCESS` changes nothing: no console either way. The
+/// value differs from the `CREATE_NO_WINDOW`-only row's `1`, which is what makes this row
+/// carry information rather than repeat the row above.
+#[test]
+fn detached_plus_no_window_behaves_as_detached() {
+    let p = probe_raw(
+        env!("CARGO_BIN_EXE_cosca_testbin"),
+        &[],
+        DETACHED_PROCESS | CREATE_NO_WINDOW,
+    );
+    assert_eq!(
+        p.field("console"),
+        "0",
+        "detached wins over window suppression: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// The non-skipping guard: if a lane ever runs this suite without a console, every `sees_caller=0`
+/// above would be satisfied by there being no console to be in. This says so in one line rather
+/// than leaving the control leg to imply it.
+#[test]
+fn caller_has_a_console_to_be_measured_against() {
+    assert_eq!(
+        common::in_our_console(std::process::id()),
+        Some(true),
+        "this test process must have a console, else every membership row here is vacuous"
+    );
+}
+
+/// `CREATE_NEW_CONSOLE` gives the child its own console too. It deliberately does NOT assert the
+/// `hwnd`/`visible` columns: those need an interactive session, which is one of the two reasons
+/// this bit stays reserved rather than getting a named intent.
+#[test]
+fn new_console_child_gets_its_own_console() {
+    let p = probe_raw(env!("CARGO_BIN_EXE_cosca_testbin"), &[], CREATE_NEW_CONSOLE);
+    assert_eq!(
+        p.field("console"),
+        "1",
+        "a new console is still a console: {}",
+        p.report
+    );
+    assert_eq!(p.field("sees_caller"), "0", "the new console is not ours: {}", p.report);
+    p.end();
+}
+
+/// Console membership is NOT a function of the creation-flag word. A GUI-subsystem image with no
+/// flags at all gets no console, where the console-subsystem control in this same file gets one
+/// and joins ours. This is the loud-failure guard behind the shipped rustdoc's one-directional
+/// wording: absence of a detaching flag establishes nothing.
+#[test]
+fn a_gui_subsystem_child_never_joins_the_callers_console() {
+    let p = probe_raw(env!("CARGO_BIN_EXE_cosca_testbin_gui"), &[], 0);
+    assert_eq!(
+        p.field("console"),
+        "0",
+        "a windows-subsystem image gets no console: {}",
+        p.report
+    );
+    assert_eq!(
+        p.field("sees_caller"),
+        "?",
+        "with no console there is no list to be in: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// Windows reports SUCCESS for a console control event that reaches nobody, so the return value
+/// is evidence in neither direction. The child's own `sees_caller=0` is the structural proof the
+/// event cannot arrive on this route — no timing, and no betting on how long a non-delivery takes.
+#[test]
+fn ctrl_break_reports_success_for_a_child_outside_our_console() {
+    use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
+
+    let p = probe_raw(
+        env!("CARGO_BIN_EXE_cosca_testbin"),
+        &[],
+        CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
+    );
+    assert_eq!(
+        p.field("sees_caller"),
+        "0",
+        "the child must be provably outside our console: {}",
+        p.report
+    );
+    // SAFETY: standard Win32 call; the live `std::process::Child` pins the pid.
+    let sent = unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, p.pid()) };
+    assert!(
+        sent.is_ok(),
+        "Win32 reports success for an undeliverable CTRL_BREAK: {sent:?}"
+    );
+    p.end();
+}
+
+/// Only the raw `CreateProcessW` backend can give a child an `argv[0]` that differs from the
+/// image it loaded, so the escaping of `argv[0]` is how later tasks prove which backend ran.
+/// Pinned here, at the mode that emits it: a plain std spawn's `argv[0]` IS the image path.
+#[test]
+fn the_report_escapes_argv0_so_a_spaced_path_cannot_split_the_record() {
+    let exe = env!("CARGO_BIN_EXE_cosca_testbin");
+    let p = probe_raw(exe, &[], 0);
+    assert_eq!(
+        p.field("argv0"),
+        escape_field(exe),
+        "argv0 is the image path, escaped: {}",
+        p.report
+    );
+    assert!(
+        !p.field("argv0").contains(char::is_whitespace),
+        "an escaped field is one whitespace-free token: {}",
+        p.report
+    );
+    p.end();
+}

--- a/tests/windows_console_identity.rs
+++ b/tests/windows_console_identity.rs
@@ -268,3 +268,125 @@ fn the_report_escapes_argv0_so_a_spaced_path_cannot_split_the_record() {
     );
     p.end();
 }
+
+// ===== cosca's own spawn paths =====
+
+/// A running cosca-spawned `report-console-identity` child plus its report line. Argv-only, so
+/// it routes to the **std** backend: an `executable()` or any fd >= 3 would route to the raw
+/// `CreateProcessW` one instead, and the existing testbin idiom uses `executable()` — so a test
+/// written in the house style would silently leave the std path unproven.
+struct CoscaProbe {
+    child: cosca::Child,
+    sock: TcpStream,
+    report: String,
+}
+
+impl CoscaProbe {
+    fn field(&self, key: &str) -> &str {
+        field(&self.report, key)
+    }
+
+    fn end(self) {
+        drop(self.sock);
+        let _ = self.child.kill_tree();
+        self.child.wait().expect("reap cosca identity probe child");
+    }
+}
+
+/// Spawn the testbin through `cosca::Command` with the image path as `argv[0]`, apply
+/// `configure`, and read the one report line.
+fn probe_cosca(configure: impl FnOnce(&mut cosca::Command)) -> CoscaProbe {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind report listener");
+    let addr = listener.local_addr().unwrap().to_string();
+    let me = std::process::id().to_string();
+    let mut cmd = cosca::Command::new();
+    cmd.args([
+        env!("CARGO_BIN_EXE_cosca_testbin"),
+        "report-console-identity",
+        addr.as_str(),
+        me.as_str(),
+    ]);
+    configure(&mut cmd);
+    let child = cmd.spawn().expect("spawn cosca identity probe child");
+    let (sock, _) = listener.accept().expect("accept report socket");
+    let report = read_report(&sock);
+    CoscaProbe { child, sock, report }
+}
+
+/// `no_window()` reaches the child on the std backend — the path most spawns take.
+#[test]
+fn cosca_no_window_child_gets_its_own_console_on_the_std_path() {
+    let p = probe_cosca(|c| {
+        c.contain().no_window();
+    });
+    assert_eq!(p.field("console"), "1", "still a console, just not ours: {}", p.report);
+    assert_eq!(
+        p.field("sees_caller"),
+        "0",
+        "the suppressed child got a console of its own: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// The same on an UNCONTAINED spawn, which is the branch `prepare` returns from before it ever
+/// reaches its Windows work — so a composition placed inside the containment branch drops the
+/// caller's word here and nowhere else.
+#[test]
+fn cosca_uncontained_raw_flags_reach_the_child() {
+    let p = probe_cosca(|c| {
+        c.no_window();
+    });
+    assert_eq!(
+        p.field("sees_caller"),
+        "0",
+        "an uncontained spawn must carry the caller's flags too: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// The control for both of the above, through the identical `cosca::Command` path with no flag
+/// methods called. A red result here would mean the harness broke, not the feature.
+#[test]
+fn a_plain_cosca_child_still_joins_the_callers_console() {
+    let p = probe_cosca(|_| {});
+    assert_eq!(
+        p.field("sees_caller"),
+        "1",
+        "a plain cosca child shares OUR console: {}",
+        p.report
+    );
+    p.end();
+}
+
+/// `graceful_mechanism()` must be derived from the word cosca actually composed, not from the
+/// containment half of it: a hidden child has no in-process route, and reporting `ConsoleGroup`
+/// for it tells the caller the opposite.
+///
+/// The two children are what make this discriminate. A derivation reading only the containment
+/// half reports `ConsoleGroup` for both, so the second assertion fails; a hardcoded
+/// `OtherConsoleGroup` fails the first.
+#[test]
+fn a_no_window_contained_child_reports_no_in_process_route() {
+    use cosca::GracefulMechanism;
+
+    let plain = probe_cosca(|c| {
+        c.contain();
+    });
+    assert_eq!(
+        plain.child.graceful_mechanism(),
+        GracefulMechanism::ConsoleGroup,
+        "a contained child leads a group in OUR console"
+    );
+    let hidden = probe_cosca(|c| {
+        c.contain().no_window();
+    });
+    assert_eq!(
+        hidden.child.graceful_mechanism(),
+        GracefulMechanism::OtherConsoleGroup,
+        "a hidden child's group is in a console of its own"
+    );
+    plain.end();
+    hidden.end();
+}

--- a/tests/windows_console_identity.rs
+++ b/tests/windows_console_identity.rs
@@ -10,7 +10,6 @@
 //! caller's pid IS in the child's list, under the identical handshake as every absence below.
 #![cfg(windows)]
 
-use std::io::{BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
 use std::os::windows::process::CommandExt;
 
@@ -47,30 +46,7 @@ impl Probe {
     }
 }
 
-/// Exact-key field extraction: substring matching is unsafe here because `console=0` is a
-/// substring of nothing but `sees_caller=0` shares its value alphabet with every other field.
-fn field<'a>(report: &'a str, key: &str) -> &'a str {
-    report
-        .split_ascii_whitespace()
-        .find_map(|kv| kv.strip_prefix(key)?.strip_prefix('='))
-        .unwrap_or_else(|| panic!("no field {key} in report: {report}"))
-}
-
-/// The escaping `report-console-identity` applies to `argv0`, reproduced here so a test can
-/// state its expectation in plain text. Everything outside `[A-Za-z0-9._-]` becomes `%XX`,
-/// because `argv[0]` is unbounded caller data in a whitespace-delimited record and a checkout
-/// path containing a space would otherwise split it.
-fn escape_field(value: &str) -> String {
-    let mut out = String::new();
-    for b in value.as_bytes() {
-        if b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-') {
-            out.push(*b as char);
-        } else {
-            out.push_str(&format!("%{b:02X}"));
-        }
-    }
-    out
-}
+use common::{escape_report_field as escape_field, read_report_line, report_field as field};
 
 /// Bind a report listener, spawn `exe` in `report-console-identity` mode with exactly `flags`
 /// through a RAW `std::process::Command` (cosca cannot express these flags in Task 1), and read
@@ -88,17 +64,8 @@ fn probe_raw(exe: &str, argv_head: &[&str], flags: u32) -> Probe {
         cmd.spawn().expect("spawn identity probe child")
     };
     let (sock, _) = listener.accept().expect("accept report socket");
-    let report = read_report(&sock);
+    let report = read_report_line(&sock);
     Probe { child, sock, report }
-}
-
-/// Read exactly the one report line. A child that panicked after connecting reaches us as EOF
-/// (an empty line), which fails the caller's field lookup loudly instead of hanging.
-fn read_report(sock: &TcpStream) -> String {
-    let mut reader = BufReader::new(sock.try_clone().expect("clone report socket"));
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("read report line");
-    line
 }
 
 /// The CONTROL leg. A console-subsystem child spawned with no flags joins the caller's console,
@@ -309,7 +276,7 @@ fn probe_cosca(configure: impl FnOnce(&mut cosca::Command)) -> CoscaProbe {
     configure(&mut cmd);
     let child = cmd.spawn().expect("spawn cosca identity probe child");
     let (sock, _) = listener.accept().expect("accept report socket");
-    let report = read_report(&sock);
+    let report = read_report_line(&sock);
     CoscaProbe { child, sock, report }
 }
 

--- a/tests/windows_creation_flags.rs
+++ b/tests/windows_creation_flags.rs
@@ -1,0 +1,349 @@
+//! Windows: a creation-flag intent reaches the child through EVERY backend cosca can route to.
+//!
+//! Four reachable configurations — sync/async × argv/`executable()` — because the routing rule
+//! sends an `executable()` (or any fd >= 3) to the raw `CreateProcessW` backend and everything
+//! else to std, and the two async backends are hand-mirrored copies whose parity the compiler
+//! does not enforce. A backend that drops a flag fails here rather than in review.
+//!
+//! Each leg names the backend it claims to exercise, and two independent things make that name
+//! true: the `executable()` legs assert the child's own `argv0` (only the raw backend can give a
+//! child an `argv[0]` that differs from the image it loaded), and the routing rule itself is one
+//! crate-internal function both routers read, pinned by
+//! `child::spawn::spawn_tests::routes_to_raw_backend_answers_for_executables_and_high_descriptors`.
+#![cfg(windows)]
+
+use std::net::{TcpListener, TcpStream};
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{escape_report_field, read_report_line, report_field, testbin};
+
+/// Which of the four reachable spawn configurations a leg drives.
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    SyncArgv,
+    SyncExecutable,
+    #[cfg(feature = "tokio")]
+    AsyncArgv,
+    #[cfg(feature = "tokio")]
+    AsyncExecutable,
+}
+
+impl Backend {
+    /// Whether this configuration routes to the raw `CreateProcessW` backend.
+    fn is_raw(self) -> bool {
+        match self {
+            Backend::SyncArgv => false,
+            Backend::SyncExecutable => true,
+            #[cfg(feature = "tokio")]
+            Backend::AsyncArgv => false,
+            #[cfg(feature = "tokio")]
+            Backend::AsyncExecutable => true,
+        }
+    }
+}
+
+/// A listener plus the argv every leg passes, so the four spawn shapes differ only in the two
+/// things under test: sync-vs-async and argv-vs-`executable()`.
+fn report_argv(addr: &str, me: &str) -> [String; 4] {
+    [
+        // argv[0]. The `executable()` legs override the loaded image, so this stays the bare
+        // name there and is what proves the raw backend ran.
+        "cosca_testbin".to_string(),
+        "report-console-identity".to_string(),
+        addr.to_string(),
+        me.to_string(),
+    ]
+}
+
+/// The one flag intent a leg asks for. An enum rather than a closure because the sync and async
+/// `Command` types share no trait, and widening the builder's accessors so one closure could
+/// serve both is a public-API decision this item does not own.
+#[derive(Clone, Copy, Debug)]
+enum Intent {
+    None,
+    NoWindow,
+    Detached,
+}
+
+/// Spawn a `report-console-identity` child through `backend`, read its report, tear it down, and
+/// return the report line.
+fn probe(backend: Backend, intent: Intent) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind report listener");
+    let addr = listener.local_addr().unwrap().to_string();
+    let me = std::process::id().to_string();
+    let mut argv = report_argv(&addr, &me);
+    if !backend.is_raw() {
+        // No `executable()` here, so `argv[0]` must carry the image path for the OS to find it.
+        argv[0] = testbin().to_string();
+    }
+
+    match backend {
+        Backend::SyncArgv | Backend::SyncExecutable => {
+            let mut cmd = cosca::Command::new();
+            cmd.args(&argv);
+            if backend.is_raw() {
+                cmd.executable(testbin());
+            }
+            match intent {
+                Intent::None => {}
+                Intent::NoWindow => {
+                    cmd.no_window();
+                }
+                Intent::Detached => {
+                    cmd.detached();
+                }
+            }
+            let child = cmd.spawn().expect("spawn creation-flag probe child");
+            let (sock, _) = listener.accept().expect("accept report socket");
+            let report = read_report_line(&sock);
+            drop(sock);
+            let _ = child.kill();
+            child.wait().expect("reap creation-flag probe child");
+            report
+        }
+        #[cfg(feature = "tokio")]
+        Backend::AsyncArgv | Backend::AsyncExecutable => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build a current-thread runtime");
+            rt.block_on(async {
+                let mut cmd = cosca::tokio::Command::new();
+                cmd.args(&argv);
+                if backend.is_raw() {
+                    cmd.executable(testbin());
+                }
+                match intent {
+                    Intent::None => {}
+                    Intent::NoWindow => {
+                        cmd.no_window();
+                    }
+                    Intent::Detached => {
+                        cmd.detached();
+                    }
+                }
+                let mut child = cmd.spawn().expect("spawn async creation-flag probe child");
+                let (sock, _) = listener.accept().expect("accept report socket");
+                let report = read_report_line(&sock);
+                drop(sock);
+                let _ = child.kill();
+                child.wait().await.expect("reap async creation-flag probe child");
+                report
+            })
+        }
+    }
+}
+
+/// Every `executable()` leg proves it reached the raw backend from the CHILD's own report:
+/// `argv[0]` differs from the image that ran, which only `CreateProcessW`'s independent
+/// `lpApplicationName`/`lpCommandLine` can produce — on the std path std sets `argv[0]` to the
+/// program it was given. See `spawn_unelevated`'s routing condition for why that is sufficient.
+fn assert_backend(backend: Backend, report: &str) {
+    if backend.is_raw() {
+        assert_eq!(
+            report_field(report, "argv0"),
+            escape_report_field("cosca_testbin"),
+            "{backend:?} must have reached the raw backend: {report}"
+        );
+    }
+}
+
+fn assert_no_window(backend: Backend) {
+    let report = probe(backend, Intent::NoWindow);
+    assert_eq!(
+        report_field(&report, "console"),
+        "1",
+        "{backend:?}: suppression still leaves a console: {report}"
+    );
+    assert_eq!(
+        report_field(&report, "sees_caller"),
+        "0",
+        "{backend:?} dropped the window-suppression request: {report}"
+    );
+    assert_backend(backend, &report);
+}
+
+fn assert_detached(backend: Backend) {
+    let report = probe(backend, Intent::Detached);
+    // A MEASURED absence, so a broken probe reports `?` and fails rather than passing.
+    assert_eq!(
+        report_field(&report, "console"),
+        "0",
+        "{backend:?} dropped the detach request: {report}"
+    );
+    assert_backend(backend, &report);
+}
+
+fn assert_plain_control(backend: Backend) {
+    let report = probe(backend, Intent::None);
+    assert_eq!(
+        report_field(&report, "sees_caller"),
+        "1",
+        "{backend:?} control: a plain child shares OUR console: {report}"
+    );
+    assert_backend(backend, &report);
+}
+
+#[test]
+fn no_window_reaches_the_child_via_sync_argv() {
+    assert_no_window(Backend::SyncArgv);
+}
+
+#[test]
+fn no_window_reaches_the_child_via_sync_executable() {
+    assert_no_window(Backend::SyncExecutable);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn no_window_reaches_the_child_via_async_argv() {
+    assert_no_window(Backend::AsyncArgv);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn no_window_reaches_the_child_via_async_executable() {
+    assert_no_window(Backend::AsyncExecutable);
+}
+
+#[test]
+fn detached_reaches_the_child_via_sync_argv() {
+    assert_detached(Backend::SyncArgv);
+}
+
+#[test]
+fn detached_reaches_the_child_via_sync_executable() {
+    assert_detached(Backend::SyncExecutable);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn detached_reaches_the_child_via_async_argv() {
+    assert_detached(Backend::AsyncArgv);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn detached_reaches_the_child_via_async_executable() {
+    assert_detached(Backend::AsyncExecutable);
+}
+
+/// The control legs. Without them every assertion above is satisfiable by a helper that never
+/// reached the backend it names — "not in our console" is also what a child that failed to
+/// register, or was never spawned at all, would look like.
+#[test]
+fn a_plain_child_joins_the_callers_console_via_sync_argv() {
+    assert_plain_control(Backend::SyncArgv);
+}
+
+#[test]
+fn a_plain_child_joins_the_callers_console_via_sync_executable() {
+    assert_plain_control(Backend::SyncExecutable);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn a_plain_child_joins_the_callers_console_via_async_argv() {
+    assert_plain_control(Backend::AsyncArgv);
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+fn a_plain_child_joins_the_callers_console_via_async_executable() {
+    assert_plain_control(Backend::AsyncExecutable);
+}
+
+/// Each raw backend builds its own `Prepared` literal, so its cooperative-signal derivation is a
+/// SEPARATE site from `prepare`'s: the std-path twin passing says nothing about this one.
+///
+/// Two children, so neither a constant nor an unwired derivation passes: a derivation reading
+/// only the containment half of the word reports `ConsoleGroup` for both.
+#[test]
+fn a_no_window_contained_child_reports_no_in_process_route_via_the_raw_backend() {
+    use cosca::GracefulMechanism;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let me = std::process::id().to_string();
+
+    let spawn_one = |hidden: bool| -> (cosca::Child, TcpStream) {
+        let mut cmd = cosca::Command::new();
+        cmd.executable(testbin()).args(report_argv(&addr, &me)).contain();
+        if hidden {
+            cmd.no_window();
+        }
+        let child = cmd.spawn().expect("spawn contained raw-backend child");
+        let (sock, _) = listener.accept().expect("accept");
+        let report = read_report_line(&sock);
+        assert_eq!(
+            report_field(&report, "argv0"),
+            escape_report_field("cosca_testbin"),
+            "this leg must have reached the raw backend: {report}"
+        );
+        (child, sock)
+    };
+
+    let (plain, plain_sock) = spawn_one(false);
+    assert_eq!(
+        plain.graceful_mechanism(),
+        GracefulMechanism::ConsoleGroup,
+        "a contained raw-backend child leads a group in OUR console"
+    );
+    let (hidden, hidden_sock) = spawn_one(true);
+    assert_eq!(
+        hidden.graceful_mechanism(),
+        GracefulMechanism::OtherConsoleGroup,
+        "the raw backend's own derivation must read the composed word"
+    );
+
+    for (child, sock) in [(plain, plain_sock), (hidden, hidden_sock)] {
+        drop(sock);
+        let _ = child.kill_tree();
+        child.wait().expect("reap");
+    }
+}
+
+/// The async raw backend has a `Prepared` literal of its own — a third derivation site.
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn an_async_no_window_contained_child_reports_no_in_process_route_via_the_raw_backend() {
+    use cosca::GracefulMechanism;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let me = std::process::id().to_string();
+
+    let spawn_one = |hidden: bool| -> (cosca::tokio::Child, TcpStream) {
+        let mut cmd = cosca::tokio::Command::new();
+        cmd.executable(testbin()).args(report_argv(&addr, &me)).contain();
+        if hidden {
+            cmd.no_window();
+        }
+        let child = cmd.spawn().expect("spawn contained async raw-backend child");
+        let (sock, _) = listener.accept().expect("accept");
+        let report = read_report_line(&sock);
+        assert_eq!(
+            report_field(&report, "argv0"),
+            escape_report_field("cosca_testbin"),
+            "this leg must have reached the raw backend: {report}"
+        );
+        (child, sock)
+    };
+
+    let (plain, plain_sock) = spawn_one(false);
+    assert_eq!(plain.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    let (hidden, hidden_sock) = spawn_one(true);
+    assert_eq!(
+        hidden.graceful_mechanism(),
+        GracefulMechanism::OtherConsoleGroup,
+        "the async raw backend's own derivation must read the composed word"
+    );
+
+    for (mut child, sock) in [(plain, plain_sock), (hidden, hidden_sock)] {
+        drop(sock);
+        let _ = child.kill_tree();
+        child.wait().await.expect("reap");
+    }
+}

--- a/tests/windows_false_success.rs
+++ b/tests/windows_false_success.rs
@@ -129,7 +129,8 @@ fn assert_false_success(expected_containment: Containment, configure: impl Fn(&m
     assert_eq!(
         child.graceful_mechanism(),
         GracefulMechanism::OtherConsoleGroup,
-        "cosca's honest report of the route; a derivation reading only the containment half of          the creation-flag word says ConsoleGroup here"
+        "cosca's honest report of the route; a derivation reading only the containment half of \
+         the creation-flag word says ConsoleGroup here"
     );
 
     child
@@ -140,7 +141,8 @@ fn assert_false_success(expected_containment: Containment, configure: impl Fn(&m
     assert_eq!(
         status.code(),
         Some(0),
-        "the child exited on OUR release byte, so the cooperative op delivered nothing; a          delivered break would have ended it with STATUS_CONTROL_C_EXIT ({STATUS_CONTROL_C_EXIT})"
+        "the child exited on OUR release byte, so the cooperative op delivered nothing; a \
+         delivered break would have ended it with STATUS_CONTROL_C_EXIT ({STATUS_CONTROL_C_EXIT})"
     );
     drop(sock);
 

--- a/tests/windows_false_success.rs
+++ b/tests/windows_false_success.rs
@@ -1,0 +1,256 @@
+//! Windows: a child whose console is not ours gets a **false success** from the cooperative
+//! shutdown ops — they return `Ok` and deliver nothing.
+//!
+//! This is wrong-but-current behaviour, pinned deliberately. Nothing in cosca can tell a target
+//! that has not registered with a console yet from one that is in another console, so nothing
+//! here refuses such a child; what cosca reports honestly is the *route*, as
+//! `graceful_mechanism() == OtherConsoleGroup`. The gap closes when a console-joining helper
+//! exists, and this file is what makes that landing flip a test rather than change behaviour in
+//! silence.
+//!
+//! The control leg is not optional: without a leg that measures a DELIVERED signal under the same
+//! handshake, "still alive" is satisfied by any build that never signals anything.
+//!
+//! Console-list hygiene: each false-success leg signals an out-of-console pid, which leaves one
+//! persistent dead entry in the caller's console process list. CI runners get a fresh console per
+//! job; locally, run this suite from a fresh terminal. No test here asserts the absence of a pid
+//! it did not just spawn.
+#![cfg(windows)]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+use cosca::identity::Liveness;
+use cosca::{ContainMode, Containment, GracefulMechanism};
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::testbin;
+
+/// Spawn a testbin control child with arbitrary builder configuration, and read its 1-byte tag
+/// BEFORE returning — the real edge proving the child is running and has completed console
+/// registration.
+///
+/// The handshake applies to every leg, not only the control. Without it every child sits in the
+/// measured pre-registration window, where a console-group signal IS delivered and kills the
+/// child at loader init — so "still alive" would be false for the wrong reason in the
+/// false-success legs, and the control would fail too.
+///
+/// `common::spawn_control` cannot serve: it takes no extra configuration.
+fn spawn_configured(mode: &str, configure: impl Fn(&mut cosca::Command)) -> (cosca::Child, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = cosca::Command::new();
+    cmd.executable(testbin())
+        .args(["cosca_testbin", mode, addr.as_str(), "R"]);
+    configure(&mut cmd);
+    let child = cmd.spawn().expect("spawn control child");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read tag");
+    assert_eq!(&tag, b"R", "wrong control tag");
+    (child, sock)
+}
+
+#[cfg(feature = "tokio")]
+fn spawn_configured_async(
+    mode: &str,
+    configure: impl Fn(&mut cosca::tokio::Command),
+) -> (cosca::tokio::Child, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let mut cmd = cosca::tokio::Command::new();
+    cmd.executable(testbin())
+        .args(["cosca_testbin", mode, addr.as_str(), "R"]);
+    configure(&mut cmd);
+    let child = cmd.spawn().expect("spawn async control child");
+    let (mut sock, _) = listener.accept().expect("accept");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read tag");
+    assert_eq!(&tag, b"R", "wrong control tag");
+    (child, sock)
+}
+
+/// THE CONTROL. A contained root with no flag methods really receives the break: its own console
+/// ctrl handler writes `B` back over its socket, which is the only positive evidence of delivery
+/// — the Win32 return value is evidence in neither direction.
+///
+/// Without this leg the three below pass against any build that never signals anything.
+#[test]
+fn a_plain_contained_root_really_receives_the_break() {
+    let (child, mut sock) = spawn_configured("control-block-ack-break", |c| {
+        c.contain();
+    });
+    assert_eq!(child.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    child.terminate_tree().expect("terminate_tree on a contained root");
+
+    let mut ack = [0u8; 1];
+    sock.read_exact(&mut ack)
+        .expect("the child's ctrl handler must write its ack; EOF here means it died instead");
+    assert_eq!(&ack, b"B", "the child acked something other than CTRL_BREAK");
+
+    drop(sock);
+    child.kill_tree().expect("kill_tree");
+    child.wait().expect("reap");
+}
+
+/// A delivered `CTRL_BREAK` ends a handler-less child with `STATUS_CONTROL_C_EXIT`. Measured on
+/// Windows 11 26100, 20 consecutive runs each way: a plain contained child exits with this, and a
+/// suppressed or detached one exits `0` because nothing reached it and it was released by the
+/// test's own byte.
+const STATUS_CONTROL_C_EXIT: i32 = 0xC000_013Au32 as i32;
+
+/// The shared body of the three false-success legs: a contained root whose creation flags put it
+/// in a console of its own.
+///
+/// `control-block` installs NO break handler, so a delivered break kills it via the default
+/// disposition — which is exactly what a plain contained child does under the same handshake.
+///
+/// **The subject is HOW the child died, so the assertion is on its termination status.** After
+/// the cooperative op has reported success, the child is released through its own socket — a real
+/// edge, not a duration — and must then exit `0`: it ended on the test's byte, having received
+/// nothing. A delivered break would have ended it with `STATUS_CONTROL_C_EXIT` first. A
+/// `Liveness` poll taken at the instant the op returns cannot serve here: measured, it reads
+/// `Alive` for a plain contained child that is already dying, so it is the same value in both
+/// worlds.
+///
+/// The second child is for the other half: the FORCED op still works on such a child even though
+/// the cooperative one reached nobody. `graceful_shutdown_tree` waits out the exit before it
+/// returns, so the `Dead` there is an edge and not a poll.
+fn assert_false_success(expected_containment: Containment, configure: impl Fn(&mut cosca::Command)) {
+    let (child, mut sock) = spawn_configured("control-block", &configure);
+    assert_eq!(
+        child.containment(),
+        expected_containment,
+        "this test is about the wrong thing if containment did not take"
+    );
+    assert_eq!(
+        child.graceful_mechanism(),
+        GracefulMechanism::OtherConsoleGroup,
+        "cosca's honest report of the route; a derivation reading only the containment half of          the creation-flag word says ConsoleGroup here"
+    );
+
+    child
+        .terminate_tree()
+        .expect("the cooperative op reports success — that is the gap this pins");
+    sock.write_all(b"x").expect("release the child through its own socket");
+    let status = child.wait().expect("reap");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "the child exited on OUR release byte, so the cooperative op delivered nothing; a          delivered break would have ended it with STATUS_CONTROL_C_EXIT ({STATUS_CONTROL_C_EXIT})"
+    );
+    drop(sock);
+
+    // A second child, because the first is already gone: the FORCED half of the graceful op
+    // still tears such a tree down.
+    let (child, sock) = spawn_configured("control-block", &configure);
+    child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .expect("the forced half tears the tree down");
+    assert_eq!(child.is_alive(), Liveness::Dead, "the forced half really ended it");
+    drop(sock);
+}
+
+#[test]
+fn a_no_window_contained_root_gets_a_false_success() {
+    assert_false_success(Containment::JobObject, |c| {
+        c.contain().no_window();
+    });
+}
+
+#[test]
+fn a_detached_contained_root_gets_a_false_success() {
+    assert_false_success(Containment::JobObject, |c| {
+        c.contain().detached();
+    });
+}
+
+/// A distinct route into the same call site: on Windows `Attached::TreeWalk` reaches
+/// `containment::windows::terminate` through `treewalk::terminate`, so a change made in one arm
+/// only would miss it.
+#[test]
+fn a_treewalk_contained_root_gets_a_false_success_too() {
+    assert_false_success(Containment::TreeWalk, |c| {
+        c.contain_with(ContainMode::TreeWalk).no_window();
+    });
+}
+
+// ===== async mirrors: parity is not compiler-enforced =====
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn an_async_plain_contained_root_really_receives_the_break() {
+    let (mut child, mut sock) = spawn_configured_async("control-block-ack-break", |c| {
+        c.contain();
+    });
+    assert_eq!(child.graceful_mechanism(), GracefulMechanism::ConsoleGroup);
+    child.terminate_tree().expect("terminate_tree on a contained root");
+
+    let mut ack = [0u8; 1];
+    sock.read_exact(&mut ack)
+        .expect("the child's ctrl handler must write its ack; EOF here means it died instead");
+    assert_eq!(&ack, b"B");
+
+    drop(sock);
+    child.kill_tree().expect("kill_tree");
+    child.wait().await.expect("reap");
+}
+
+#[cfg(feature = "tokio")]
+async fn assert_false_success_async(expected_containment: Containment, configure: impl Fn(&mut cosca::tokio::Command)) {
+    let (mut child, mut sock) = spawn_configured_async("control-block", &configure);
+    assert_eq!(child.containment(), expected_containment);
+    assert_eq!(
+        child.graceful_mechanism(),
+        GracefulMechanism::OtherConsoleGroup,
+        "the async derivation must read the composed word too"
+    );
+
+    child.terminate_tree().expect("the cooperative op reports success");
+    sock.write_all(b"x").expect("release the child through its own socket");
+    let status = child.wait().await.expect("reap");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "the child exited on OUR release byte, so the cooperative op delivered nothing"
+    );
+    drop(sock);
+
+    let (mut child, sock) = spawn_configured_async("control-block", &configure);
+    child
+        .graceful_shutdown_tree(Duration::ZERO)
+        .await
+        .expect("the forced half tears the tree down");
+    assert_eq!(child.is_alive(), Liveness::Dead);
+    drop(sock);
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn an_async_no_window_contained_root_gets_a_false_success() {
+    assert_false_success_async(Containment::JobObject, |c| {
+        c.contain().no_window();
+    })
+    .await;
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn an_async_detached_contained_root_gets_a_false_success() {
+    assert_false_success_async(Containment::JobObject, |c| {
+        c.contain().detached();
+    })
+    .await;
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn an_async_treewalk_contained_root_gets_a_false_success_too() {
+    assert_false_success_async(Containment::TreeWalk, |c| {
+        c.contain_with(ContainMode::TreeWalk).no_window();
+    })
+    .await;
+}


### PR DESCRIPTION
Closes #50
Closes #51

Four builder methods — `no_window()` (portable), and `detached()` / `breakaway_from_job()` / `creation_flags(u32)` on Windows — with one pure function composing the `dwCreationFlags` word cosca supplies for all three Windows spawn backends, and a second pure function classifying a spawn *failure* the OS has already returned.

Three things the diff does not make obvious.

**This adds no console-related refusal, and a hidden or detached child's graceful tree ops return `Ok` and deliver nothing.** Window suppression puts the child in a console of its own, so an in-process `GenerateConsoleCtrlEvent` cannot reach it — but Windows reports success for an undeliverable event, and non-delivery is not knowable from inside this process, so nothing here refuses such a child. That is a pre-existing gap; what is new is that it is now **pinned by tests** (`tests/windows_false_success.rs`), so a console-broker route landing flips a test rather than changing behaviour in silence. The false-success legs assert the child's *termination status*: after the cooperative op reports success, the child is released through its own socket and must exit `0`, where a delivered `CTRL_BREAK` would have ended it with `STATUS_CONTROL_C_EXIT`. Measured 20 runs each way, cleanly separated.

**`graceful_mechanism()` now reflects caller-supplied flags, so a `.contain().no_window()` child reports `OtherConsoleGroup` — no in-process route.** This is not a behaviour change: no child could carry those flags before this PR, and both console-group variants share one dispatch arm in `graceful::signal`. It is a correctness obligation of adding the flags — feeding the derivation the containment half of the word alone would tell a caller they have a direct route to a child they deliberately hid.

**`breakaway_from_job()` cannot succeed from inside a cosca-contained tree.** cosca's own containment job sets neither breakaway limit, and a member process cannot relax the limits of the job that holds it. The method still ships, because the case that motivated it is a program held by an *outside* job that permits escape; the limitation is in its rustdoc, and the failure message names who would have to change the job's limits rather than instructing the caller to do it.

## Also worth knowing

- Validation is at spawn, not in the setters: a pairwise rule in a setter would give a verdict that depends on builder call order. `prepare` becomes `Result`, with the Windows composition hoisted above its uncontained early return — which is what used to drop a caller's flags on an uncontained spawn entirely.
- Ten bits are reserved and refused by symbolic name with a replacement. `creation_flags` **replaces** rather than accumulating, matching `std::os::windows::process::CommandExt`.
- The ambient job is probed **after** a failed spawn, never before: spawning does not disturb job membership, but membership changes on its own, so a pre-spawn guard would decide the outcome from possibly-stale state. Classification happens at the three spawn syscalls, not around the spawn tree, so an access-denied from stdio resolution or the post-spawn attach is never blamed on a flag.
- A refused spawn now leaves this process unmutated: both raw backends composed and validated *after* `clear_std_handle_inheritance`, a process-global `SetHandleInformation` nothing undoes.
- `routes_to_raw_backend` is extracted and read by both routers, **above** each one's `std::mem::take(cmd.fds_mut())`. Evaluated after the take it collapses to "does it have an `executable()`", which would silently drop a high-descriptor-only command's descriptors on the std path (whose fd >= 3 collection is unix-only). That branch had no coverage anywhere; it does now.
- `CREATE_NEW_CONSOLE` stays reserved, on two reasons rather than the three cosca#58 records; that issue has been corrected.

## Verification

Windows 11 26100, `--features tokio`: 723 tests before, 798 after, 0 failures either way. Exactly one pre-existing test was removed — `windows_contain_setup_records_the_mechanism_of_the_flags_it_chose`, relocated to the composed word as `the_composed_word_reports_a_different_mechanism_for_each_containment_shape`, because after the hoist nothing derives a mechanism from the containment half alone. Clippy `-D warnings` across `--all-targets --all-features`, `cargo fmt --check`, and `RUSTDOCFLAGS=-D warnings cargo doc` are clean. The Unix legs are CI-only.