### PR TITLE
docs: record the drop-thread tree-signal invariant, the sync/async reap divergence, and kill_on_drop's contract

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -525,6 +525,12 @@ impl Drop for Child {
             );
             log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
         }
+        // Kill, block until the child has exited, and collect its status here — this handle owns
+        // the child outright. The async twin (`cosca::tokio::Child`'s `Drop`) blocks the same way
+        // but must NOT collect: tokio owns that child and its own reaping, so it waits without
+        // reaping and leaves the collection to tokio's field-drop. `src/tokio/` mirrors this
+        // surface by hand with nothing enforcing parity, so that difference is deliberate, not
+        // drift.
         self.proc.teardown_on_drop();
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -202,6 +202,18 @@ impl Command {
         self
     }
 
+    /// Tear the child down when its handle drops. **On by default**; pass `false` to opt out for
+    /// every child of this command, or [`Child::detach`](crate::Child::detach) to opt one out
+    /// after the fact.
+    ///
+    /// What "tear down" means, on both handles: hard-kill the contained tree (a no-op for an
+    /// uncontained child — see [`contain`](Command::contain)), then block until the ROOT has
+    /// exited. There is no cooperative signal first; use
+    /// [`graceful_shutdown_tree`](crate::Child::graceful_shutdown_tree) before dropping if the
+    /// child needs one. Descendants are killed, not waited for.
+    ///
+    /// An elevated child this process cannot signal is the one case that does not block: the
+    /// teardown gives up rather than wait forever, and the child is left running.
     pub fn kill_on_drop(&mut self, yes: bool) -> &mut Command {
         self.kill_on_drop = yes;
         self

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -604,6 +604,9 @@ impl Child {
     }
 }
 
