### PR TITLE
fix(tokio): reap the elevated cleanup child on a wait-only entry, not a second kill

### DIFF
--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -89,6 +89,9 @@ fn fixture_survives_group_signal() {
 
 /// The fully-qualified libtest path of [`fixture_registers_then_blocks`], for callers that
 /// re-exec this binary against it directly (`current_exe() --exact <this>`).
+// Gated with its consumers: the sync caller uses it only under `cfg(windows)`, the other two are
+// behind the `tokio` feature, so a default-feature Unix build has none and `-D warnings` rejects it.
+#[cfg(any(windows, feature = "tokio"))]
 pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_TEST: &str = "test_child::fixture_registers_then_blocks";
 
 /// The env var carrying the `127.0.0.1:<port>` address [`fixture_registers_then_blocks`] tags.
@@ -98,6 +101,7 @@ pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV: &str = "COSCA_FIXTURE_R
 
 /// Bind a rendezvous listener for [`fixture_registers_then_blocks`]; returns it and its
 /// `127.0.0.1:<port>` address.
+#[cfg(any(windows, feature = "tokio"))]
 pub(crate) fn registration_rendezvous() -> (std::net::TcpListener, String) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind rendezvous listener");
     let addr = listener.local_addr().expect("local_addr").to_string();

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -89,39 +89,36 @@ fn fixture_survives_group_signal() {
 
 /// The fully-qualified libtest path of [`fixture_registers_then_blocks`], for callers that
 /// re-exec this binary against it directly (`current_exe() --exact <this>`).
-#[cfg(windows)]
 pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_TEST: &str = "test_child::fixture_registers_then_blocks";
 
 /// The env var carrying the `127.0.0.1:<port>` address [`fixture_registers_then_blocks`] tags.
 /// Its mere presence also tells the fixture it was re-exec'd deliberately rather than picked up
 /// by an ordinary, unfiltered suite run.
-#[cfg(windows)]
 pub(crate) const FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV: &str = "COSCA_FIXTURE_REGISTERS_THEN_BLOCKS_ADDR";
 
 /// Bind a rendezvous listener for [`fixture_registers_then_blocks`]; returns it and its
 /// `127.0.0.1:<port>` address.
-#[cfg(windows)]
 pub(crate) fn registration_rendezvous() -> (std::net::TcpListener, String) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind rendezvous listener");
     let addr = listener.local_addr().expect("local_addr").to_string();
     (listener, addr)
 }
 
-/// Windows-only fixture supplying the happens-before edge a cooperative console signal needs: a
-/// no-op when picked up by an ordinary, unfiltered suite run
-/// ([`FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV`] is unset there). Re-executed via `current_exe()
-/// --exact` [`FIXTURE_REGISTERS_THEN_BLOCKS_TEST`] with that var set, it connects to the
-/// caller's listener, writes one tag byte, then blocks on a 1-byte read of that same socket.
+/// Fixture supplying a happens-before edge on a live child: a no-op when picked up by an
+/// ordinary, unfiltered suite run ([`FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV`] is unset there).
+/// Re-executed via `current_exe() --exact` [`FIXTURE_REGISTERS_THEN_BLOCKS_TEST`] with that var
+/// set, it connects to the caller's listener, writes one tag byte, then blocks on a 1-byte read
+/// of that same socket. The caller unblocks it by writing a byte back, and it then exits 0 of
+/// its own accord — an exit code no forced kill can produce.
 ///
-/// The tag is the edge: the fixture cannot write it until it is executing its own code, which is
-/// after the console has registered it. A child signalled before that point dies during loader
-/// init instead of to the console event, which is a different exit code and a different thing
-/// under test.
+/// The tag is the edge: the fixture cannot write it until it is executing its own code. On
+/// Windows that is also after the console has registered it — a child signalled before that
+/// point dies during loader init instead of to the console event, which is a different exit code
+/// and a different thing under test.
 ///
 /// It installs no console-control handler, so `CTRL_BREAK`'s default disposition terminates it.
 /// Blocking on the socket rather than parking means a panicking or aborted caller closes the
 /// socket and the fixture exits on EOF instead of orphaning.
-#[cfg(windows)]
 #[test]
 fn fixture_registers_then_blocks() {
     let Some(addr) = std::env::var_os(FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV) else {

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -91,7 +91,7 @@ impl Child {
         )
     }
     /// Blocking reap used by the POSIX spawn-error cleanup path (a sync context — no reactor
-    /// `await` available), delegating to the same per-backend primitive `Drop` uses.
+    /// `await` available).
     ///
     /// **Wait-only, and the caller must already have killed successfully** — that kill is the
     /// precondition that bounds this wait. Killing again here would gate the wait on the second

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -90,12 +90,19 @@ impl Child {
             Some(crate::elevation::ElevatedVia::Wrapped(_) | crate::elevation::ElevatedVia::WindowsUac)
         )
     }
-    /// Blocking kill-then-reap used by the POSIX spawn-error cleanup path (a sync context — no
-    /// reactor `await` available), delegating to the same per-backend primitive `Drop` uses.
+    /// Blocking reap used by the POSIX spawn-error cleanup path (a sync context — no reactor
+    /// `await` available), delegating to the same per-backend primitive `Drop` uses.
+    ///
+    /// **Wait-only, and the caller must already have killed successfully** — that kill is the
+    /// precondition that bounds this wait. Killing again here would gate the wait on the second
+    /// kill's result, and a second kill of an elevated child can be refused (it drops to root
+    /// mid-teardown, and a zombie keeps the credentials it died with), so the reap would be
+    /// skipped on the ordinary success path.
+    ///
     /// Unix-only: the Windows elevation arm builds its child in-module with no deferred password.
     #[cfg(unix)]
-    pub(super) fn reap_blocking(&mut self) {
-        self.proc.reap_now_on_drop(self.id.pid());
+    pub(super) fn wait_and_reap_blocking(&mut self) {
+        self.proc.wait_and_reap(self.id.pid());
     }
 
     /// The child's stable identity — valid after `wait`.
@@ -577,6 +584,10 @@ impl Child {
 mod child_drop_tests;
 
 #[cfg(test)]
+#[path = "child_reap_tests.rs"]
+mod child_reap_tests;
+
+#[cfg(test)]
 #[path = "child_wait_tree_tests.rs"]
 mod child_wait_tree_tests;
 
@@ -617,14 +628,10 @@ impl Drop for Child {
     }
 }
 
-/// Guaranteed synchronous teardown, shared by `Drop` and the spawn error path: kill the child,
-/// then block until it has exited. On Unix we wait with `WNOWAIT` (NOT reaping), so tokio's own
-/// `Child` field-drop reaps the zombie synchronously in its drop (its `try_wait` returns
-/// `Ok(Some)`, not a park-dependent orphan enqueue) — a guaranteed reap before `Drop` returns.
-/// We only wait while tokio still owns the child (`id().is_some()`), which pins the pid; once
-/// tokio is `Done` (a prior `wait()` reaped it), the pid may be recycled and we must not wait on
-/// it. `done_ok` says whether an already-`Done` child is legal here: `true` for `Drop` (the user
-/// may have `wait()`ed), `false` for the spawn-error path (the child was never awaited).
+/// Guaranteed synchronous teardown for `Drop`: kill the child, then block until it has exited.
+/// The kill here is what bounds the wait, so a caller that has ALREADY killed must use
+/// [`wait_and_reap`] instead — re-killing would make its reap conditional on a second kill that
+/// can be refused.
 /// **Invariant:** no `wait()` future for this child is in flight when this runs.
 pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: bool) {
     // `start_kill` bounds the wait below — it MUST run in release (NOT inside `debug_assert!`,
@@ -637,12 +644,27 @@ pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: b
     if killed.is_err() {
         return;
     }
+    wait_and_reap(child, pid, done_ok);
+}
+
+/// The wait-then-reap half of [`reap_now`], with **no kill of its own**: the caller's own
+/// successful kill is the precondition that bounds this wait.
+///
+/// On Unix we wait with `WNOWAIT` (NOT reaping), so tokio's own `Child` field-drop reaps the
+/// zombie synchronously in its drop (its `try_wait` returns `Ok(Some)`, not a park-dependent
+/// orphan enqueue) — a guaranteed reap before the handle is gone. We only wait while tokio still
+/// owns the child (`id().is_some()`), which pins the pid; once tokio is `Done` (a prior `wait()`
+/// reaped it), the pid may be recycled and we must not wait on it. `done_ok` says whether an
+/// already-`Done` child is legal here: `true` for `Drop` (the user may have `wait()`ed), `false`
+/// for a caller whose child was never awaited.
+/// **Invariant:** no `wait()` future for this child is in flight when this runs.
+pub(crate) fn wait_and_reap(child: &mut ::tokio::process::Child, pid: u32, done_ok: bool) {
     // tokio `Done` ⇒ already reaped, pid possibly recycled ⇒ nothing to do (the recycled-pid wait
     // hazard the sync side avoids by holding a handle).
     if child.id().is_none() {
         debug_assert!(
             done_ok,
-            "reap_now found an already-reaped child where one was impossible"
+            "wait_and_reap found an already-reaped child where one was impossible"
         );
         return;
     }
@@ -666,7 +688,7 @@ pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: b
             }
             // id() was Some above (tokio un-reaped ⇒ pid pinned), so no ECHILD / other errno should
             // occur — a debug tripwire, with a safe release `break`.
-            debug_assert!(false, "waitid in reap_now failed unexpectedly: {err}");
+            debug_assert!(false, "waitid in wait_and_reap failed unexpectedly: {err}");
             break;
         }
     }
