### PR TITLE
fix(tokio): signal the root on the dropping thread and reap on a pool thread (closes #105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ name = "cosca"
 version = "0.2.0"
 dependencies = [
  "command-fds",
+ "crossbeam-channel",
  "getrandom",
  "libc",
  "log",
@@ -55,6 +56,21 @@ dependencies = [
  "windows",
  "zeroize",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-
 
 [features]
 pty = []
-tokio = ["dep:tokio"]
+tokio = ["dep:tokio", "dep:crossbeam-channel"]
 # Serialize a ProcessIdRecord so an identity survives a supervisor restart.
 serde = ["dep:serde"]
 
@@ -34,6 +34,11 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # reactor-native death-watch); `time` solely for the grace bound on it. `sync` backs the
 # per-instance wait observer (a `#[cfg(test)]` oneshot seam) the raw async backend is tested with.
 tokio = { version = "1", optional = true, features = ["process", "rt", "io-util", "macros", "net", "sync", "time"] }
+# The reaper pool's job queue. `std::sync::mpsc::Receiver` is neither `Sync` nor `Clone`, so the
+# std route is a hand-rolled queue behind a mutex whose most likely defect — holding the guard
+# across the job — collapses the pool's bulkhead into a serial reaper. Each worker owns a cloned
+# MPMC receiver instead, so no lock exists to get wrong.
+crossbeam-channel = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/child.rs
+++ b/src/child.rs
@@ -525,6 +525,9 @@ impl Drop for Child {
             );
             log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
         }
+        // Blocks until the child has exited (except when the kill failed). Deliberately unlike
+        // the async twin, `cosca::tokio::Child`'s `Drop`, which only signals: a sync caller owns
+        // the thread it is blocking, so "after drop, the child is gone" costs nobody a worker.
         self.proc.teardown_on_drop();
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -202,6 +202,9 @@ impl Command {
         self
     }
 
+    /// Tear the child (and its contained tree) down when the handle drops. On by default.
+    /// The sync [`Child`](crate::Child) blocks until the child has exited; the async
+    /// [`Child`](crate::tokio::Child) only signals — see its `Drop` for what each guarantees.
     pub fn kill_on_drop(&mut self, yes: bool) -> &mut Command {
         self.kill_on_drop = yes;
         self

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -26,7 +26,7 @@ pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
 /// option placed there is silently eaten and `--exact` degrades to substring matching.
 /// `--test-threads=1` keeps a future filter that matches more than one test from running them
 /// concurrently inside a process the caller is about to signal.
-#[cfg(windows)]
+#[cfg(any(windows, feature = "tokio"))]
 pub(crate) fn fixture_argv(test: &str) -> [&str; 4] {
     ["cosca_unit_tests", "--test-threads=1", "--exact", test]
 }
@@ -134,4 +134,68 @@ fn fixture_registers_then_blocks() {
     sock.flush().expect("flush registration tag");
     let mut sink = [0u8; 1];
     let _ = sock.read(&mut sink);
+}
+
+/// The fully-qualified libtest path of [`fixture_control_block`].
+#[cfg(feature = "tokio")]
+pub(crate) const FIXTURE_CONTROL_BLOCK_TEST: &str = "test_child::fixture_control_block";
+
+/// The env var carrying the `127.0.0.1:<port>` address [`fixture_control_block`] tags. Its mere
+/// presence also tells the fixture it was re-exec'd deliberately rather than picked up by an
+/// ordinary, unfiltered suite run.
+#[cfg(feature = "tokio")]
+pub(crate) const FIXTURE_CONTROL_BLOCK_ADDR_ENV: &str = "COSCA_FIXTURE_CONTROL_BLOCK_ADDR";
+
+/// A child that reports readiness and then blocks until the caller releases or kills it: a no-op
+/// when picked up by an ordinary, unfiltered suite run ([`FIXTURE_CONTROL_BLOCK_ADDR_ENV`] is
+/// unset there). Re-executed via `current_exe() --exact` [`FIXTURE_CONTROL_BLOCK_TEST`] with that
+/// var set, it connects to the caller's listener, writes one tag byte, then blocks on a 1-byte
+/// read of that same socket and RETURNS as soon as the read returns — so a caller that writes a
+/// byte gets a clean voluntary exit, and a caller that kills it gets the socket's EOF.
+///
+/// Mirrors [`fixture_survives_group_signal`]'s filtered-re-exec idiom (see
+/// [`spawn_a_process_that_exits`] for why the filter is mandatory), and deliberately takes NO
+/// `spawn_lock()`: see [`spawn_async_blocker`].
+#[cfg(feature = "tokio")]
+#[test]
+fn fixture_control_block() {
+    let Some(addr) = std::env::var_os(FIXTURE_CONTROL_BLOCK_ADDR_ENV) else {
+        return; // picked up by an ordinary suite run — deliberately inert
+    };
+    use std::io::{Read, Write};
+
+    let mut sock = std::net::TcpStream::connect(addr.to_str().expect("utf8 addr")).expect("connect control socket");
+    sock.write_all(b"R").expect("write readiness tag");
+    sock.flush().expect("flush readiness tag");
+    let mut sink = [0u8; 1];
+    let _ = sock.read(&mut sink);
+}
+
+/// Spawn [`fixture_control_block`] through `cosca::tokio` and return its handle plus the control
+/// socket, already past the readiness tag — so the child is provably executing its own code.
+///
+/// **Takes no `spawn_lock()`, deliberately.** That lock is a plain non-reentrant mutex and
+/// cosca's own async spawn takes it internally, so a helper holding it across a cosca spawn
+/// deadlocks on its own thread. Every existing helper that takes it spawns via
+/// `std::process::Command`; the cosca-spawning helpers do not.
+///
+/// Uncontained (so the tree teardown is a verified no-op) and stdin INHERITED (so closing the
+/// parent's stdio cannot make the child exit on its own). Spawned via `executable()`, which puts
+/// Windows on the raw `CreateProcessW` backend.
+#[cfg(feature = "tokio")]
+pub(crate) fn spawn_async_blocker() -> (crate::tokio::Child, std::net::TcpStream) {
+    use std::io::Read as _;
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind control listener");
+    let addr = listener.local_addr().expect("local_addr").to_string();
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = crate::tokio::Command::new();
+    cmd.executable(&exe)
+        .args(fixture_argv(FIXTURE_CONTROL_BLOCK_TEST))
+        .env(FIXTURE_CONTROL_BLOCK_ADDR_ENV, &addr);
+    let child = cmd.spawn().expect("spawn the control-block fixture");
+    let (mut sock, _) = listener.accept().expect("accept the control socket");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read the readiness tag");
+    assert_eq!(&tag, b"R", "unexpected control tag");
+    (child, sock)
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -658,6 +658,15 @@ impl Drop for Child {
         }
         // No `debug_assert` here: a failed kill is a designed outcome the branch below serves (a
         // higher-integrity elevated child), and asserting would panic inside a destructor.
+        // The test seam REPLACES the kill rather than masking its result — a masked kill would
+        // still have signalled the child, and the branch below is about one that was not.
+        #[cfg(test)]
+        let killed = if reaper::fault::take_force_kill_failure() {
+            Err(Error::Io(std::io::Error::other("forced kill failure (test seam)")))
+        } else {
+            proc.start_kill()
+        };
+        #[cfg(not(test))]
         let killed = proc.start_kill();
         if killed.is_err() {
             if !matches!(proc.try_wait(), Ok(Some(_))) {

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -8,6 +8,10 @@ mod graceful;
 mod proc_source;
 pub(crate) use proc_source::ProcSource;
 
+#[path = "child/reaper.rs"]
+mod reaper;
+pub(crate) use reaper::reap_now;
+
 use std::collections::BTreeMap;
 use std::process::ExitStatus;
 
@@ -101,7 +105,13 @@ impl Child {
     /// Unix-only: the Windows elevation arm builds its child in-module with no deferred password.
     #[cfg(unix)]
     pub(super) fn reap_blocking(&mut self) {
-        self.proc.as_mut().expect(PROC_TAKEN).reap_now_on_drop(self.id.pid());
+        let pid = self.id.pid();
+        let proc = self.proc.as_mut().expect(PROC_TAKEN);
+        // A failed kill is not a live process to wait on — the same early return `reap_now` makes,
+        // spelled out because the wait no longer carries a kill of its own.
+        if proc.start_kill().is_ok() {
+            proc.wait_and_reap(pid);
+        }
     }
 
     /// The child's stable identity — valid after `wait`.
@@ -616,11 +626,19 @@ impl Child {
 
 impl Drop for Child {
     fn drop(&mut self) {
+        // The opt-out/`detach()` contract: nothing is signalled and nothing is logged.
         if !self.kill_on_drop {
             return;
         }
-        // Tree teardown — the SOLE coverage for descendants (reap_now only guarantees the root),
-        // so surface a real mechanism failure in debug. A no-op for an uncontained child.
+        #[cfg(test)]
+        let probe = reaper::test_probe::take();
+        #[cfg(test)]
+        if let Some(p) = probe.as_ref() {
+            let _ = p.entered.send(std::thread::current().id());
+        }
+        // Tree teardown — the SOLE coverage for descendants (the root's own kill below reaches
+        // only the root), so surface a real mechanism failure in debug. A no-op for an
+        // uncontained child.
         let tree = self.attached.hard_kill();
         if let Err(e) = &tree {
             debug_assert!(
@@ -630,79 +648,37 @@ impl Drop for Child {
             log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
         }
         let _ = tree;
-        // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
-        // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend
-        // (tokio field-drop reap vs the raw handle's kill-then-wait).
-        let pid = self.id.pid();
-        self.proc.as_mut().expect(PROC_TAKEN).reap_now_on_drop(pid);
-    }
-}
 
-/// Guaranteed synchronous teardown, shared by `Drop` and the spawn error path: kill the child,
-/// then block until it has exited. On Unix we wait with `WNOWAIT` (NOT reaping), so tokio's own
-/// `Child` field-drop reaps the zombie synchronously in its drop (its `try_wait` returns
-/// `Ok(Some)`, not a park-dependent orphan enqueue) — a guaranteed reap before `Drop` returns.
-/// We only wait while tokio still owns the child (`id().is_some()`), which pins the pid; once
-/// tokio is `Done` (a prior `wait()` reaped it), the pid may be recycled and we must not wait on
-/// it. `done_ok` says whether an already-`Done` child is legal here: `true` for `Drop` (the user
-/// may have `wait()`ed), `false` for the spawn-error path (the child was never awaited).
-/// **Invariant:** no `wait()` future for this child is in flight when this runs.
-pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: bool) {
-    // `start_kill` bounds the wait below — it MUST run in release (NOT inside `debug_assert!`,
-    // whose argument is stripped in release). A no-op on an already-exited child.
-    let killed = child.start_kill();
-    debug_assert!(killed.is_ok(), "start_kill of an owned child should not fail");
-    // A failed start_kill means this is not a live process to wait on (ESRCH = already exited;
-    // EPERM is impossible for our own child) — skip, so a kill failure can never turn the bounded
-    // exit-wait into an unbounded block. tokio's field-drop reaps any leftover zombie.
-    if killed.is_err() {
-        return;
-    }
-    // tokio `Done` ⇒ already reaped, pid possibly recycled ⇒ nothing to do (the recycled-pid wait
-    // hazard the sync side avoids by holding a handle).
-    if child.id().is_none() {
-        debug_assert!(
-            done_ok,
-            "reap_now found an already-reaped child where one was impossible"
-        );
-        return;
-    }
-    #[cfg(unix)]
-    {
-        // `nix` doesn't expose `waitid` on macOS (0.31 configures it out), so call `libc::waitid`
-        // directly (WEXITED | WNOWAIT: block until exit without reaping) — portable across every Unix
-        // target and the identical syscall.
-        debug_assert!(pid <= i32::MAX as u32, "pid {pid} exceeds i32::MAX");
-        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
-        loop {
-            // SAFETY: a well-formed `waitid` call; `info` is a valid, owned, zeroed `siginfo_t` the
-            // kernel fills in. WNOWAIT leaves the child reapable for tokio's in-drop reap.
-            let rc = unsafe { libc::waitid(libc::P_PID, pid as libc::id_t, &mut info, libc::WEXITED | libc::WNOWAIT) };
-            if rc == 0 {
-                break;
-            }
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            // id() was Some above (tokio un-reaped ⇒ pid pinned), so no ECHILD / other errno should
-            // occur — a debug tripwire, with a safe release `break`.
-            debug_assert!(false, "waitid in reap_now failed unexpectedly: {err}");
-            break;
+        let pid = self.id.pid();
+        let mut proc = self.proc.take().expect(PROC_TAKEN);
+        // Already reaped: there is no signal to issue and no wait to hand over. The remaining
+        // resources release on the dropping thread, with this handle.
+        if proc.is_reaped() {
+            return;
         }
-    }
-    #[cfg(windows)]
-    {
-        use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
-        use windows::Win32::System::Threading::{WaitForSingleObject, INFINITE};
-        let _ = pid;
-        let h = child.raw_handle().expect("tokio owns the handle while id() is Some");
-        // SAFETY: tokio owns and (on its field-drop) closes the handle; we only wait on it.
-        // INFINITE is bounded by `start_kill` above.
-        let waited = unsafe { WaitForSingleObject(HANDLE(h), INFINITE) };
-        debug_assert!(
-            waited == WAIT_OBJECT_0,
-            "reap_now did not observe the child's exit: {waited:?}"
-        );
+        // No `debug_assert` here: a failed kill is a designed outcome the branch below serves (a
+        // higher-integrity elevated child), and asserting would panic inside a destructor.
+        let killed = proc.start_kill();
+        if killed.is_err() {
+            if !matches!(proc.try_wait(), Ok(Some(_))) {
+                log::warn!("async child {pid} could not be terminated on drop; leaving it running");
+            }
+            return;
+        }
+        // Every field holding an OS resource travels with the backend, so its release stays
+        // ordered after the reap, as it is on this handle today.
+        reaper::submit(reaper::ReapJob {
+            proc,
+            attached: std::mem::replace(&mut self.attached, Attached::None),
+            pipes: std::mem::take(&mut self.pipes),
+            owned_std: std::mem::take(&mut self.owned_std),
+            pid,
+            #[cfg(test)]
+            origin: std::thread::current().id(),
+            #[cfg(test)]
+            probe,
+            #[cfg(test)]
+            force_panic: false,
+        });
     }
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -27,10 +27,16 @@ pub(super) type FdPipes = BTreeMap<Fd, ParentEnd>;
 #[cfg(windows)]
 pub(super) type FdPipes = BTreeMap<Fd, super::stdio::OwnedStd>;
 
+/// `proc` is `Some` for the handle's whole life: only [`Drop`] takes it, and nothing else runs
+/// on the handle after that.
+pub(super) const PROC_TAKEN: &str = "the async child's process backend is taken only by Drop";
+
 #[derive(Debug)]
 pub struct Child {
     // `pub(super)`: the sibling `pump` module borrows the backend for `communicate`'s `wait` future.
-    pub(super) proc: ProcSource,
+    // `Option` because `Drop` takes `&mut self` and cannot move the backend out otherwise; the
+    // taken state is in the type system rather than in a `ManuallyDrop` the compiler cannot check.
+    pub(super) proc: Option<ProcSource>,
     id: ProcessId,
     attached: Attached,
     kill_on_drop: bool,
@@ -60,7 +66,7 @@ impl Child {
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
-            proc,
+            proc: Some(proc),
             id,
             attached: attachment.attached,
             kill_on_drop,
@@ -95,7 +101,7 @@ impl Child {
     /// Unix-only: the Windows elevation arm builds its child in-module with no deferred password.
     #[cfg(unix)]
     pub(super) fn reap_blocking(&mut self) {
-        self.proc.reap_now_on_drop(self.id.pid());
+        self.proc.as_mut().expect(PROC_TAKEN).reap_now_on_drop(self.id.pid());
     }
 
     /// The child's stable identity — valid after `wait`.
@@ -118,25 +124,37 @@ impl Child {
         if let Some(owned) = self.take_owned_in(crate::stdio::Fd::STDIN) {
             return Some(super::stdio::ChildStdin { inner: owned });
         }
-        self.proc.take_stdin().map(|s| super::stdio::ChildStdin {
-            inner: super::stdio::InInner::Tokio(s),
-        })
+        self.proc
+            .as_mut()
+            .expect(PROC_TAKEN)
+            .take_stdin()
+            .map(|s| super::stdio::ChildStdin {
+                inner: super::stdio::InInner::Tokio(s),
+            })
     }
     pub fn stdout(&mut self) -> Option<super::stdio::ChildStdout> {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDOUT) {
             return Some(super::stdio::ChildStdout { inner: owned });
         }
-        self.proc.take_stdout().map(|s| super::stdio::ChildStdout {
-            inner: super::stdio::OutInner::Stdout(s),
-        })
+        self.proc
+            .as_mut()
+            .expect(PROC_TAKEN)
+            .take_stdout()
+            .map(|s| super::stdio::ChildStdout {
+                inner: super::stdio::OutInner::Stdout(s),
+            })
     }
     pub fn stderr(&mut self) -> Option<super::stdio::ChildStderr> {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDERR) {
             return Some(super::stdio::ChildStderr { inner: owned });
         }
-        self.proc.take_stderr().map(|s| super::stdio::ChildStderr {
-            inner: super::stdio::OutInner::Stderr(s),
-        })
+        self.proc
+            .as_mut()
+            .expect(PROC_TAKEN)
+            .take_stderr()
+            .map(|s| super::stdio::ChildStderr {
+                inner: super::stdio::OutInner::Stderr(s),
+            })
     }
 
     /// Take the stashed our-owned read end of an Out-direction merge target (plain
@@ -350,11 +368,11 @@ impl Child {
     /// Block until the child exits, returning its status. For a bounded wait use
     /// `tokio::time::timeout(d, child.wait())`.
     pub async fn wait(&mut self) -> Result<ExitStatus, Error> {
-        self.proc.wait().await
+        self.proc.as_mut().expect(PROC_TAKEN).wait().await
     }
     /// Exit status if the child has already exited (non-blocking).
     pub fn try_wait(&mut self) -> Result<Option<ExitStatus>, Error> {
-        self.proc.try_wait()
+        self.proc.as_mut().expect(PROC_TAKEN).try_wait()
     }
 
     /// Hard-kill the (lone) child. Handle-bound, so it cannot race a recycled pid.
@@ -364,7 +382,7 @@ impl Child {
     pub fn kill(&mut self) -> Result<(), Error> {
         // A plain child is unaffected (the mapping only fires on an elevated wrapper child whose
         // kill returns EPERM/ACCESS_DENIED); everything else stays `Io`/`Ok` exactly as before.
-        match self.proc.start_kill() {
+        match self.proc.as_mut().expect(PROC_TAKEN).start_kill() {
             Err(Error::Io(e)) => Err(crate::elevation::map_elevated_kill_error(e, self.is_elevated_wrapper())),
             other => other,
         }
@@ -484,7 +502,7 @@ impl Child {
         // After the mechanism guard, which is permanent and pid-independent: an uncontained
         // child must keep hearing why it has no tree to signal, not why a pid is unpinned.
         #[cfg(windows)]
-        if !self.proc.pins_pid() {
+        if !self.proc.as_ref().expect(PROC_TAKEN).pins_pid() {
             return Err(self.unpinned_pid_refusal("terminate_tree"));
         }
         // See kill_tree's identical precondition assert for the full rationale, including the
@@ -589,7 +607,10 @@ impl Child {
         started: ::tokio::sync::oneshot::Sender<()>,
         outcome: ::tokio::sync::oneshot::Sender<crate::child::spawn::windows_raw::WaitOutcome>,
     ) {
-        self.proc.install_wait_observer(started, outcome);
+        self.proc
+            .as_mut()
+            .expect(PROC_TAKEN)
+            .install_wait_observer(started, outcome);
     }
 }
 
@@ -613,7 +634,7 @@ impl Drop for Child {
         // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend
         // (tokio field-drop reap vs the raw handle's kill-then-wait).
         let pid = self.id.pid();
-        self.proc.reap_now_on_drop(pid);
+        self.proc.as_mut().expect(PROC_TAKEN).reap_now_on_drop(pid);
     }
 }
 

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -624,6 +624,12 @@ impl Child {
     }
 }
 
+/// Signals the tree and the root and does NOT wait: the child is not necessarily gone when
+/// `drop` returns, and neither is it necessarily reaped. A caller that must observe the teardown
+/// calls [`kill`](Child::kill)/[`kill_tree`](Child::kill_tree) and then awaits
+/// [`wait`](Child::wait)/[`wait_tree`](Child::wait_tree).
+///
+/// The sync [`Child`](crate::Child)'s `Drop` still blocks; that divergence is deliberate.
 impl Drop for Child {
     fn drop(&mut self) {
         // The opt-out/`detach()` contract: nothing is signalled and nothing is logged.
@@ -639,6 +645,11 @@ impl Drop for Child {
         // Tree teardown — the SOLE coverage for descendants (the root's own kill below reaches
         // only the root), so surface a real mechanism failure in debug. A no-op for an
         // uncontained child.
+        //
+        // MUST stay on the dropping thread: the graceful phase's signal stops at group
+        // boundaries (`CTRL_BREAK` reaches only the root's console group, `SIGTERM` via `killpg`
+        // only the root's process group), so a nested descendant leading its own group survives
+        // it and this is the only thing that reaches it before `drop` returns.
         let tree = self.attached.hard_kill();
         if let Err(e) = &tree {
             debug_assert!(

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -100,18 +100,19 @@ impl Child {
             Some(crate::elevation::ElevatedVia::Wrapped(_) | crate::elevation::ElevatedVia::WindowsUac)
         )
     }
-    /// Blocking kill-then-reap used by the POSIX spawn-error cleanup path (a sync context — no
-    /// reactor `await` available), delegating to the same per-backend primitive `Drop` uses.
+    /// Blocking reap for the POSIX spawn-error cleanup path (a sync context — no reactor `await`
+    /// available), delegating to the same per-backend primitive `Drop` uses.
+    ///
+    /// **Wait-only; the caller must already have killed**, which is what bounds the wait. Killing
+    /// again here would reintroduce the defect the reaper pool exists to avoid: a second kill can
+    /// fail, every kill-then-wait path reads a failed kill as "do not wait", and the reap would
+    /// then be lost silently on the ordinary success path.
+    ///
     /// Unix-only: the Windows elevation arm builds its child in-module with no deferred password.
     #[cfg(unix)]
-    pub(super) fn reap_blocking(&mut self) {
+    pub(super) fn wait_and_reap_blocking(&mut self) {
         let pid = self.id.pid();
-        let proc = self.proc.as_mut().expect(PROC_TAKEN);
-        // A failed kill is not a live process to wait on — the same early return `reap_now` makes,
-        // spelled out because the wait no longer carries a kill of its own.
-        if proc.start_kill().is_ok() {
-            proc.wait_and_reap(pid);
-        }
+        self.proc.as_mut().expect(PROC_TAKEN).wait_and_reap(pid);
     }
 
     /// The child's stable identity — valid after `wait`.

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -74,7 +74,7 @@ impl Child {
     pub fn terminate(&self) -> Result<(), Error> {
         let mechanism = self.graceful_mechanism();
         #[cfg(windows)]
-        if mechanism.addresses_a_bare_pid() && !self.proc.pins_pid() {
+        if mechanism.addresses_a_bare_pid() && !self.proc.as_ref().expect(super::PROC_TAKEN).pins_pid() {
             return Err(self.unpinned_pid_refusal("terminate"));
         }
         crate::graceful::signal(mechanism, self.id())

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -87,13 +87,23 @@ impl ProcSource {
         }
     }
 
-    /// Guaranteed synchronous teardown for `Drop`: kill, then block until the child has exited.
-    /// **Invariant:** no `wait()` future for this child is in flight when this runs.
-    pub(crate) fn reap_now_on_drop(&mut self, pid: u32) {
+    /// `true` once the backend has collected the child's status, so no reap remains.
+    pub(crate) fn is_reaped(&self) -> bool {
         match self {
-            ProcSource::Tokio(c) => super::reap_now(c, pid, true),
+            ProcSource::Tokio(c) => c.id().is_none(),
             #[cfg(windows)]
-            ProcSource::Raw(r) => r.reap_blocking(),
+            ProcSource::Raw(r) => r.is_reaped(),
+        }
+    }
+
+    /// Wait for exit, then let the backend reap. **Never kills** — the signal is issued by the
+    /// caller, on the dropping thread.
+    /// **Invariant:** no `wait()` future for this child is in flight when this runs.
+    pub(crate) fn wait_and_reap(&mut self, pid: u32) {
+        match self {
+            ProcSource::Tokio(c) => super::reaper::wait_and_reap(c, pid, true),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.wait_and_reap(),
         }
     }
 

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -9,14 +9,17 @@
 //! under our own `waitid`.
 //!
 //! Workers are immortal. The loop ends only on disconnect, which cannot happen (both channel ends
-//! live in a `static`), and the job body runs inside `catch_unwind`, so a panic cannot end it
-//! either. That is what keeps the live-worker count monotone.
+//! live in the pool), and the whole job body runs inside `catch_unwind`, so a panic cannot end it
+//! either. Nothing decrements the slot count on exit, so were a worker to die anyway the pool
+//! would narrow permanently — but no job is stranded by that, because a submitter only ever sends
+//! against a token a live worker published.
 //!
-//! Degraded mode is a knowing trade, not an oversight: under thread exhaustion the alternatives
-//! are blocking the dropping thread (reinstating the defect at the worst moment) or holding
-//! pinned pids in our own queue indefinitely. The child goes to the runtime's orphan handling
-//! instead, which is best-effort — the one place this module uses the mechanism it otherwise
-//! rejects.
+//! Degraded mode is a knowing trade, not an oversight: when the OS refuses a thread the
+//! alternatives are blocking the dropping thread (reinstating the defect at the worst moment) or
+//! holding pinned pids in our own queue indefinitely. The child goes to the runtime's orphan
+//! handling instead, which is best-effort — the one place this module uses the mechanism it
+//! otherwise rejects. Reaching the bound is NOT this case: there the workers exist and are
+//! working, so the job queues.
 //!
 //! Process exit with jobs still queued is benign: the root is already signalled by then, so the
 //! worst case is a zombie the OS reaps when the process exits.
@@ -41,91 +44,173 @@ pub(crate) struct ReapJob {
     pub(crate) origin: std::thread::ThreadId,
     #[cfg(test)]
     pub(crate) probe: Option<test_probe::DropProbe>,
-    /// Sampled at submit time on the dropping thread — a thread-local armed by the test is
-    /// invisible on a worker.
+    /// Sampled on the dropping thread — see `fault::set_force_teardown_panic`.
     #[cfg(test)]
     pub(crate) force_panic: bool,
 }
 
-/// A wedged child occupies one worker and no other; the rest keep servicing their own jobs. Not
-/// a throughput device — an ordinary reap waits microseconds on an already-killed child.
+/// The pool's bulkhead width: a wedged job occupies one worker and no other, so up to this many
+/// independently wedged children can be in flight before a further one has to wait. Not a
+/// throughput device — an ordinary reap waits microseconds on an already-killed child.
 const REAPER_POOL_THREADS: usize = 4;
 
-/// Reserved worker slots. Monotone: a reserved slot is released only when the spawn itself
-/// fails, and a started worker never exits.
-static LIVE: AtomicUsize = AtomicUsize::new(0);
-
-type Queue = (crossbeam_channel::Sender<ReapJob>, crossbeam_channel::Receiver<ReapJob>);
-
-/// Both ends live here for the process's life, so the channel can never disconnect.
-fn queue() -> &'static Queue {
-    static QUEUE: OnceLock<Queue> = OnceLock::new();
-    QUEUE.get_or_init(crossbeam_channel::unbounded)
+/// What [`Pool::start_worker`] managed to do about the absence of an idle worker.
+enum WorkerStart {
+    /// A worker was started; it owes its starter one receive.
+    Started,
+    /// Every slot is taken and none is idle. The job queues — see [`Pool::dispatch`].
+    AtBound,
+    /// The OS refused the thread. Degraded mode.
+    SpawnFailed,
 }
 
-fn worker(rx: crossbeam_channel::Receiver<ReapJob>) {
-    for job in rx {
-        run_teardown(job);
+/// A bounded set of reaper threads over one MPMC queue.
+///
+/// **The queue's invariant:** every job sent is backed by a receive no other job can take — either
+/// an idle token claimed from a parked worker, or the first receive owed by a worker this submit
+/// just started. A worker holds no token while it runs a job, so a wedged one is never sent to.
+/// The single exception is the at-bound path, which queues deliberately.
+struct Pool {
+    tx: crossbeam_channel::Sender<ReapJob>,
+    rx: crossbeam_channel::Receiver<ReapJob>,
+    /// Workers parked in `recv` that no submitter has claimed. **Published by the worker itself**,
+    /// so a thread that failed to start cannot contribute one — which is what makes this a
+    /// liveness signal rather than a proxy for one.
+    idle: AtomicUsize,
+    /// Slots taken by a started-or-starting thread. The CAP, and only the cap: a reservation here
+    /// never authorises a send.
+    spawned: AtomicUsize,
+    bound: usize,
+}
+
+impl Pool {
+    fn new(bound: usize) -> Pool {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        Pool {
+            tx,
+            rx,
+            idle: AtomicUsize::new(0),
+            spawned: AtomicUsize::new(0),
+            bound,
+        }
     }
-    debug_assert!(false, "reaper channel disconnected");
-}
 
-/// ONE spawn attempt — no loop, no retry budget. The bound is on live workers; the retry is one
-/// attempt per submit while there are none.
-fn ensure_worker() -> bool {
-    let live = LIVE.load(Ordering::Acquire);
-    // Grow only when there is nobody at all, or when the queue is already backing up. A burst of
-    // short-lived children is serviced by one worker without creating threads for it.
-    if live < REAPER_POOL_THREADS && (live == 0 || !queue().0.is_empty()) {
-        // Reserve before spawning, so concurrent submits cannot overshoot the bound.
-        if LIVE.fetch_add(1, Ordering::AcqRel) < REAPER_POOL_THREADS {
-            let rx = queue().1.clone();
-            if let Err(e) = std::thread::Builder::new()
-                .name("cosca-reaper".to_string())
-                .spawn(move || worker(rx))
-            {
-                LIVE.fetch_sub(1, Ordering::AcqRel);
-                log::error!("spawning a reaper thread failed: {e}");
-            }
+    /// Take one idle token, or report that no parked worker is available. An unbounded CAS retry,
+    /// not a budget.
+    fn claim_idle(&self) -> bool {
+        self.idle
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| n.checked_sub(1))
+            .is_ok()
+    }
+
+    fn start_worker(&'static self, force_spawn_failure: bool) -> WorkerStart {
+        let reserved = self
+            .spawned
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                (n < self.bound).then_some(n + 1)
+            })
+            .is_ok();
+        if !reserved {
+            return WorkerStart::AtBound;
+        }
+        // The seam sits on the spawn itself, so the branch a real thread exhaustion takes is the
+        // branch under test. A constant `false` outside test builds.
+        let spawned = if force_spawn_failure {
+            Err(std::io::Error::other("forced thread-spawn failure (test seam)"))
         } else {
-            LIVE.fetch_sub(1, Ordering::AcqRel);
+            std::thread::Builder::new()
+                .name("cosca-reaper".to_string())
+                .spawn(move || self.work())
+                .map(|_| ())
+        };
+        match spawned {
+            Ok(()) => WorkerStart::Started,
+            Err(e) => {
+                // Roll the slot back. No job was sent — the caller still holds it — so nothing is
+                // stranded, and no concurrent submitter was told a worker exists.
+                self.spawned.fetch_sub(1, Ordering::AcqRel);
+                log::error!("spawning a reaper thread failed: {e}");
+                WorkerStart::SpawnFailed
+            }
         }
     }
-    LIVE.load(Ordering::Acquire) > 0
+
+    fn work(&'static self) {
+        // The first receive is owed to the thread that started this worker, so no token is
+        // published for it; every later park publishes one.
+        let mut publish = false;
+        loop {
+            if publish {
+                self.idle.fetch_add(1, Ordering::Release);
+            }
+            publish = true;
+            match self.rx.recv() {
+                // The guard the module header promises: a panic anywhere in the job.
+                Ok(job) => {
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_teardown(job)));
+                }
+                Err(_) => break,
+            }
+        }
+        debug_assert!(false, "reaper channel disconnected");
+    }
+
+    /// Hand the job to a worker. **Identity-preserving:** the job stays in hand until a receive is
+    /// secured for it, and is never enqueued speculatively and never dequeued — with a shared FIFO
+    /// what you dequeue is not what you enqueued, so a thread recovering "a" job would release
+    /// another thread's child and report it on the wrong probe.
+    fn dispatch(&'static self, job: ReapJob) {
+        #[cfg(test)]
+        let job = {
+            let mut job = job;
+            job.force_panic = fault::take_force_teardown_panic(); // sampled here — see `fault`
+            job
+        };
+        #[cfg(test)]
+        let force_spawn_failure = fault::take_force_spawn_failure();
+        #[cfg(not(test))]
+        let force_spawn_failure = false;
+
+        if !self.claim_idle() {
+            match self.start_worker(force_spawn_failure) {
+                WorkerStart::Started => {}
+                WorkerStart::AtBound => {
+                    // Queue rather than release. Every worker being busy is the ordinary shape of
+                    // a burst of short-lived children, each finishing in microseconds; and if they
+                    // are instead all wedged, the runtime's orphan handling could not reap this
+                    // child either, so releasing would trade a delay for a leak.
+                    log::debug!(
+                        "reaper pool at its bound ({}); child {} waits for a worker",
+                        self.bound,
+                        job.pid
+                    );
+                }
+                WorkerStart::SpawnFailed => {
+                    release(job);
+                    return;
+                }
+            }
+        }
+        if let Err(e) = self.tx.send(job) {
+            // Unreachable: both ends live in the pool, which outlives the process. Even so,
+            // recover the job rather than dropping it unordered.
+            debug_assert!(false, "the reaper channel cannot disconnect");
+            release(e.into_inner());
+        }
+    }
 }
 
-/// Hand the job to a worker. **Identity-preserving:** the job stays in hand until a worker is
-/// known to exist, and is never enqueued speculatively — with a shared FIFO, what you dequeue is
-/// not what you enqueued, so a thread recovering "a" job would release another thread's child and
-/// report it on the wrong probe.
+fn pool() -> &'static Pool {
+    static POOL: OnceLock<Pool> = OnceLock::new();
+    POOL.get_or_init(|| Pool::new(REAPER_POOL_THREADS))
+}
+
 pub(crate) fn submit(job: ReapJob) {
-    #[cfg(test)]
-    let job = {
-        let mut job = job;
-        // Sampled HERE, on the dropping thread: the region it models runs on a worker, where a
-        // thread-local armed by the test is invisible.
-        job.force_panic = fault::take_force_teardown_panic();
-        if fault::take_force_no_reaper() {
-            release(job);
-            return;
-        }
-        job
-    };
-    if !ensure_worker() {
-        release(job);
-        return;
-    }
-    if let Err(e) = queue().0.send(job) {
-        // Unreachable: the receiver lives in a `static` for the process's life. Even so, recover
-        // the job rather than dropping it unordered.
-        debug_assert!(false, "the reaper channel cannot disconnect");
-        release(e.into_inner());
-    }
+    pool().dispatch(job);
 }
 
-/// Degraded mode: no worker exists and the spawn failed. The root is already signalled, so the
-/// remaining cost is the reap — handed to tokio's orphan handling (a no-op on Windows, which has
-/// nothing to reap). `error`, not `warn`: the crate is knowingly giving up its own guarantee.
+/// Degraded mode — see the module header for why this is the least bad option. `error`, not
+/// `warn`: the crate is knowingly giving up its own guarantee.
 fn release(job: ReapJob) {
     log::error!(
         "no reaper thread is available; child {} is left to the runtime's orphan handling (it is \
@@ -161,6 +246,11 @@ pub(crate) fn run_teardown(job: ReapJob) {
     let owned_std = job.owned_std;
     let pid = job.pid;
 
+    #[cfg(test)]
+    if let Some(p) = probe.as_ref() {
+        let _ = p.started.send(std::thread::current().id());
+    }
+
     // Executing elsewhere ⇒ the test may hold the teardown until it has observed the
     // not-yet-reaped state. Executing on the dropping thread means the teardown was inlined, so
     // skipping the gate lets that broken world fail on an assertion instead of deadlocking.
@@ -171,8 +261,9 @@ pub(crate) fn run_teardown(job: ReapJob) {
         }
     }
 
-    // `proc` is BORROWED into the region, never moved: an unwind must not destroy a resource
-    // whose release the outer code still owns and orders.
+    // `proc` is BORROWED into this inner region, never moved, so a panic in the wait cannot
+    // destroy a resource whose release the code below still owns and orders. The worker wraps the
+    // whole call as well, which is what keeps the loop alive.
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         #[cfg(test)]
         if force_panic {
@@ -283,24 +374,25 @@ pub(crate) mod fault {
     use std::cell::Cell;
 
     thread_local! {
-        static FORCE_NO_REAPER: Cell<bool> = const { Cell::new(false) };
+        static FORCE_SPAWN_FAILURE: Cell<bool> = const { Cell::new(false) };
         static FORCE_TEARDOWN_PANIC: Cell<bool> = const { Cell::new(false) };
         static FORCE_KILL_FAILURE: Cell<bool> = const { Cell::new(false) };
     }
 
-    /// Force the NEXT submit on THIS thread to take the release branch. Forces the DECISION, not
-    /// the spawn: the pool is process-global and the suite runs in parallel, so a worker is
-    /// almost always already live.
-    pub(crate) fn set_force_no_reaper(on: bool) {
-        FORCE_NO_REAPER.with(|f| f.set(on));
+    /// Force the NEXT reaper-thread spawn on THIS thread to fail. Sits on the `Builder::spawn`
+    /// call itself, so the branch a real thread exhaustion takes is the branch under test — the
+    /// slot reservation, its rollback and the release are all genuinely executed. A test drives
+    /// it through a pool of its own, where "no worker is idle" is a fact rather than a fake.
+    pub(crate) fn set_force_spawn_failure(on: bool) {
+        FORCE_SPAWN_FAILURE.with(|f| f.set(on));
     }
-    pub(crate) fn take_force_no_reaper() -> bool {
-        FORCE_NO_REAPER.with(|f| f.replace(false))
+    pub(crate) fn take_force_spawn_failure() -> bool {
+        FORCE_SPAWN_FAILURE.with(|f| f.replace(false))
     }
 
-    /// Force the NEXT teardown to panic. SAMPLED AT SUBMIT TIME into `ReapJob::force_panic`,
-    /// because the region it models runs on a worker, where a thread-local armed on the test
-    /// thread is invisible.
+    /// Force the NEXT teardown to panic. Sampled at DISPATCH time into `ReapJob::force_panic`:
+    /// the region it models runs on a worker, where a thread-local armed on the test thread is
+    /// invisible.
     pub(crate) fn set_force_teardown_panic(on: bool) {
         FORCE_TEARDOWN_PANIC.with(|f| f.set(on));
     }
@@ -334,6 +426,9 @@ pub(crate) mod test_probe {
     pub(crate) struct DropProbe {
         /// The dropping thread's id, sent from `Drop` before the handoff.
         pub(crate) entered: std::sync::mpsc::Sender<std::thread::ThreadId>,
+        /// The executing worker's id, sent on entry to the teardown and BEFORE the gate — the
+        /// only way to observe which worker a job occupies while it is still wedged on it.
+        pub(crate) started: std::sync::mpsc::Sender<std::thread::ThreadId>,
         /// Held teardowns wait here; a dropped sender releases them.
         pub(crate) gate: std::sync::mpsc::Receiver<()>,
         pub(crate) outcome: std::sync::mpsc::Sender<ReapOutcome>,

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -2,6 +2,24 @@
 //!
 //! `Drop` signals the tree and the root on the dropping thread, then hands what remains to a
 //! bounded pool of reaper threads.
+//!
+//! The job carries the process backend and every field whose release must stay ordered after the
+//! reap, not a bare pid: the backend pins the pid for the whole wait, and a bare pid would let
+//! the runtime's orphan queue reap it and let the OS recycle it onto another of our children —
+//! under our own `waitid`.
+//!
+//! Workers are immortal. The loop ends only on disconnect, which cannot happen (both channel ends
+//! live in a `static`), and the job body runs inside `catch_unwind`, so a panic cannot end it
+//! either. That is what keeps the live-worker count monotone.
+//!
+//! Degraded mode is a knowing trade, not an oversight: under thread exhaustion the alternatives
+//! are blocking the dropping thread (reinstating the defect at the worst moment) or holding
+//! pinned pids in our own queue indefinitely. The child goes to the runtime's orphan handling
+//! instead, which is best-effort — the one place this module uses the mechanism it otherwise
+//! rejects.
+//!
+//! Process exit with jobs still queued is benign: the root is already signalled by then, so the
+//! worst case is a zombie the OS reaps when the process exits.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -81,6 +81,18 @@ fn ensure_worker() -> bool {
 /// not what you enqueued, so a thread recovering "a" job would release another thread's child and
 /// report it on the wrong probe.
 pub(crate) fn submit(job: ReapJob) {
+    #[cfg(test)]
+    let job = {
+        let mut job = job;
+        // Sampled HERE, on the dropping thread: the region it models runs on a worker, where a
+        // thread-local armed by the test is invisible.
+        job.force_panic = fault::take_force_teardown_panic();
+        if fault::take_force_no_reaper() {
+            release(job);
+            return;
+        }
+        job
+    };
     if !ensure_worker() {
         release(job);
         return;
@@ -242,6 +254,49 @@ pub(crate) fn wait_and_reap(child: &mut ::tokio::process::Child, pid: u32, done_
             waited == WAIT_OBJECT_0,
             "wait_and_reap did not observe the child's exit: {waited:?}"
         );
+    }
+}
+
+/// Fault seams for the three off-nominal paths. Take-semantics, matching `crate::wait::fault`.
+/// Each is CONSUMED on the dropping thread; only the panic flag's effect is deferred, by riding
+/// in the job.
+#[cfg(test)]
+pub(crate) mod fault {
+    use std::cell::Cell;
+
+    thread_local! {
+        static FORCE_NO_REAPER: Cell<bool> = const { Cell::new(false) };
+        static FORCE_TEARDOWN_PANIC: Cell<bool> = const { Cell::new(false) };
+        static FORCE_KILL_FAILURE: Cell<bool> = const { Cell::new(false) };
+    }
+
+    /// Force the NEXT submit on THIS thread to take the release branch. Forces the DECISION, not
+    /// the spawn: the pool is process-global and the suite runs in parallel, so a worker is
+    /// almost always already live.
+    pub(crate) fn set_force_no_reaper(on: bool) {
+        FORCE_NO_REAPER.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_no_reaper() -> bool {
+        FORCE_NO_REAPER.with(|f| f.replace(false))
+    }
+
+    /// Force the NEXT teardown to panic. SAMPLED AT SUBMIT TIME into `ReapJob::force_panic`,
+    /// because the region it models runs on a worker, where a thread-local armed on the test
+    /// thread is invisible.
+    pub(crate) fn set_force_teardown_panic(on: bool) {
+        FORCE_TEARDOWN_PANIC.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_teardown_panic() -> bool {
+        FORCE_TEARDOWN_PANIC.with(|f| f.replace(false))
+    }
+
+    /// Force the NEXT root `start_kill` in `Drop` on THIS thread to report failure. It REPLACES
+    /// the kill rather than masking its result, so the child really is left unsignalled.
+    pub(crate) fn set_force_kill_failure(on: bool) {
+        FORCE_KILL_FAILURE.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_kill_failure() -> bool {
+        FORCE_KILL_FAILURE.with(|f| f.replace(false))
     }
 }
 

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -1,0 +1,286 @@
+//! The wait-and-reap half of the async [`Child`](super::Child)'s teardown.
+//!
+//! `Drop` signals the tree and the root on the dropping thread, then hands what remains to a
+//! bounded pool of reaper threads.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
+
+use crate::containment::Attached;
+use crate::stdio::Fd;
+
+/// Everything `Drop` hands over: the process backend plus every field that holds an OS resource
+/// and drops after it today, so the release order survives the handoff.
+pub(crate) struct ReapJob {
+    pub(crate) proc: super::ProcSource,
+    pub(crate) attached: Attached,
+    pub(crate) pipes: super::FdPipes,
+    pub(crate) owned_std: BTreeMap<Fd, crate::tokio::stdio::OwnedStd>,
+    pub(crate) pid: u32,
+    /// The thread `Drop` ran on. `run_teardown` gates only when it is executing elsewhere.
+    #[cfg(test)]
+    pub(crate) origin: std::thread::ThreadId,
+    #[cfg(test)]
+    pub(crate) probe: Option<test_probe::DropProbe>,
+    /// Sampled at submit time on the dropping thread — a thread-local armed by the test is
+    /// invisible on a worker.
+    #[cfg(test)]
+    pub(crate) force_panic: bool,
+}
+
+/// A wedged child occupies one worker and no other; the rest keep servicing their own jobs. Not
+/// a throughput device — an ordinary reap waits microseconds on an already-killed child.
+const REAPER_POOL_THREADS: usize = 4;
+
+/// Reserved worker slots. Monotone: a reserved slot is released only when the spawn itself
+/// fails, and a started worker never exits.
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+type Queue = (crossbeam_channel::Sender<ReapJob>, crossbeam_channel::Receiver<ReapJob>);
+
+/// Both ends live here for the process's life, so the channel can never disconnect.
+fn queue() -> &'static Queue {
+    static QUEUE: OnceLock<Queue> = OnceLock::new();
+    QUEUE.get_or_init(crossbeam_channel::unbounded)
+}
+
+fn worker(rx: crossbeam_channel::Receiver<ReapJob>) {
+    for job in rx {
+        run_teardown(job);
+    }
+    debug_assert!(false, "reaper channel disconnected");
+}
+
+/// ONE spawn attempt — no loop, no retry budget. The bound is on live workers; the retry is one
+/// attempt per submit while there are none.
+fn ensure_worker() -> bool {
+    let live = LIVE.load(Ordering::Acquire);
+    // Grow only when there is nobody at all, or when the queue is already backing up. A burst of
+    // short-lived children is serviced by one worker without creating threads for it.
+    if live < REAPER_POOL_THREADS && (live == 0 || !queue().0.is_empty()) {
+        // Reserve before spawning, so concurrent submits cannot overshoot the bound.
+        if LIVE.fetch_add(1, Ordering::AcqRel) < REAPER_POOL_THREADS {
+            let rx = queue().1.clone();
+            if let Err(e) = std::thread::Builder::new()
+                .name("cosca-reaper".to_string())
+                .spawn(move || worker(rx))
+            {
+                LIVE.fetch_sub(1, Ordering::AcqRel);
+                log::error!("spawning a reaper thread failed: {e}");
+            }
+        } else {
+            LIVE.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+    LIVE.load(Ordering::Acquire) > 0
+}
+
+/// Hand the job to a worker. **Identity-preserving:** the job stays in hand until a worker is
+/// known to exist, and is never enqueued speculatively — with a shared FIFO, what you dequeue is
+/// not what you enqueued, so a thread recovering "a" job would release another thread's child and
+/// report it on the wrong probe.
+pub(crate) fn submit(job: ReapJob) {
+    if !ensure_worker() {
+        release(job);
+        return;
+    }
+    if let Err(e) = queue().0.send(job) {
+        // Unreachable: the receiver lives in a `static` for the process's life. Even so, recover
+        // the job rather than dropping it unordered.
+        debug_assert!(false, "the reaper channel cannot disconnect");
+        release(e.into_inner());
+    }
+}
+
+/// Degraded mode: no worker exists and the spawn failed. The root is already signalled, so the
+/// remaining cost is the reap — handed to tokio's orphan handling (a no-op on Windows, which has
+/// nothing to reap). `error`, not `warn`: the crate is knowingly giving up its own guarantee.
+fn release(job: ReapJob) {
+    log::error!(
+        "no reaper thread is available; child {} is left to the runtime's orphan handling (it is \
+         already signalled)",
+        job.pid
+    );
+    #[cfg(test)]
+    let probe = job.probe;
+    drop(job.proc);
+    drop(job.attached);
+    drop(job.pipes);
+    drop(job.owned_std);
+    #[cfg(test)]
+    if let Some(p) = probe {
+        let _ = p.outcome.send(test_probe::ReapOutcome::Released);
+    }
+}
+
+/// Wait for the root's exit, reap it, then release the job's resources in `Child`'s own field
+/// order. **Never kills:** the signal was already issued on the dropping thread, and a second
+/// kill can fail (Windows denies terminating an already-exiting process), which every
+/// kill-then-wait path reads as "do not wait" — silently losing the reap.
+pub(crate) fn run_teardown(job: ReapJob) {
+    #[cfg(test)]
+    let origin = job.origin;
+    #[cfg(test)]
+    let probe = job.probe;
+    #[cfg(test)]
+    let force_panic = job.force_panic;
+    let mut proc = job.proc;
+    let attached = job.attached;
+    let pipes = job.pipes;
+    let owned_std = job.owned_std;
+    let pid = job.pid;
+
+    // Executing elsewhere ⇒ the test may hold the teardown until it has observed the
+    // not-yet-reaped state. Executing on the dropping thread means the teardown was inlined, so
+    // skipping the gate lets that broken world fail on an assertion instead of deadlocking.
+    #[cfg(test)]
+    if std::thread::current().id() != origin {
+        if let Some(p) = probe.as_ref() {
+            let _ = p.gate.recv(); // a dropped sender is also a release
+        }
+    }
+
+    // `proc` is BORROWED into the region, never moved: an unwind must not destroy a resource
+    // whose release the outer code still owns and orders.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        #[cfg(test)]
+        if force_panic {
+            panic!("forced teardown panic (test seam)");
+        }
+        proc.wait_and_reap(pid);
+    }));
+    if outcome.is_err() {
+        log::error!("reaping child {pid} panicked; releasing its resources anyway");
+    }
+
+    // `Child`'s declaration order — `proc` first, so the pid stays pinned for the whole wait and
+    // every other release stays ordered after the reap.
+    drop(proc);
+    drop(attached);
+    drop(pipes);
+    drop(owned_std);
+
+    #[cfg(test)]
+    if let Some(p) = probe {
+        let _ = p.outcome.send(if outcome.is_err() {
+            test_probe::ReapOutcome::Panicked
+        } else {
+            test_probe::ReapOutcome::Reaped(std::thread::current().id())
+        });
+    }
+}
+
+/// Guaranteed synchronous teardown for the spawn error paths: kill the child, then block until
+/// it has exited. `done_ok` says whether an already-`Done` child is legal here: `true` for a
+/// caller whose child the user may have `wait()`ed, `false` for the spawn-error path (the child
+/// was never awaited).
+/// **Invariant:** no `wait()` future for this child is in flight when this runs.
+pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: bool) {
+    // `start_kill` bounds the wait below — it MUST run in release (NOT inside `debug_assert!`,
+    // whose argument is stripped in release). A no-op on an already-exited child.
+    let killed = child.start_kill();
+    debug_assert!(killed.is_ok(), "start_kill of an owned child should not fail");
+    // A failed start_kill means this is not a live process to wait on (ESRCH = already exited;
+    // EPERM is impossible for our own child) — skip, so a kill failure can never turn the bounded
+    // exit-wait into an unbounded block. tokio's field-drop reaps any leftover zombie.
+    if killed.is_err() {
+        return;
+    }
+    wait_and_reap(child, pid, done_ok);
+}
+
+/// The wait-then-reap half of [`reap_now`], with no kill of its own. On Unix we wait with
+/// `WNOWAIT` (NOT reaping), so tokio's own `Child` field-drop reaps the zombie synchronously in
+/// its drop (its `try_wait` returns `Ok(Some)`, not a park-dependent orphan enqueue). We only
+/// wait while tokio still owns the child (`id().is_some()`), which pins the pid; once tokio is
+/// `Done` (a prior `wait()` reaped it), the pid may be recycled and we must not wait on it.
+pub(crate) fn wait_and_reap(child: &mut ::tokio::process::Child, pid: u32, done_ok: bool) {
+    // tokio `Done` ⇒ already reaped, pid possibly recycled ⇒ nothing to do (the recycled-pid wait
+    // hazard the sync side avoids by holding a handle).
+    if child.id().is_none() {
+        debug_assert!(
+            done_ok,
+            "wait_and_reap found an already-reaped child where one was impossible"
+        );
+        return;
+    }
+    #[cfg(unix)]
+    {
+        // `nix` doesn't expose `waitid` on macOS (0.31 configures it out), so call `libc::waitid`
+        // directly (WEXITED | WNOWAIT: block until exit without reaping) — portable across every Unix
+        // target and the identical syscall.
+        debug_assert!(pid <= i32::MAX as u32, "pid {pid} exceeds i32::MAX");
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        loop {
+            // SAFETY: a well-formed `waitid` call; `info` is a valid, owned, zeroed `siginfo_t` the
+            // kernel fills in. WNOWAIT leaves the child reapable for tokio's in-drop reap.
+            let rc = unsafe { libc::waitid(libc::P_PID, pid as libc::id_t, &mut info, libc::WEXITED | libc::WNOWAIT) };
+            if rc == 0 {
+                break;
+            }
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            // id() was Some above (tokio un-reaped ⇒ pid pinned), so no ECHILD / other errno should
+            // occur — a debug tripwire, with a safe release `break`.
+            debug_assert!(false, "waitid in wait_and_reap failed unexpectedly: {err}");
+            break;
+        }
+    }
+    #[cfg(windows)]
+    {
+        use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+        use windows::Win32::System::Threading::{WaitForSingleObject, INFINITE};
+        let _ = pid;
+        let h = child.raw_handle().expect("tokio owns the handle while id() is Some");
+        // SAFETY: tokio owns and (on its field-drop) closes the handle; we only wait on it.
+        // INFINITE is bounded by the kill the caller already issued.
+        let waited = unsafe { WaitForSingleObject(HANDLE(h), INFINITE) };
+        debug_assert!(
+            waited == WAIT_OBJECT_0,
+            "wait_and_reap did not observe the child's exit: {waited:?}"
+        );
+    }
+}
+
+/// Observation seam for the drop handoff. `#[cfg(test)]`, not `#[doc(hidden)] pub`: nothing
+/// test-only reaches a downstream build, so no gate can ever block in a consumer's `Drop`.
+#[cfg(test)]
+pub(crate) mod test_probe {
+    use std::cell::RefCell;
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub(crate) enum ReapOutcome {
+        Reaped(std::thread::ThreadId),
+        Released,
+        Panicked,
+    }
+
+    pub(crate) struct DropProbe {
+        /// The dropping thread's id, sent from `Drop` before the handoff.
+        pub(crate) entered: std::sync::mpsc::Sender<std::thread::ThreadId>,
+        /// Held teardowns wait here; a dropped sender releases them.
+        pub(crate) gate: std::sync::mpsc::Receiver<()>,
+        pub(crate) outcome: std::sync::mpsc::Sender<ReapOutcome>,
+    }
+
+    thread_local! {
+        static PROBE: RefCell<Option<DropProbe>> = const { RefCell::new(None) };
+    }
+
+    /// Arm a probe for the NEXT `Child::drop` on THIS thread (take-semantics, matching
+    /// `crate::wait::fault`).
+    pub(crate) fn arm(probe: DropProbe) {
+        PROBE.with(|p| *p.borrow_mut() = Some(probe));
+    }
+
+    pub(crate) fn take() -> Option<DropProbe> {
+        PROBE.with(|p| p.borrow_mut().take())
+    }
+}
+
+#[cfg(test)]
+#[path = "reaper_tests.rs"]
+mod reaper_tests;

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -3,6 +3,7 @@
 
 use std::sync::mpsc;
 
+use super::fault;
 use super::test_probe::{arm, DropProbe, ReapOutcome};
 use super::{run_teardown, ReapJob};
 use crate::identity::{ProcessId, Resolved};
@@ -145,4 +146,86 @@ async fn teardown_reports_the_executing_thread_not_the_origin() {
         ReapOutcome::Reaped(executing),
         "the reported thread must be the EXECUTING one, not the job's origin"
     );
+}
+
+#[tokio::test]
+async fn no_reaper_available_releases_the_job_in_hand() {
+    let ends = arm_probe();
+    let (child, _sock) = spawn_async_blocker();
+    fault::set_force_no_reaper(true);
+    drop(child);
+
+    ends.entered.recv().expect("Drop must reach the handoff");
+    // Release the gate: the release path never gates, but a broken world that submitted the job
+    // would otherwise wedge the worker behind it instead of failing the assertion below.
+    drop(ends.gate);
+    assert_eq!(
+        ends.outcome.recv().expect("the release path must report an outcome"),
+        ReapOutcome::Released,
+        "with no reaper available the job must be released in hand, not reaped"
+    );
+    assert!(
+        !fault::take_force_no_reaper(),
+        "the fault must have been consumed — a flag nothing read cannot pass this test"
+    );
+}
+
+#[tokio::test]
+async fn teardown_panic_is_caught_and_reported() {
+    let ends = arm_probe();
+    let (child, _sock) = spawn_async_blocker();
+    fault::set_force_teardown_panic(true);
+    drop(child);
+
+    ends.entered.recv().expect("Drop must reach the handoff");
+    drop(ends.gate);
+    assert_eq!(
+        ends.outcome
+            .recv()
+            .expect("without catch_unwind the worker unwinds and no outcome ever arrives"),
+        ReapOutcome::Panicked,
+        "a panicking teardown must be caught and reported"
+    );
+    assert!(
+        !fault::take_force_teardown_panic(),
+        "the fault must have been consumed at submit time"
+    );
+}
+
+#[tokio::test]
+async fn unkillable_root_is_not_submitted() {
+    use std::io::{Read as _, Write as _};
+    let ends = arm_probe();
+    let (child, mut sock) = spawn_async_blocker();
+    let id = child.id();
+    fault::set_force_kill_failure(true);
+    drop(child);
+
+    ends.entered.recv().expect("Drop must reach the handoff");
+    // Nothing is submitted, so nothing gates; releasing anyway keeps a broken world that DID
+    // submit from wedging the worker instead of failing the assertion below.
+    drop(ends.gate);
+    // The probe's outcome sender drops with the job that was never built: a submitted job would
+    // report `Reaped(_)` here and park a pool slot on a child nobody can kill.
+    assert!(
+        ends.outcome.recv().is_err(),
+        "a child whose kill failed must not be submitted"
+    );
+    assert!(!fault::take_force_kill_failure(), "the fault must have been consumed");
+    // Race-free: the fault REPLACED the kill, so nothing was ever signalled.
+    assert_eq!(
+        id.is_alive(),
+        crate::identity::Liveness::Alive,
+        "an unkillable root must be left running"
+    );
+
+    // Release it so it exits. Its reaping is left to the runtime's orphan handling — the
+    // documented behaviour of this path — so the assertion is on the EXIT, not the reap.
+    sock.write_all(b"x").expect("release the unsignalled child");
+    let mut buf = [0u8; 1];
+    match sock.read(&mut buf) {
+        Ok(0) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+        other => panic!("released child did not exit: {other:?}"),
+    }
 }

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -6,6 +6,11 @@ use std::sync::mpsc;
 use super::fault;
 use super::test_probe::{arm, DropProbe, ReapOutcome};
 use super::{run_teardown, ReapJob};
+// Windows has no zombie, and a pid outlives its last handle by an asynchronous kernel rundown
+// that nothing in user mode signals (measured on an idle box: 0-14 `OpenProcess` probes of
+// slack). So identity-after-teardown is a Unix-only property, as the `#[cfg(unix)]`
+// `async_drop_leaves_no_zombie` this coverage came from already recorded.
+#[cfg(unix)]
 use crate::identity::{ProcessId, Resolved};
 use crate::test_child::spawn_async_blocker;
 
@@ -33,6 +38,7 @@ async fn drop_signals_the_root_and_returns_before_the_reap() {
     use std::io::Read as _;
     let ends = arm_probe();
     let (child, mut sock) = spawn_async_blocker();
+    #[cfg(unix)]
     let id = child.id();
     drop(child);
 
@@ -56,12 +62,21 @@ async fn drop_signals_the_root_and_returns_before_the_reap() {
         other => panic!("root not signalled on the dropping thread: {other:?}"),
     }
 
-    // Exited but NOT reaped — the identity still resolves — so `Drop` returned before the reap.
-    // Reuse-immune: the comparison is pid + start token, so a recycled pid cannot false-pass.
+    // `Drop` returned before the teardown. Race-free rather than merely not-yet-observed: we
+    // still hold the gate SENDER, so a teardown on a worker CANNOT have reported, while an
+    // inlined one provably reported before `drop` returned. This is the whole discriminator on
+    // Windows, where the identity comparison below cannot tell the two worlds apart.
+    assert!(
+        matches!(ends.outcome.try_recv(), Err(mpsc::TryRecvError::Empty)),
+        "Drop must return before the teardown runs"
+    );
+    // Unix sharpens it: the child has exited but is still an unreaped zombie, so its identity
+    // resolves. Reuse-immune — the comparison is pid + start token.
+    #[cfg(unix)]
     assert_eq!(
         ProcessId::of(id.pid()),
         Resolved::Found(id),
-        "Drop must return before the reap: the exited child's identity must still resolve"
+        "the exited child must still be an unreaped zombie while the teardown is gated"
     );
 
     drop(ends.gate);
@@ -69,6 +84,7 @@ async fn drop_signals_the_root_and_returns_before_the_reap() {
         matches!(ends.outcome.recv(), Ok(ReapOutcome::Reaped(_))),
         "the released teardown must reap"
     );
+    #[cfg(unix)]
     assert_ne!(
         ProcessId::of(id.pid()),
         Resolved::Found(id),
@@ -80,6 +96,7 @@ async fn drop_signals_the_root_and_returns_before_the_reap() {
 async fn drop_reaps_on_a_worker_thread() {
     let ends = arm_probe();
     let (child, _sock) = spawn_async_blocker();
+    #[cfg(unix)]
     let id = child.id();
     drop(child);
 
@@ -98,6 +115,10 @@ async fn drop_reaps_on_a_worker_thread() {
     // The no-zombie property, sequenced after a real edge rather than after a blocking `Drop`.
     // A zombie still resolves to `Found(id)` (Linux `/proc` persists); a reaped pid resolves to
     // `Gone` or, if recycled, a DIFFERENT identity — so a recycled pid never false-passes.
+    // Unix-only, keeping the gate its source test carried: Windows has no zombie, and the
+    // outcome above already implies the backend was released, because it is sent only after the
+    // job's four resources are dropped.
+    #[cfg(unix)]
     assert_ne!(
         ProcessId::of(id.pid()),
         Resolved::Found(id),

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -14,23 +14,69 @@ use super::{run_teardown, ReapJob};
 use crate::identity::{ProcessId, Resolved};
 use crate::test_child::spawn_async_blocker;
 
-/// The three ends a test keeps: the dropping thread's id, the gate release, and the outcome.
+/// The ends a test keeps: the dropping thread's id, the executing worker's id, the gate release,
+/// and the outcome.
 struct ProbeEnds {
     entered: mpsc::Receiver<std::thread::ThreadId>,
+    started: mpsc::Receiver<std::thread::ThreadId>,
     gate: mpsc::Sender<()>,
     outcome: mpsc::Receiver<ReapOutcome>,
 }
 
-fn arm_probe() -> ProbeEnds {
+fn probe_pair() -> (DropProbe, ProbeEnds) {
     let (entered_tx, entered) = mpsc::channel();
+    let (started_tx, started) = mpsc::channel();
     let (gate, gate_rx) = mpsc::channel();
     let (outcome_tx, outcome) = mpsc::channel();
-    arm(DropProbe {
-        entered: entered_tx,
-        gate: gate_rx,
-        outcome: outcome_tx,
-    });
-    ProbeEnds { entered, gate, outcome }
+    (
+        DropProbe {
+            entered: entered_tx,
+            started: started_tx,
+            gate: gate_rx,
+            outcome: outcome_tx,
+        },
+        ProbeEnds {
+            entered,
+            started,
+            gate,
+            outcome,
+        },
+    )
+}
+
+fn arm_probe() -> ProbeEnds {
+    let (probe, ends) = probe_pair();
+    arm(probe);
+    ends
+}
+
+/// A pool of this test's own. The process-global one is shared with every other test in the
+/// binary, so neither its worker count nor its idleness is a fact a test may reason about; these
+/// two do exactly that. Leaked because workers borrow it for their whole life — which is the
+/// pool's design, not a concession to the test.
+fn private_pool() -> &'static super::Pool {
+    Box::leak(Box::new(super::Pool::new(super::REAPER_POOL_THREADS)))
+}
+
+/// A job around a bare `::tokio::process::Child` that exits at once. Built by hand rather than by
+/// emptying a `cosca` handle, which would hit `PROC_TAKEN` in its own `Drop` and panic the test.
+fn bare_job(origin: std::thread::ThreadId, probe: Option<DropProbe>) -> ReapJob {
+    let mut cmd = ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"));
+    cmd.args(["--exact", "__cosca_no_such_test__"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let proc = cmd.spawn().expect("spawn a child that exits");
+    let pid = proc.id().expect("a freshly spawned child has a pid");
+    ReapJob {
+        proc: super::super::ProcSource::Tokio(proc),
+        attached: crate::containment::Attached::None,
+        pipes: Default::default(),
+        owned_std: Default::default(),
+        pid,
+        origin,
+        probe,
+        force_panic: false,
+    }
 }
 
 #[tokio::test]
@@ -128,30 +174,10 @@ async fn drop_reaps_on_a_worker_thread() {
 
 #[tokio::test]
 async fn teardown_reports_the_executing_thread_not_the_origin() {
-    // Built by hand around a bare `::tokio::process::Child`, NOT by emptying a `cosca` handle —
-    // an emptied handle would hit `PROC_TAKEN` in its own `Drop` and panic the test.
-    let mut cmd = ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"));
-    cmd.args(["--exact", "__cosca_no_such_test__"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
-    let proc = cmd.spawn().expect("spawn a child that exits");
-    let pid = proc.id().expect("a freshly spawned child has a pid");
-
-    let (entered, _entered_rx) = mpsc::channel();
-    let (gate_tx, gate) = mpsc::channel();
-    let (outcome, outcome_rx) = mpsc::channel();
-    drop(gate_tx); // a dropped sender is a release, so the worker never blocks
+    let (probe, ends) = probe_pair();
+    drop(ends.gate); // a dropped sender is a release, so the worker never blocks
     let origin = std::thread::current().id();
-    let job = ReapJob {
-        proc: super::super::ProcSource::Tokio(proc),
-        attached: crate::containment::Attached::None,
-        pipes: Default::default(),
-        owned_std: Default::default(),
-        pid,
-        origin,
-        probe: Some(DropProbe { entered, gate, outcome }),
-        force_panic: false,
-    };
+    let job = bare_job(origin, Some(probe));
 
     // `h.thread().id()` is a value the TEST holds without asking the executing thread, and it
     // differs from `origin` — so an implementation reporting `job.origin` fails here. Calling
@@ -163,31 +189,122 @@ async fn teardown_reports_the_executing_thread_not_the_origin() {
 
     assert_ne!(executing, origin, "the teardown must run off the origin thread");
     assert_eq!(
-        outcome_rx.recv().expect("the teardown must report an outcome"),
+        ends.outcome.recv().expect("the teardown must report an outcome"),
         ReapOutcome::Reaped(executing),
         "the reported thread must be the EXECUTING one, not the job's origin"
     );
 }
 
+/// The bulkhead: `REAPER_POOL_THREADS` independently wedged jobs must occupy one worker EACH, a
+/// further one must wait rather than grow a thread, and releasing one must free only that worker.
 #[tokio::test]
-async fn no_reaper_available_releases_the_job_in_hand() {
-    let ends = arm_probe();
-    let (child, _sock) = spawn_async_blocker();
-    fault::set_force_no_reaper(true);
-    drop(child);
+async fn a_wedged_job_occupies_one_worker_and_the_pool_stops_at_its_bound() {
+    let pool = private_pool();
+    let bound = super::REAPER_POOL_THREADS;
+    let origin = std::thread::current().id();
 
-    ends.entered.recv().expect("Drop must reach the handoff");
-    // Release the gate: the release path never gates, but a broken world that submitted the job
-    // would otherwise wedge the worker behind it instead of failing the assertion below.
+    // One more job than the pool is wide, each wedged on its own held gate.
+    let mut ends: Vec<ProbeEnds> = Vec::new();
+    for _ in 0..=bound {
+        let (probe, e) = probe_pair();
+        ends.push(e);
+        pool.dispatch(bare_job(origin, Some(probe)));
+    }
+
+    // Deterministic on the dispatching thread, and the assertion that fails FIRST if growth is
+    // driven by the wrong signal: a wedged worker publishes no idle token, so each of the first
+    // `bound` dispatches must have had to start a thread of its own, and the last must not.
+    assert_eq!(
+        pool.spawned.load(std::sync::atomic::Ordering::Acquire),
+        bound,
+        "the pool must grow one worker per concurrently wedged job, up to its bound"
+    );
+    assert_eq!(
+        pool.idle.load(std::sync::atomic::Ordering::Acquire),
+        0,
+        "a worker running a job must publish no idle token"
+    );
+
+    // Behavioural form of the same claim: `bound` DISTINCT workers are wedged at once.
+    let workers: Vec<std::thread::ThreadId> = (0..bound)
+        .map(|i| ends[i].started.recv().expect("each wedged job must reach a worker"))
+        .collect();
+    assert_eq!(
+        workers.iter().collect::<std::collections::HashSet<_>>().len(),
+        bound,
+        "each wedged job must occupy a worker of its own"
+    );
+    // Race-free: every worker is wedged on a gate this test still holds, so the extra job CANNOT
+    // have started. A fifth thread would have taken it.
+    assert!(
+        matches!(ends[bound].started.try_recv(), Err(mpsc::TryRecvError::Empty)),
+        "the pool must not exceed its bound"
+    );
+
+    // Release ONE. Its reap completes, and the freed worker — not a new one — picks up the job
+    // that was waiting.
+    let first = ends.remove(0);
+    drop(first.gate);
+    assert_eq!(
+        first.outcome.recv().expect("the released job must reap"),
+        ReapOutcome::Reaped(workers[0]),
+        "the released job reaps on the worker it was wedged on"
+    );
+    let queued = ends.last().expect("the queued job's ends");
+    assert_eq!(
+        queued
+            .started
+            .recv()
+            .expect("the queued job must run once a worker frees"),
+        workers[0],
+        "the waiting job must reuse the freed worker rather than grow the pool"
+    );
+    // Isolation: the still-gated jobs are untouched by any of that. Race-free — this test holds
+    // their gates.
+    for (i, e) in ends.iter().enumerate().take(bound - 1) {
+        assert!(
+            matches!(e.outcome.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "wedged job {i} must be unaffected by another job's release"
+        );
+    }
+
+    // Let the rest finish so the leaked pool's workers reap their children.
+    for e in ends {
+        drop(e.gate);
+        e.outcome.recv().expect("every job must reap once released");
+    }
+}
+
+#[tokio::test]
+async fn thread_spawn_failure_releases_the_job_in_hand() {
+    // A pool of its own, so "no worker is idle" is a fact and only the `Builder::spawn` call is
+    // faked: the slot reservation, its rollback and the release all genuinely run.
+    let pool = private_pool();
+    let (probe, ends) = probe_pair();
+    // The release path never gates; releasing anyway keeps a world that DID find a worker from
+    // wedging one behind the gate instead of failing the assertion below.
     drop(ends.gate);
+    fault::set_force_spawn_failure(true);
+    pool.dispatch(bare_job(std::thread::current().id(), Some(probe)));
+
     assert_eq!(
         ends.outcome.recv().expect("the release path must report an outcome"),
         ReapOutcome::Released,
-        "with no reaper available the job must be released in hand, not reaped"
+        "a job that could not be given a worker must be released in hand, not queued"
     );
     assert!(
-        !fault::take_force_no_reaper(),
+        !fault::take_force_spawn_failure(),
         "the fault must have been consumed — a flag nothing read cannot pass this test"
+    );
+    assert_eq!(
+        pool.spawned.load(std::sync::atomic::Ordering::Acquire),
+        0,
+        "a failed spawn must roll its reserved slot back"
+    );
+    assert_eq!(
+        pool.idle.load(std::sync::atomic::Ordering::Acquire),
+        0,
+        "a thread that never started must publish no idle token"
     );
 }
 

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -1,0 +1,148 @@
+//! Probe-based coverage of the drop handoff. These are unit tests because the probe is
+//! `#[cfg(test)]`: an integration test has no edge to wait on.
+
+use std::sync::mpsc;
+
+use super::test_probe::{arm, DropProbe, ReapOutcome};
+use super::{run_teardown, ReapJob};
+use crate::identity::{ProcessId, Resolved};
+use crate::test_child::spawn_async_blocker;
+
+/// The three ends a test keeps: the dropping thread's id, the gate release, and the outcome.
+struct ProbeEnds {
+    entered: mpsc::Receiver<std::thread::ThreadId>,
+    gate: mpsc::Sender<()>,
+    outcome: mpsc::Receiver<ReapOutcome>,
+}
+
+fn arm_probe() -> ProbeEnds {
+    let (entered_tx, entered) = mpsc::channel();
+    let (gate, gate_rx) = mpsc::channel();
+    let (outcome_tx, outcome) = mpsc::channel();
+    arm(DropProbe {
+        entered: entered_tx,
+        gate: gate_rx,
+        outcome: outcome_tx,
+    });
+    ProbeEnds { entered, gate, outcome }
+}
+
+#[tokio::test]
+async fn drop_signals_the_root_and_returns_before_the_reap() {
+    use std::io::Read as _;
+    let ends = arm_probe();
+    let (child, mut sock) = spawn_async_blocker();
+    let id = child.id();
+    drop(child);
+
+    // Guard: `Drop` reached the handoff at all. Without it an early return would leave every
+    // assertion below observing nothing and passing vacuously.
+    let dropping = ends.entered.recv().expect("Drop must reach the handoff");
+    assert_eq!(
+        dropping,
+        std::thread::current().id(),
+        "#[tokio::test] is current-thread"
+    );
+
+    // The root was SIGNALLED on the dropping thread and has exited: its control socket is shut.
+    // Were the signal to move onto the worker, this read would block forever behind the held
+    // gate and the job timeout is the failure signal — the convention
+    // `async_drop_tears_down_a_contained_tree` already uses.
+    let mut buf = [0u8; 1];
+    match sock.read(&mut buf) {
+        Ok(0) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+        other => panic!("root not signalled on the dropping thread: {other:?}"),
+    }
+
+    // Exited but NOT reaped — the identity still resolves — so `Drop` returned before the reap.
+    // Reuse-immune: the comparison is pid + start token, so a recycled pid cannot false-pass.
+    assert_eq!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "Drop must return before the reap: the exited child's identity must still resolve"
+    );
+
+    drop(ends.gate);
+    assert!(
+        matches!(ends.outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "the released teardown must reap"
+    );
+    assert_ne!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "after the teardown the child's identity must be gone"
+    );
+}
+
+#[tokio::test]
+async fn drop_reaps_on_a_worker_thread() {
+    let ends = arm_probe();
+    let (child, _sock) = spawn_async_blocker();
+    let id = child.id();
+    drop(child);
+
+    let dropping = ends.entered.recv().expect("Drop must reach the handoff");
+    drop(ends.gate);
+    let outcome = ends.outcome.recv().expect("the teardown must report an outcome");
+    // Thread ids FIRST: an inlined teardown is the failure under test, and asserting the
+    // identity first would fail it for an incidental reason instead.
+    match outcome {
+        ReapOutcome::Reaped(executing) => assert_ne!(
+            executing, dropping,
+            "the reap must run on a worker thread, not the dropping thread"
+        ),
+        other => panic!("expected Reaped, got {other:?}"),
+    }
+    // The no-zombie property, sequenced after a real edge rather than after a blocking `Drop`.
+    // A zombie still resolves to `Found(id)` (Linux `/proc` persists); a reaped pid resolves to
+    // `Gone` or, if recycled, a DIFFERENT identity — so a recycled pid never false-passes.
+    assert_ne!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "the teardown must fully reap the child (no lingering process or zombie at its identity)"
+    );
+}
+
+#[tokio::test]
+async fn teardown_reports_the_executing_thread_not_the_origin() {
+    // Built by hand around a bare `::tokio::process::Child`, NOT by emptying a `cosca` handle —
+    // an emptied handle would hit `PROC_TAKEN` in its own `Drop` and panic the test.
+    let mut cmd = ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"));
+    cmd.args(["--exact", "__cosca_no_such_test__"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let proc = cmd.spawn().expect("spawn a child that exits");
+    let pid = proc.id().expect("a freshly spawned child has a pid");
+
+    let (entered, _entered_rx) = mpsc::channel();
+    let (gate_tx, gate) = mpsc::channel();
+    let (outcome, outcome_rx) = mpsc::channel();
+    drop(gate_tx); // a dropped sender is a release, so the worker never blocks
+    let origin = std::thread::current().id();
+    let job = ReapJob {
+        proc: super::super::ProcSource::Tokio(proc),
+        attached: crate::containment::Attached::None,
+        pipes: Default::default(),
+        owned_std: Default::default(),
+        pid,
+        origin,
+        probe: Some(DropProbe { entered, gate, outcome }),
+        force_panic: false,
+    };
+
+    // `h.thread().id()` is a value the TEST holds without asking the executing thread, and it
+    // differs from `origin` — so an implementation reporting `job.origin` fails here. Calling
+    // `run_teardown` synchronously and comparing against `thread::current().id()` would be two
+    // evaluations of one expression and could not fail.
+    let h = std::thread::spawn(move || run_teardown(job));
+    let executing = h.thread().id();
+    h.join().expect("the teardown thread must not panic");
+
+    assert_ne!(executing, origin, "the teardown must run off the origin thread");
+    assert_eq!(
+        outcome_rx.recv().expect("the teardown must report an outcome"),
+        ReapOutcome::Reaped(executing),
+        "the reported thread must be the EXECUTING one, not the job's origin"
+    );
+}

--- a/src/tokio/pump.rs
+++ b/src/tokio/pump.rs
@@ -62,7 +62,7 @@ impl Child {
         };
         // `wait` is the sole borrow of `self` here (already mapped to `Error`); the stream futures
         // own their taken locals, so the four-future join has no aliasing conflict.
-        let wait = async { self.proc.wait().await };
+        let wait = async { self.proc.as_mut().expect(super::child::PROC_TAKEN).wait().await };
 
         let ((), out, err, status) = ::tokio::try_join!(write, read_out, read_err, wait)?;
         Ok(Output {

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -84,7 +84,7 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                         // non-blocking try_wait() and note the child may still be running.
                         let kill_note = match child.kill() {
                             Ok(()) => {
-                                child.reap_blocking();
+                                child.wait_and_reap_blocking();
                                 "the elevated child was terminated".to_string()
                             }
                             Err(e) => {

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -188,39 +188,23 @@ impl RawAsyncChild {
         }
     }
 
-    /// Synchronous kill-then-reap for `Drop` (no reactor, no `wait()` future in flight). A plain
-    /// child is `TerminateProcess`d so the wait returns at once. A runas child a lower-integrity
-    /// parent cannot terminate is torn down best-effort WITHOUT blocking (universal teardown).
-    pub(crate) fn reap_blocking(&mut self) {
+    /// `true` once this backend has collected the child's exit status, so no wait remains.
+    pub(crate) fn is_reaped(&self) -> bool {
+        self.exited.is_some()
+    }
+
+    /// Wait for the child's exit; the caller has already signalled it. **Never kills:** a second
+    /// `TerminateProcess` on an already-exiting child returns ACCESS_DENIED, and the classified
+    /// kill decision was already made on the dropping thread.
+    pub(crate) fn wait_and_reap(&mut self) {
         if self.exited.is_some() {
             return;
         }
-        if self.runas {
-            // SAFETY: our live, owned process handle.
-            match unsafe { TerminateProcess(self.handle(), 1) } {
-                Ok(()) => {
-                    // It will exit; the wait is bounded by a real termination event.
-                    // SAFETY: our live, owned process handle.
-                    let _ = unsafe { WaitForSingleObject(self.handle(), INFINITE) };
-                }
-                Err(e) if e.code() == windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0) => {
-                    if !matches!(self.try_wait(), Ok(Some(_))) {
-                        log::warn!(
-                            "elevated async child {} could not be terminated on drop; leaving it running",
-                            self.pid
-                        );
-                    }
-                }
-                Err(e) => log::warn!("terminating elevated async child {} on drop failed: {e:?}", self.pid),
-            }
-            return;
-        }
-        let _ = self.start_kill();
-        // SAFETY: our live, owned process handle; INFINITE is bounded by the kill above.
+        // SAFETY: our live, owned process handle; INFINITE is bounded by the caller's kill.
         let waited = unsafe { WaitForSingleObject(self.handle(), INFINITE) };
         debug_assert!(
             waited == WAIT_OBJECT_0,
-            "raw async Drop did not observe child {} exit: {waited:?}",
+            "raw async teardown did not observe child {} exit: {waited:?}",
             self.pid
         );
         let _ = waited;

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -232,15 +232,10 @@ async fn async_drop_tears_down_a_contained_tree() {
         cosca::Containment::None,
         "contained spawn must engage a mechanism"
     );
-    let root_id = child.id();
     drop(child);
-    // The root is deterministically dead — reap_now blocked until its exit before Drop returned.
-    assert_eq!(
-        root_id.is_alive(),
-        cosca::identity::Liveness::Dead,
-        "the contained root must be torn down by Drop"
-    );
-    // The grandchild's death is proven by its control-socket EOF: a survivor blocks the read (a CI failure).
+    // No post-drop liveness assertion: `Drop` signals and does not wait, and `start_kill` is
+    // asynchronous. Each process's death is proven by its own control-socket EOF: a survivor
+    // blocks the read (a CI failure).
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {
@@ -253,15 +248,15 @@ async fn async_drop_tears_down_a_contained_tree() {
 
 #[tokio::test]
 async fn async_drop_after_wait_still_tears_down_the_tree() {
-    // After awaiting the root's exit it is already reaped (reap_now is then a no-op), so the tree
-    // teardown must come from attached.hard_kill() on Drop — proven by the grandchild's EOF.
+    // After awaiting the root's exit it is already reaped, so `Drop` submits no job at all and the
+    // tree teardown must come from attached.hard_kill() — proven by the grandchild's EOF.
     use std::io::{Read as _, Write as _};
     let (mut child, mut root, mut grand) = common::spawn_grandchild_async(true);
     let root_id = child.id();
     root.write_all(b"x").expect("release the root so it exits");
     child.wait().await.expect("wait reaps the root");
     assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "root exited");
-    drop(child); // root already reaped → reap_now no-op; attached.hard_kill must still kill the grandchild
+    drop(child); // root already reaped → nothing submitted; attached.hard_kill must still kill the grandchild
     let mut buf = [0u8; 1];
     match grand.read(&mut buf) {
         Ok(0) => {}
@@ -322,23 +317,9 @@ async fn async_kill_on_drop_false_leaves_the_root_running() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn async_drop_leaves_no_zombie() {
-    // The guaranteed-reap contract: after Drop the child is FULLY reaped (reap_now waited for exit,
-    // then tokio's field-drop collected the zombie). Reuse-immune proof: the child's original
-    // identity (pid + start token) is gone. A zombie would still resolve to `Some(id)` (Linux /proc
-    // persists); a reaped pid resolves to `None` or, if recycled, a different identity — so a
-    // recycled pid never false-fails (no pid-reuse race, which a bare-pid `waitpid` would risk).
-    let (child, _sock) = common::spawn_blocker_async();
-    let id = child.id();
-    drop(child);
-    assert_ne!(
-        cosca::identity::ProcessId::of(id.pid()),
-        cosca::identity::Resolved::Found(id),
-        "Drop must fully reap the child (no lingering process/zombie at its identity)"
-    );
-}
+// `async_drop_leaves_no_zombie` moved to `drop_reaps_on_a_worker_thread` in
+// `src/tokio/child/reaper_tests.rs`: once `Drop` returns before the reap, only the
+// `#[cfg(test)]` probe offers an edge to sequence the no-zombie check after.
 
 // Arbitrary fd (n>=3) — Unix only, wired via command-fds (async mirror of spawn_io.rs) =====
 
@@ -687,13 +668,9 @@ async fn async_windows_contained_spawn_runs_then_job_tears_down() {
         cosca::Containment::JobObject,
         "Windows Strongest => JobObject"
     );
-    let root_id = child.id();
     drop(child);
-    assert_eq!(
-        root_id.is_alive(),
-        cosca::identity::Liveness::Dead,
-        "the contained root must be torn down by Drop"
-    );
+    // As in `async_drop_tears_down_a_contained_tree`: `Drop` does not wait, so the control-socket
+    // EOFs are the real edges.
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {


### PR DESCRIPTION
`cosca::tokio::Child::drop` blocked the dropping thread: its Unix path ran a
`waitid(WEXITED|WNOWAIT)` retry loop until the child exited. `Drop` is the one place a caller can
neither await nor cancel, and it is the teardown on abort and runtime-shutdown paths, so an async
consumer parked a runtime worker on a child that did not die promptly.

Every **signal** stays on the dropping thread; only the **wait** moves to a bounded pool.

## What `Drop` guarantees on return

| Exit | Tree signalled | Root signalled | Resources released | Waited |
| --- | --- | --- | --- | --- |
| `kill_on_drop(false)` / `detach()` | no, by design | no, by design | on the dropping thread | no |
| already reaped | yes | none to issue (tokio's `start_kill` on a reaped child sends nothing, so neither did the old code) | on the dropping thread | no |
| kill failed | yes | attempted, failed, logged if still running | on the dropping thread | no |
| normal | yes | yes | with the job, after the reap | no |

Never guaranteed on any path: that the root has exited, or that it has been reaped. Across all
four exits the set of signals issued is identical to before.

**Behaviour break:** the async `Drop` no longer implies "the child is gone when `drop` returns".
Call `kill()`/`kill_tree()` and await `wait()`/`wait_tree()` to observe the teardown.

## The pool

Up to 4 worker threads over one MPMC queue, each owning a cloned `crossbeam_channel::Receiver` —
no mutex, so a wedged job occupies one worker and no other.

Growth is driven by **idle tokens the workers publish themselves**. A worker publishes one only
when it parks in `recv`, and holds none while it runs a job; the first receive after it starts is
owed to the thread that started it, so it publishes nothing for that either. `submit` therefore
either claims a token (a parked worker exists and no other job can take it), or starts a worker
under the bound, or — at the bound — queues. Every send is backed by a receive no other job can
take, which is what makes this a bulkhead rather than a serial reaper. A thread that failed to
start publishes nothing, so a failed spawn can never be mistaken for a live worker.

The slot counter is the **cap and only the cap**: a reservation never authorises a send. When a
spawn fails, the slot is rolled back and the job — still in hand — goes to the release path.

**At the bound the job queues rather than releasing.** Four busy workers is the ordinary shape of a
burst of short-lived children, each finishing in microseconds; and if the four are instead all
wedged, the runtime's orphan handling could not reap the fifth child either, so releasing would
trade a delay for a leak. Logged at `debug`.

**Degraded mode.** When the OS refuses a thread and none was idle, the job is released in hand at
`log::error!` and the child goes to the runtime's orphan handling — best-effort, and a no-op on
Windows. Blocking the dropping thread would reinstate the defect at the worst moment; holding
pinned pids in our own queue indefinitely is worse.

Workers are immortal: the loop ends only on disconnect (impossible — both channel ends live in the
pool), and the whole job body runs inside `catch_unwind`.

## Why the resource fields travel with the backend

`attached`, `pipes` and `owned_std` all drop after `proc` today. Handing `proc` off alone would
invert that: a Linux cgroup leaf would fail both its removals while the root is still live and
leak, as the normal case rather than the rare one. The job carries the backend rather than a bare
pid for the same reason — the backend pins the pid for the whole wait, and a bare pid could be
reaped by the runtime's orphan queue and recycled onto another of our children under our own
`waitid`.

## Invariant: the tree is SIGNALLED on the dropping thread

`Attached::hard_kill()` must not move off it. The graceful phase's signal stops at group
boundaries — `CTRL_BREAK` reaches only the root's console group, `SIGTERM` via `killpg` only the
root's process group — so a nested descendant leading its own group survives it and this is the
only thing that reaches it.

## Sync surface: unchanged, deliberately

A sync `Child::drop` runs on the caller's own thread, with no reactor multiplexed onto it, so
blocking is the ordinary RAII contract. Both `Drop` impls now name the other.

## New dependency

`crossbeam-channel`, optional, enabled only by the `tokio` feature. `std::sync::mpsc::Receiver`
is neither `Sync` nor `Clone`, so the std route is a hand-rolled queue behind a mutex whose most
likely defect — holding the guard across the job — collapses the bulkhead into a serial reaper.

## Residual

`Attached::hard_kill()` still does unbounded work on the dropping thread on the
`ProcessGroup`/`Session`, `FdMarker` and `TreeWalk` arms. Filed separately (#111), along with
the spawn-error-path wait (#112).

## Test counts

Baselines read from CI run
[32097153685](https://github.com/bindreams/cosca/actions/runs/32097153685) on merged `main`
`c1f6f03` (green on all six platforms). The library target is heavily `cfg`-gated, so no single
count holds across the triples.

| Platform | `--lib` baseline | expected | `--test tokio_io` baseline | expected |
| --- | --- | --- | --- | --- |
| linux/amd64 | 551 | 559 (+8) | 32 | 31 (−1) |
| linux/arm64 | 551 | 559 (+8) | 32 | 31 (−1) |
| darwin/amd64 | 644 | 652 (+8) | 32 | 31 (−1) |
| darwin/arm64 | 644 | 652 (+8) | 32 | 31 (−1) |
| windows/amd64 | 602 | 610 (+8) | 26 | 26 (±0) |
| windows/arm64 | 602 | 610 (+8) | 26 | 26 (±0) |

`--lib` gains seven probe-based tests plus the `fixture_control_block` re-exec fixture, which is
itself a `#[test]`. `tokio_io` loses `async_drop_leaves_no_zombie` (`#[cfg(unix)]`, hence ±0 on
Windows); its property moved to `drop_reaps_on_a_worker_thread`, which makes the identical
reuse-immune pid+start-token comparison but sequences it after a real edge instead of after a
`Drop` that merely happened to block. That comparison is `#[cfg(unix)]` in its new home too: a
Windows pid outlives its last handle by an asynchronous kernel rundown nothing in user mode
signals (measured: 0-14 `OpenProcess` probes of slack on an idle box), so on Windows the property
has no edge and is not asserted.

Closes #105.