+/// Hard-kills the contained tree, then blocks until the root has exited — the same shape as the
+/// sync [`Child`](crate::Child)'s `Drop`. What differs, deliberately, is who collects the status:
+/// see the reap below.
 impl Drop for Child {
     fn drop(&mut self) {
         if !self.kill_on_drop {
@@ -611,6 +614,20 @@ impl Drop for Child {
         }
         // Tree teardown — the SOLE coverage for descendants (reap_now only guarantees the root),
         // so surface a real mechanism failure in debug. A no-op for an uncontained child.
+        //
+        // MUST stay on the dropping thread, and the reason is mechanism-specific — deferring it
+        // to a background thread or an awaitable teardown would take the guarantee away.
+        //
+        // Windows job object: a nested contained descendant is spawned into its OWN process group
+        // (`windows::group_flags`), so a consumer's `terminate_tree` — `CTRL_BREAK` to the ROOT's
+        // group — never reaches it, and `TerminateJobObject` here is the only thing that does.
+        //
+        // Unix: reach is identical either way. A nested contained descendant is `Delegated` and
+        // creates no group of its own, so `killpg` reaches it; a descendant that escaped by
+        // calling `setsid` itself is out of `hard_kill`'s reach too, since that is the same
+        // `killpg`. (The cgroup and fd-marker mechanisms sweep the same membership for both
+        // signals.) What this adds there is force, not reach: `SIGTERM` is catchable, `SIGKILL`
+        // is not.
         let tree = self.attached.hard_kill();
         if let Err(e) = &tree {
             debug_assert!(
@@ -623,6 +640,11 @@ impl Drop for Child {
         // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
         // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend
         // (tokio field-drop reap vs the raw handle's kill-then-wait).
+        //
+        // The sync twin (`crate::Child`'s `Drop`) collects the status itself; this one must not —
+        // tokio owns the child and its own reaping, so the wait is non-reaping (`WNOWAIT`) and the
+        // collection is left to tokio's field-drop. `src/tokio/` mirrors the sync surface by hand
+        // with nothing enforcing parity, so that difference is deliberate, not drift.
         let pid = self.id.pid();
         self.proc.reap_now_on_drop(pid);
     }

--- a/src/tokio/command.rs
+++ b/src/tokio/command.rs
@@ -87,6 +87,9 @@ impl Command {
         self.inner.current_dir(dir);
         self
     }
+    /// Async mirror of [`Command::kill_on_drop`](crate::Command::kill_on_drop) — see there for
+    /// what the teardown does. The per-child opt-out is
+    /// [`Child::detach`](crate::tokio::Child::detach).
     pub fn kill_on_drop(&mut self, yes: bool) -> &mut Command {
         self.inner.kill_on_drop(yes);
         self


### PR DESCRIPTION
Stacked on #115 — review that first; this PR's base is `azhukova/114`.

Three contracts the code already keeps but never wrote down. Comments only; no behaviour change.

**The tree teardown must stay on the dropping thread.** `attached.hard_kill()` in the async `Drop` is already noted as the sole coverage for descendants; what was missing is why it cannot move. A consumer's cooperative signal stops at group boundaries — `CTRL_BREAK` reaches only the root's console group, `SIGTERM` via `killpg` only the root's process group — so a nested contained descendant leading its own group survives `terminate_tree`, and this call is the only thing that reaches it before `drop` returns. Without that recorded, deferring it to a background thread or an awaitable teardown reads as a clean improvement.

**The sync/async reap divergence.** Both `Drop`s kill the tree and then block until the root has exited. They differ in who collects the status: the sync handle owns the child and collects it itself; the async one must not, because tokio owns that child and its own reaping, so it waits non-reaping (`WNOWAIT`) and leaves the collection to tokio's field-drop. Noted on both impls, each naming the other — `src/tokio/` mirrors the sync surface by hand with nothing enforcing parity, so this is the only thing standing between that difference and a future "restore parity" edit.

**`kill_on_drop`'s contract**, written for the first time: on by default, what "tear down" actually means on both handles, that there is no cooperative signal first, that descendants are killed rather than waited for, and that an unkillable elevated child is left running rather than blocked on.

## Salvage notes

The wording comes from the parked branch on #105, which is redesigning its scheduling. Two of the three claims described its unlanded reaper pool rather than today's code and were reworked:

- It documented the async `Drop` as *"signals the tree and the root and does NOT wait"*, diverging from a blocking sync twin. That divergence does not exist today — both block. Replaced with the divergence that does exist, which is about reaping, not blocking.
- `kill_on_drop`'s note carried the same claim (*"the sync `Child` blocks …; the async `Child` only signals"*). Dropped, and the contract rewritten from what `Drop` does on `main`.
- The tree-signal invariant survives close to verbatim; "the graceful phase's signal" was reworded to name the consumer's `terminate_tree`, since on `main` there is no graceful phase inside `Drop`.

Everything asserted here was checked against `main`: `kill_on_drop` defaults to `true`; `Attached::hard_kill` is a single kill pass on every mechanism, never a drain wait; and the unkillable-child give-up is real on the sync `teardown_on_drop`, the async tokio arm, and the Windows raw runas arm alike.

## Verification

`cargo test --locked --all-features` on `x86_64-pc-windows-msvc`: **816 passed, 0 failed** across 21 binaries, before and after (both empty failure lists) — identical, as expected for a comments-only change.

`cargo clippy --all-features --all-targets --locked -- -D warnings` clean natively and cross-target on `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked` clean on all three — the new intra-doc links resolve on every target.


---

## Review round 2

**The tree-signal invariant's rationale was wrong on Unix.** It claimed a nested contained descendant leads its own group and so survives `terminate_tree`'s `killpg`. Verified against the code, neither half holds there:

- A nested contained descendant is `Containment::Delegated` — [dispatch](https://github.com/bindreams/cosca/blob/c1f6f03dd17d701d5bc654fcc8165dd87fd87b91/src/containment/dispatch.rs#L575-L580) returns it precisely because *"it joined the ancestor's cgroup/process group … rather than creating its own"*. It stays in the root's group, and `killpg` reaches it.
- A descendant that escaped by calling `setsid` itself is out of `hard_kill`'s reach too, since `Attached::ProcessGroup`'s `hard_kill` is the same `killpg` on the same pgid.
- The cgroup and fd-marker mechanisms sweep the same membership for both signals (`CgroupLeaf::terminate` walks `cgroup.procs`; `Marker::terminate` is a `sweep_pass` like `hard_kill`'s), so there is no reach gap there either.

The conclusion survives, but only for the Windows job object: `windows::group_flags` gives every nested contained spawn `CREATE_NEW_PROCESS_GROUP`, so `CTRL_BREAK` to the root's group genuinely never reaches it, and `TerminateJobObject` genuinely is the only thing that does. The comment now says that, and states the Unix case as what it actually is — same reach either way, so what `hard_kill` adds there is force, not reach.

This mattered beyond the diff: the comment is the only recorded justification for a constraint the scheduler redesign has to respect, and a wrong reason would have been designed against.

**Verification:** comments only — suite unchanged at 818 passed, 0 failed, 21 binaries. Clippy `--all-targets -D warnings` clean 9/9 across {default, `tokio`, all-features} × three targets; cross-target rustdoc clean on all three.
