### PR TITLE
refactor(tokio): make the async child's process backend takeable

### DIFF
--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -27,10 +27,14 @@ pub(super) type FdPipes = BTreeMap<Fd, ParentEnd>;
 #[cfg(windows)]
 pub(super) type FdPipes = BTreeMap<Fd, super::stdio::OwnedStd>;
 
+/// The `expect` behind the two backend accessors: nothing takes `proc`, so both are infallible.
+const PROC_TAKEN: &str = "the async child's process backend is never taken";
+
 #[derive(Debug)]
 pub struct Child {
-    // `pub(super)`: the sibling `pump` module borrows the backend for `communicate`'s `wait` future.
-    pub(super) proc: ProcSource,
+    /// `Option` only so the backend can be moved out of a `&mut self` receiver; nothing does.
+    /// Read it through `proc_mut()` / `proc()`, never directly.
+    proc: Option<ProcSource>,
     id: ProcessId,
     attached: Attached,
     kill_on_drop: bool,
@@ -60,7 +64,7 @@ impl Child {
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
-            proc,
+            proc: Some(proc),
             id,
             attached: attachment.attached,
             kill_on_drop,
@@ -70,6 +74,17 @@ impl Child {
             owned_std,
             elevation: None,
         }
+    }
+
+    /// The process backend. `pub(super)`: the sibling `pump` module borrows it for
+    /// `communicate`'s `wait` future, and `child::graceful` for its pid-pinning guard.
+    pub(super) fn proc_mut(&mut self) -> &mut ProcSource {
+        self.proc.as_mut().expect(PROC_TAKEN)
+    }
+    /// Shared read-only accessor for the two `pins_pid` guards, which hold `&self`.
+    #[cfg(windows)]
+    pub(super) fn proc(&self) -> &ProcSource {
+        self.proc.as_ref().expect(PROC_TAKEN)
     }
 
     /// Attach the elevation report — set by the spawn arms before the deferred password write, so
@@ -102,7 +117,8 @@ impl Child {
     /// Unix-only: the Windows elevation arm builds its child in-module with no deferred password.
     #[cfg(unix)]
     pub(super) fn wait_and_reap_blocking(&mut self) {
-        self.proc.wait_and_reap(self.id.pid());
+        let pid = self.id.pid();
+        self.proc_mut().wait_and_reap(pid);
     }
 
     /// The child's stable identity — valid after `wait`.
@@ -125,7 +141,7 @@ impl Child {
         if let Some(owned) = self.take_owned_in(crate::stdio::Fd::STDIN) {
             return Some(super::stdio::ChildStdin { inner: owned });
         }
-        self.proc.take_stdin().map(|s| super::stdio::ChildStdin {
+        self.proc_mut().take_stdin().map(|s| super::stdio::ChildStdin {
             inner: super::stdio::InInner::Tokio(s),
         })
     }
@@ -133,7 +149,7 @@ impl Child {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDOUT) {
             return Some(super::stdio::ChildStdout { inner: owned });
         }
-        self.proc.take_stdout().map(|s| super::stdio::ChildStdout {
+        self.proc_mut().take_stdout().map(|s| super::stdio::ChildStdout {
             inner: super::stdio::OutInner::Stdout(s),
         })
     }
@@ -141,7 +157,7 @@ impl Child {
         if let Some(owned) = self.take_owned_out(crate::stdio::Fd::STDERR) {
             return Some(super::stdio::ChildStderr { inner: owned });
         }
-        self.proc.take_stderr().map(|s| super::stdio::ChildStderr {
+        self.proc_mut().take_stderr().map(|s| super::stdio::ChildStderr {
             inner: super::stdio::OutInner::Stderr(s),
         })
     }
@@ -357,11 +373,11 @@ impl Child {
     /// Block until the child exits, returning its status. For a bounded wait use
     /// `tokio::time::timeout(d, child.wait())`.
     pub async fn wait(&mut self) -> Result<ExitStatus, Error> {
-        self.proc.wait().await
+        self.proc_mut().wait().await
     }
     /// Exit status if the child has already exited (non-blocking).
     pub fn try_wait(&mut self) -> Result<Option<ExitStatus>, Error> {
-        self.proc.try_wait()
+        self.proc_mut().try_wait()
     }
 
     /// Hard-kill the (lone) child. Handle-bound, so it cannot race a recycled pid.
@@ -371,7 +387,7 @@ impl Child {
     pub fn kill(&mut self) -> Result<(), Error> {
         // A plain child is unaffected (the mapping only fires on an elevated wrapper child whose
         // kill returns EPERM/ACCESS_DENIED); everything else stays `Io`/`Ok` exactly as before.
-        match self.proc.start_kill() {
+        match self.proc_mut().start_kill() {
             Err(Error::Io(e)) => Err(crate::elevation::map_elevated_kill_error(e, self.is_elevated_wrapper())),
             other => other,
         }
@@ -491,7 +507,7 @@ impl Child {
         // After the mechanism guard, which is permanent and pid-independent: an uncontained
         // child must keep hearing why it has no tree to signal, not why a pid is unpinned.
         #[cfg(windows)]
-        if !self.proc.pins_pid() {
+        if !self.proc().pins_pid() {
             return Err(self.unpinned_pid_refusal("terminate_tree"));
         }
         // See kill_tree's identical precondition assert for the full rationale, including the
@@ -600,7 +616,7 @@ impl Child {
         started: ::tokio::sync::oneshot::Sender<()>,
         outcome: ::tokio::sync::oneshot::Sender<crate::child::spawn::windows_raw::WaitOutcome>,
     ) {
-        self.proc.install_wait_observer(started, outcome);
+        self.proc_mut().install_wait_observer(started, outcome);
     }
 }
 
@@ -646,7 +662,7 @@ impl Drop for Child {
         // collection is left to tokio's field-drop. `src/tokio/` mirrors the sync surface by hand
         // with nothing enforcing parity, so that difference is deliberate, not drift.
         let pid = self.id.pid();
-        self.proc.reap_now_on_drop(pid);
+        self.proc_mut().reap_now_on_drop(pid);
     }
 }
 

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -74,7 +74,7 @@ impl Child {
     pub fn terminate(&self) -> Result<(), Error> {
         let mechanism = self.graceful_mechanism();
         #[cfg(windows)]
-        if mechanism.addresses_a_bare_pid() && !self.proc.pins_pid() {
+        if mechanism.addresses_a_bare_pid() && !self.proc().pins_pid() {
             return Err(self.unpinned_pid_refusal("terminate"));
         }
         crate::graceful::signal(mechanism, self.id())

--- a/src/tokio/pump.rs
+++ b/src/tokio/pump.rs
@@ -12,7 +12,7 @@ use super::child::Child;
 impl Child {
     pub async fn communicate(&mut self, input: Option<Vec<u8>>) -> Result<Output, Error> {
         // Take the three streams into owned locals BEFORE the join: only `wait` then borrows
-        // `self.proc` (so the four-future join compiles), and the Tokio backend's `wait` internally
+        // `self.proc_mut()` (so the four-future join compiles), and the Tokio backend's `wait` internally
         // drops its own stdin, already taken here, so it cannot race the write future.
         let mut stdin = self.stdin();
         let mut stdout = self.stdout();
@@ -62,7 +62,7 @@ impl Child {
         };
         // `wait` is the sole borrow of `self` here (already mapped to `Error`); the stream futures
         // own their taken locals, so the four-future join has no aliasing conflict.
-        let wait = async { self.proc.wait().await };
+        let wait = async { self.proc_mut().wait().await };
 
         let ((), out, err, status) = ::tokio::try_join!(write, read_out, read_err, wait)?;
         Ok(Output {


### PR DESCRIPTION
Stacked on #116, which is stacked on #115 — this PR's base is `azhukova/105-2`.

`Child::proc` becomes `Option<ProcSource>`. The field is now private and the twelve read sites go through `proc_mut()` / `proc()`, whose shared `expect` states the invariant: `proc` is `Some` for the handle's whole life, and the only planned taker is `Drop`, after which nothing else runs on the handle.

**This is preparation, and on its own it is arguably worse code.** It adds a panic path and buys nothing: nothing takes the backend today, so every `expect` is dead weight. It is landing now so that #105 — which moves the blocking reap in `Drop` off the dropping thread, and needs `Drop` to move the backend out of `&mut self` and hand it to a reaper thread — is reviewed on its scheduling design rather than on a mechanical `Option`-wrapping diff running through it.

The accessors are the one deliberate change from the parked branch, which repeated `self.proc.as_mut().expect(PROC_TAKEN)` inline at each site.

`proc()` (the `&self` half) is `#[cfg(windows)]`: its only callers are the two `pins_pid` guards, which do not exist elsewhere, and an ungated accessor would be dead code off Windows.

## Verification

`cargo test --locked --all-features` on `x86_64-pc-windows-msvc`: **816 passed, 0 failed** across 21 binaries, before and after, with identical (empty) failure lists.

`cargo clippy --all-features --all-targets --locked -- -D warnings` clean natively and cross-target on `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked` clean on all three. The cross-target run earned its keep: routing the `#[cfg(unix)]` `wait_and_reap_blocking` through the accessor made `self.proc_mut().wait_and_reap(self.id.pid())` a borrow conflict that no Windows check can see.


---

## Review round 2

Took the two conciseness cuts that land here: the field doc and the `PROC_TAKEN` doc both described the unlanded reaper-thread design this PR explicitly does not implement. They now state only what is true today — `Option` so the backend can be moved out of a `&mut self` receiver, nothing does, read it through the accessors — and the `expect` message says *"is never taken"* rather than asserting a taker that does not exist. The "what this prepares for" belongs in the commit message and above, not narrated in the source.

The third cut was filed against this PR but belongs to #115, where the line lives; it is applied there.

**Verification:** suite unchanged at 818 passed, 0 failed, 21 binaries. Clippy `--all-targets -D warnings` clean 9/9 across {default, `tokio`, all-features} × three targets; cross-target rustdoc clean on all three.