@@ -677,11 +699,11 @@ pub(crate) fn reap_now(child: &mut ::tokio::process::Child, pid: u32, done_ok: b
         let _ = pid;
         let h = child.raw_handle().expect("tokio owns the handle while id() is Some");
         // SAFETY: tokio owns and (on its field-drop) closes the handle; we only wait on it.
-        // INFINITE is bounded by `start_kill` above.
+        // INFINITE is bounded by the kill the caller already issued.
         let waited = unsafe { WaitForSingleObject(HANDLE(h), INFINITE) };
         debug_assert!(
             waited == WAIT_OBJECT_0,
-            "reap_now did not observe the child's exit: {waited:?}"
+            "wait_and_reap did not observe the child's exit: {waited:?}"
         );
     }
 }

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -97,6 +97,20 @@ impl ProcSource {
         }
     }
 
+    /// Block until the child has exited, then let the backend reap it. **Never kills** — the
+    /// caller's own successful kill is what bounds the wait.
+    /// **Invariant:** no `wait()` future for this child is in flight when this runs.
+    ///
+    /// Unix-only, so it needs no `Raw` arm: that backend exists only on Windows, and the sole
+    /// caller ([`Child::wait_and_reap_blocking`](super::Child::wait_and_reap_blocking)) is the
+    /// POSIX elevated-spawn cleanup path.
+    #[cfg(unix)]
+    pub(crate) fn wait_and_reap(&mut self, pid: u32) {
+        match self {
+            ProcSource::Tokio(c) => super::wait_and_reap(c, pid, true),
+        }
+    }
+
     /// Install the per-instance test wait observer (raw backend only). Panics on a Tokio child —
     /// the observer seam exists solely for the raw async wait path.
     #[cfg(all(test, windows))]

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -103,11 +103,13 @@ impl ProcSource {
     ///
     /// Unix-only, so it needs no `Raw` arm: that backend exists only on Windows, and the sole
     /// caller ([`Child::wait_and_reap_blocking`](super::Child::wait_and_reap_blocking)) is the
-    /// POSIX elevated-spawn cleanup path.
+    /// POSIX elevated-spawn cleanup path. That child was never awaited, so `done_ok` is `false`
+    /// (matching the other never-awaited callers): an already-reaped one is a broken precondition,
+    /// not a case to return quietly from — which is the shape this entry exists to remove.
     #[cfg(unix)]
     pub(crate) fn wait_and_reap(&mut self, pid: u32) {
         match self {
-            ProcSource::Tokio(c) => super::wait_and_reap(c, pid, true),
+            ProcSource::Tokio(c) => super::wait_and_reap(c, pid, false),
         }
     }
 

--- a/src/tokio/child_reap_tests.rs
+++ b/src/tokio/child_reap_tests.rs
@@ -1,0 +1,60 @@
+// `wait_and_reap` is the half of the teardown primitive that a caller which has ALREADY killed
+// uses. Its whole point is that it issues no kill of its own, so its wait rests on the caller's
+// kill instead of on a second one that can be refused.
+//
+// The fixture is the oracle. `test_child::fixture_registers_then_blocks` tags the rendezvous
+// socket (proving it is live and executing its own code — no timer, no poll), blocks on a 1-byte
+// read of that socket, and on receiving the byte exits 0 of its own accord. Exit code 0 is
+// unreachable through a kill: `TerminateProcess(_, 1)` reports 1 and `SIGKILL` reports no code at
+// all. So the status this test reads distinguishes "waited for the child's own exit" from "killed
+// it and waited for that", which is exactly the difference between this function and `reap_now`.
+//
+// Runs on every target: the elevated-spawn cleanup path that needs the wait-only entry is
+// `#[cfg(unix)]`, but the primitive and its Windows arm are not, and a kill re-added on either
+// arm fails here.
+#[tokio::test]
+async fn wait_and_reap_waits_for_the_childs_own_exit_and_never_kills() {
+    use std::io::{Read, Write};
+
+    let (listener, addr) = crate::test_child::registration_rendezvous();
+    let mut child = {
+        // Every cosca-originated spawn takes this lock; a raw tokio spawn here must too, so a
+        // macOS fork cannot transiently inherit another test's fd-marker write end.
+        let _guard = crate::child::spawn::spawn_lock();
+        ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"))
+            .args([
+                "--test-threads=1",
+                "--exact",
+                crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_TEST,
+            ])
+            .env(crate::test_child::FIXTURE_REGISTERS_THEN_BLOCKS_ADDR_ENV, &addr)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn the rendezvous fixture")
+    };
+    let pid = child.id().expect("tokio owns an un-reaped child");
+
+    let (mut sock, _) = listener.accept().expect("accept the fixture's rendezvous connection");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read the fixture's readiness tag");
+
+    // Release the fixture: its blocking read returns and it exits 0 on its own.
+    sock.write_all(b"g").expect("release the fixture");
+    sock.flush().expect("flush the release byte");
+
+    super::wait_and_reap(&mut child, pid, true);
+
+    // No poll loop and no retry: `try_wait` is called exactly once, immediately. It can only
+    // report an exit if `wait_and_reap` already blocked until the child had one.
+    let status = child
+        .try_wait()
+        .expect("try_wait")
+        .expect("wait_and_reap must return only after the child has exited");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "the fixture must have exited on its own; a kill inside wait_and_reap would report the \
+         forced code instead ({status:?})"
+    );
+}

--- a/src/tokio/child_reap_tests.rs
+++ b/src/tokio/child_reap_tests.rs
@@ -18,8 +18,9 @@ async fn wait_and_reap_waits_for_the_childs_own_exit_and_never_kills() {
 
     let (listener, addr) = crate::test_child::registration_rendezvous();
     let mut child = {
-        // Every cosca-originated spawn takes this lock; a raw tokio spawn here must too, so a
-        // macOS fork cannot transiently inherit another test's fd-marker write end.
+        // Raw tokio bypasses cosca's spawn path, so its internal `spawn_lock()` is taken here by
+        // hand: a macOS fork must not transiently inherit another test's fd-marker write end.
+        // Wrapping a *cosca* spawn this way would self-deadlock — the mutex is not reentrant.
         let _guard = crate::child::spawn::spawn_lock();
         ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"))
             .args([
@@ -63,6 +64,8 @@ async fn wait_and_reap_waits_for_the_childs_own_exit_and_never_kills() {
 /// libtest filter that matches nothing. See `test_child::spawn_a_process_that_exits` for why the
 /// filter is mandatory (an unfiltered re-exec runs the whole suite, including this test).
 fn spawn_a_tokio_child_that_exits() -> ::tokio::process::Child {
+    // Raw tokio, so it bypasses cosca's spawn path and its internal `spawn_lock()` — taken here
+    // by hand instead. A cosca spawn must NOT be wrapped this way (the mutex is not reentrant).
     let _guard = crate::child::spawn::spawn_lock();
     ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"))
         .args(["--exact", "__cosca_no_such_test__"])
@@ -119,10 +122,10 @@ async fn the_elevated_cleanup_entry_refuses_an_already_reaped_child() {
         .args(["cosca_unit_tests", "--exact", "__cosca_no_such_test__"]);
     cmd.stdout(crate::stdio::Stdio::null()).expect("stdout null");
     cmd.stderr(crate::stdio::Stdio::null()).expect("stderr null");
-    let mut child = {
-        let _guard = crate::child::spawn::spawn_lock();
-        cmd.spawn().expect("spawn")
-    };
+    // NO `spawn_lock()` here: this is a cosca spawn, which takes it internally, and it is a plain
+    // non-reentrant mutex. The raw `::tokio::process::Command` spawns elsewhere in this file take
+    // it by hand precisely because they bypass that path — do not copy the guard across.
+    let mut child = cmd.spawn().expect("spawn");
     child.wait().await.expect("wait");
     child.wait_and_reap_blocking();
     // Only reachable in release (debug panicked above, as expected):

--- a/src/tokio/child_reap_tests.rs
+++ b/src/tokio/child_reap_tests.rs
@@ -58,3 +58,76 @@ async fn wait_and_reap_waits_for_the_childs_own_exit_and_never_kills() {
          forced code instead ({status:?})"
     );
 }
+
+/// A tokio child that exits promptly and needs no external binary: this test binary with a
+/// libtest filter that matches nothing. See `test_child::spawn_a_process_that_exits` for why the
+/// filter is mandatory (an unfiltered re-exec runs the whole suite, including this test).
+fn spawn_a_tokio_child_that_exits() -> ::tokio::process::Child {
+    let _guard = crate::child::spawn::spawn_lock();
+    ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"))
+        .args(["--exact", "__cosca_no_such_test__"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn")
+}
+
+// `done_ok` is the whole diagnostic: an already-reaped child is legal for `Drop` (the user may
+// have `wait()`ed) and a broken precondition for a caller whose child was never awaited. Both
+// arms are pinned, so neither loosening the assert nor hard-firing it survives.
+//
+// Debug-only oracle, `kinfo_tests`' calm-release shape: `debug_assert!` is compiled out in the
+// release lane, where the same straight-line code returns instead — which the post-call assert
+// pins.
+#[cfg_attr(
+    debug_assertions,
+    should_panic(expected = "already-reaped child where one was impossible")
+)]
+#[tokio::test]
+async fn wait_and_reap_refuses_an_already_reaped_child_the_caller_never_awaited() {
+    let mut child = spawn_a_tokio_child_that_exits();
+    let pid = child.id().expect("tokio owns an un-reaped child");
+    child.wait().await.expect("wait");
+    super::wait_and_reap(&mut child, pid, false);
+    // Only reachable in release (debug panicked above, as expected):
+    assert!(child.id().is_none(), "the child was reaped by the wait() above");
+}
+
+#[tokio::test]
+async fn wait_and_reap_accepts_an_already_reaped_child_the_caller_may_have_awaited() {
+    let mut child = spawn_a_tokio_child_that_exits();
+    let pid = child.id().expect("tokio owns an un-reaped child");
+    child.wait().await.expect("wait");
+    super::wait_and_reap(&mut child, pid, true); // `Drop`'s disposition: legal, returns quietly
+}
+
+// The value the elevated-spawn cleanup path passes. That child is killed and reaped without ever
+// being awaited, so an already-reaped one means the precondition broke — passing `done_ok = true`
+// here would swallow it silently, the same shape this entry exists to remove from that path.
+//
+// `#[cfg(unix)]` with the entry itself: the Windows elevation arm has no deferred password.
+#[cfg(unix)]
+#[cfg_attr(
+    debug_assertions,
+    should_panic(expected = "already-reaped child where one was impossible")
+)]
+#[tokio::test]
+async fn the_elevated_cleanup_entry_refuses_an_already_reaped_child() {
+    let mut cmd = crate::tokio::Command::new();
+    cmd.executable(std::env::current_exe().expect("current_exe"))
+        // `cosca::Command::args` is the FULL argv; libtest drops slot 0 as the binary name.
+        .args(["cosca_unit_tests", "--exact", "__cosca_no_such_test__"]);
+    cmd.stdout(crate::stdio::Stdio::null()).expect("stdout null");
+    cmd.stderr(crate::stdio::Stdio::null()).expect("stderr null");
+    let mut child = {
+        let _guard = crate::child::spawn::spawn_lock();
+        cmd.spawn().expect("spawn")
+    };
+    child.wait().await.expect("wait");
+    child.wait_and_reap_blocking();
+    // Only reachable in release (debug panicked above, as expected):
+    assert!(
+        matches!(child.try_wait(), Ok(Some(_))),
+        "the child was reaped by the wait() above"
+    );
+}

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -79,12 +79,13 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
                         // Do NOT orphan the running elevated child on a genuine write failure:
                         // kill + reap, folding the teardown outcome into the error detail. A
                         // successful kill() (SIGKILL, uncatchable) is followed by a BLOCKING reap
-                        // (try_wait cannot reap a just-killed child, so it would leak a zombie); an
-                        // Err kill() (e.g. Unkillable) can't be reaped, so fall back to a
-                        // non-blocking try_wait() and note the child may still be running.
+                        // (try_wait cannot reap a just-killed child, so it would leak a zombie),
+                        // which waits only — this kill is what bounds it; an Err kill() (e.g.
+                        // Unkillable) can't be reaped, so fall back to a non-blocking try_wait()
+                        // and note the child may still be running.
                         let kill_note = match child.kill() {
                             Ok(()) => {
-                                child.reap_blocking();
+                                child.wait_and_reap_blocking();
                                 "the elevated child was terminated".to_string()
                             }
                             Err(e) => {


### PR DESCRIPTION
Closes #114.

The POSIX elevated-spawn cleanup path kills the child, then calls a blocking reap that kills it *again* and uses that second kill's result to decide whether to wait at all. A refused second kill — reachable on an elevated child, which drops fully to root mid-teardown and keeps those credentials as a zombie — therefore skips the wait on the path whose own comment promises "a successful `kill()` … is followed by a BLOCKING reap". In debug a `debug_assert` fires; in release nothing does, and the guaranteed synchronous reap degrades to tokio's park-dependent orphan queue.

`reap_now` splits into its two halves. `Drop` keeps the kill — it has not signalled the root itself, so its own kill is what bounds its wait, and skipping the wait when that kill fails is correct there. The elevated cleanup path gets the new wait-only `wait_and_reap`, with the caller's already-successful kill as the documented precondition. This is the shape the sync twin in `src/child/spawn.rs` has always had.

## Test

`wait_and_reap_waits_for_the_childs_own_exit_and_never_kills` drives the primitive against `test_child::fixture_registers_then_blocks`, which tags a rendezvous socket (proving it is live and running its own code), blocks on a 1-byte read, and on receiving the byte exits **0** — a code no kill can produce. `try_wait` is then called exactly once, with no poll loop.

The fixture and its two consts were `#[cfg(windows)]`; they are now unconditional, since nothing in them is Windows-specific and the primitive is not either. The elevated caller itself is `#[cfg(unix)]` and needs a real `sudo`/`doas` password-write failure, so it is not exercised here — the test covers the primitive both halves share, on every target.

**Mutation proofs**, 5 runs each, both `FAILED` every time:

| mutant | assertion that catches it |
| --- | --- |
| re-add `child.start_kill()` at the top of `wait_and_reap` | exit code is `1` (`TerminateProcess`), not `0` |
| make `wait_and_reap` return immediately | `try_wait` reports no exit at all |

## Verification

`cargo test --locked --all-features` on `x86_64-pc-windows-msvc`: **815 → 816 passed, 0 failed** across 21 binaries; the +1 is this test, and the sorted failure lists are both empty.

`cargo clippy --all-features --all-targets --locked -- -D warnings` clean natively and cross-target on `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked` clean on all three.


---

## Review round 2

**`done_ok` was inverted at the new call site.** `ProcSource::wait_and_reap` passed `true`, but this child was never awaited — the two other never-awaited callers of the primitive already pass `false`. With `true`, an already-reaped child returned with no wait and no diagnostic in either profile, which is the exact shape this PR exists to remove from this path. Now `false`, with the reason on the function.

Three tests pin it, in `child_reap_tests.rs`. The two cross-platform ones pin the parameter's meaning from both sides; the third pins the value this path passes and is `#[cfg(unix)]` with the entry itself. All use the `kinfo_tests` calm-release shape (`#[cfg_attr(debug_assertions, should_panic(...))]`) so the darwin release lane exercises the compiled-out arm instead of failing on it.

**Mutation proofs**, on the cross-platform pair:

| mutant | outcome |
| --- | --- |
| delete `debug_assert!(done_ok, …)` | `..._refuses_an_already_reaped_child_the_caller_never_awaited` FAILED (no panic where one was expected) |
| `debug_assert!(false, …)` | `..._accepts_an_already_reaped_child_the_caller_may_have_awaited` FAILED (panicked) |

**Not proved here:** flipping the call site back to `true` is caught only by the `#[cfg(unix)]` test, which this Windows box cannot run. CI's four Unix targets do.

Also cut the now-false *"delegating to the same per-backend primitive `Drop` uses"* from `wait_and_reap_blocking`'s doc — the split made it wrong, since `Drop` still kills-then-waits and this entry deliberately does not. The review filed that cut against #117; it belongs here, where the line lives and where the split happened.

**Verification:** suite 816 → 818 on `x86_64-pc-windows-msvc` (+2 cross-platform tests; +3 on Unix), 21 binaries, 0 failed, failure lists empty. Clippy `--all-targets -D warnings` clean 9/9 across {default, `tokio`, all-features} × {`x86_64-pc-windows-msvc`, `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`}; cross-target rustdoc clean on all three.


---

## Review round 3 — Unix deadlock

`the_elevated_cleanup_entry_refuses_an_already_reaped_child` took `spawn_lock()` by hand and then called `crate::tokio::Command::spawn`, which takes the same non-reentrant mutex internally ([`src/tokio/spawn.rs`](https://github.com/bindreams/cosca/blob/c1f6f03dd17d701d5bc654fcc8165dd87fd87b91/src/tokio/spawn.rs#L353-L365), and wider still on the macOS arm). Self-deadlock, holding the lock forever; the other three tests in the file then blocked acquiring it, so all four reported as stuck and the job died at the wall. `#[cfg(unix)]`, so Windows never compiled it.

The guard is gone. The three raw-`::tokio::process::Command` spawns in the same file keep theirs — they bypass cosca's spawn path, so they must take it — and all three sites now say which kind of spawn they are, so the pattern is not copied across again.

**Reproduced, not just reasoned:** re-adding the guard on a Linux host wedges that test with no result and the binary is killed at a 40s bound (exit 124); without it, all four pass in ~0.07s.

## Verification now runs on a Unix host

The last two rounds shipped Unix-only test code that had never executed anywhere — a nine-way clippy matrix typechecks Unix but cannot see a runtime deadlock. This round the suite ran on a real Linux host (WSL Ubuntu 24.04, `cargo test --locked --all-features`): **725 passed, 0 failed, 1 ignored** across 21 binaries, all four `child_reap_tests` green, and the `#[cfg(unix)]` test's `should_panic` oracle confirmed firing.

That also closes last round's stated gap. The mutation only the `#[cfg(unix)]` test can catch — reverting the call site to `done_ok = true` — was run on Linux and **FAILED that test, and only that test**.

Windows suite unchanged at 818 passed / 0 failed. Clippy `--all-targets -D warnings` 9/9 clean across {default, `tokio`, all-features} × {`x86_64-pc-windows-msvc`, `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`}; cross-target rustdoc clean on all three.
