### PR TITLE
fix(tokio): reap an async child on an eager reaper pool instead of blocking the dropping thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ name = "cosca"
 version = "0.2.0"
 dependencies = [
  "command-fds",
+ "crossbeam-channel",
  "getrandom",
  "libc",
  "log",
@@ -55,6 +56,21 @@ dependencies = [
  "windows",
  "zeroize",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-
 
 [features]
 pty = []
-tokio = ["dep:tokio"]
+tokio = ["dep:tokio", "dep:crossbeam-channel"]
 # Serialize a ProcessIdRecord so an identity survives a supervisor restart.
 serde = ["dep:serde"]
 
@@ -34,6 +34,11 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # reactor-native death-watch); `time` solely for the grace bound on it. `sync` backs the
 # per-instance wait observer (a `#[cfg(test)]` oneshot seam) the raw async backend is tested with.
 tokio = { version = "1", optional = true, features = ["process", "rt", "io-util", "macros", "net", "sync", "time"] }
+# The reaper pool's job queue. `std::sync::mpsc::Receiver` is neither `Sync` nor `Clone`, so the
+# std route is a hand-rolled queue behind a mutex whose most likely defect — holding the guard
+# across the job — collapses the pool's bulkhead into a serial reaper. Each worker owns a cloned
+# MPMC receiver instead, so no lock exists to get wrong.
+crossbeam-channel = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/child.rs
+++ b/src/child.rs
@@ -526,10 +526,11 @@ impl Drop for Child {
             log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
         }
         // Kill, block until the child has exited, and collect its status here — this handle owns
-        // the child outright. The async twin (`cosca::tokio::Child`'s `Drop`) blocks the same way
-        // but must NOT collect: tokio owns that child and its own reaping, so it waits without
-        // reaping and leaves the collection to tokio's field-drop. `src/tokio/` mirrors this
-        // surface by hand with nothing enforcing parity, so that difference is deliberate, not
+        // the child outright, and a sync caller owns the thread it is blocking. The async twin
+        // (`cosca::tokio::Child`'s `Drop`) diverges twice, deliberately: it only signals, handing
+        // the wait to its own reaper threads rather than parking a runtime worker, and it must
+        // not collect, since tokio owns that child and its own reaping. `src/tokio/` mirrors this
+        // surface by hand with nothing enforcing parity, so both differences are deliberate, not
         // drift.
         self.proc.teardown_on_drop();
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -215,9 +215,14 @@ impl Command {
     /// **Where the two handles differ is the wait.** The sync [`Child`](crate::Child) blocks
     /// until the root has exited, so after `drop` returns the child is gone. The async
     /// [`Child`](crate::tokio::Child) signals and returns — parking a runtime worker in a
-    /// destructor is not something the caller can await or cancel — and hands the wait to
-    /// reaper threads of its own; the reap is still guaranteed, just not by the time `drop`
-    /// returns. See its `Drop` for the full contract.
+    /// destructor is not something the caller can await or cancel — and hands the wait to reaper
+    /// threads of its own, so the reap happens later and off this thread.
+    ///
+    /// The async reap is **not** unconditional: a host too thread-starved to start the pool falls
+    /// back to the runtime's orphan handling, and a process that forks without `exec` loses it
+    /// entirely in the forked child. Code that must know the child is gone should `kill` and
+    /// `await` [`wait`](crate::tokio::Child::wait) rather than rely on the drop. See that `Drop`'s
+    /// rustdoc for both paths.
     ///
     /// An elevated child this process cannot signal is the one case the sync handle does not
     /// block on: the teardown gives up rather than wait forever, and the child is left running.

--- a/src/command.rs
+++ b/src/command.rs
@@ -207,13 +207,20 @@ impl Command {
     /// after the fact.
     ///
     /// What "tear down" means, on both handles: hard-kill the contained tree (a no-op for an
-    /// uncontained child — see [`contain`](Command::contain)), then block until the ROOT has
-    /// exited. There is no cooperative signal first; use
+    /// uncontained child — see [`contain`](Command::contain)), then kill the ROOT. There is no
+    /// cooperative signal first; use
     /// [`graceful_shutdown_tree`](crate::Child::graceful_shutdown_tree) before dropping if the
     /// child needs one. Descendants are killed, not waited for.
     ///
-    /// An elevated child this process cannot signal is the one case that does not block: the
-    /// teardown gives up rather than wait forever, and the child is left running.
+    /// **Where the two handles differ is the wait.** The sync [`Child`](crate::Child) blocks
+    /// until the root has exited, so after `drop` returns the child is gone. The async
+    /// [`Child`](crate::tokio::Child) signals and returns — parking a runtime worker in a
+    /// destructor is not something the caller can await or cancel — and hands the wait to
+    /// reaper threads of its own; the reap is still guaranteed, just not by the time `drop`
+    /// returns. See its `Drop` for the full contract.
+    ///
+    /// An elevated child this process cannot signal is the one case the sync handle does not
+    /// block on: the teardown gives up rather than wait forever, and the child is left running.
     pub fn kill_on_drop(&mut self, yes: bool) -> &mut Command {
         self.kill_on_drop = yes;
         self

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -193,6 +193,12 @@ pub(crate) fn spawn_async_blocker() -> (crate::tokio::Child, std::net::TcpStream
     cmd.executable(&exe)
         .args(fixture_argv(FIXTURE_CONTROL_BLOCK_TEST))
         .env(FIXTURE_CONTROL_BLOCK_ADDR_ENV, &addr);
+    // The child runs a full libtest harness, which writes its `running 1 test` / `test result:`
+    // banner to fd 1 directly — libtest's capture wraps the Rust print machinery, not the
+    // descriptor, so an inherited fd 1 lands that banner raw (and mid-line) in THIS binary's
+    // output. Both are nulled; stdin stays inherited, per this helper's contract.
+    cmd.stdout(crate::stdio::Stdio::null()).expect("stdout null");
+    cmd.stderr(crate::stdio::Stdio::null()).expect("stderr null");
     let child = cmd.spawn().expect("spawn the control-block fixture");
     let (mut sock, _) = listener.accept().expect("accept the control socket");
     let mut tag = [0u8; 1];

--- a/src/test_child.rs
+++ b/src/test_child.rs
@@ -26,7 +26,7 @@ pub(crate) fn spawn_a_process_that_exits() -> std::process::Child {
 /// option placed there is silently eaten and `--exact` degrades to substring matching.
 /// `--test-threads=1` keeps a future filter that matches more than one test from running them
 /// concurrently inside a process the caller is about to signal.
-#[cfg(windows)]
+#[cfg(any(windows, feature = "tokio"))]
 pub(crate) fn fixture_argv(test: &str) -> [&str; 4] {
     ["cosca_unit_tests", "--test-threads=1", "--exact", test]
 }
@@ -135,4 +135,68 @@ fn fixture_registers_then_blocks() {
     sock.flush().expect("flush registration tag");
     let mut sink = [0u8; 1];
     let _ = sock.read(&mut sink);
+}
+
+/// The fully-qualified libtest path of [`fixture_control_block`].
+#[cfg(feature = "tokio")]
+pub(crate) const FIXTURE_CONTROL_BLOCK_TEST: &str = "test_child::fixture_control_block";
+
+/// The env var carrying the `127.0.0.1:<port>` address [`fixture_control_block`] tags. Its mere
+/// presence also tells the fixture it was re-exec'd deliberately rather than picked up by an
+/// ordinary, unfiltered suite run.
+#[cfg(feature = "tokio")]
+pub(crate) const FIXTURE_CONTROL_BLOCK_ADDR_ENV: &str = "COSCA_FIXTURE_CONTROL_BLOCK_ADDR";
+
+/// A child that reports readiness and then blocks until the caller releases or kills it: a no-op
+/// when picked up by an ordinary, unfiltered suite run ([`FIXTURE_CONTROL_BLOCK_ADDR_ENV`] is
+/// unset there). Re-executed via `current_exe() --exact` [`FIXTURE_CONTROL_BLOCK_TEST`] with that
+/// var set, it connects to the caller's listener, writes one tag byte, then blocks on a 1-byte
+/// read of that same socket and RETURNS as soon as the read returns — so a caller that writes a
+/// byte gets a clean voluntary exit, and a caller that kills it gets the socket's EOF.
+///
+/// Mirrors [`fixture_registers_then_blocks`]'s filtered-re-exec idiom (see
+/// [`spawn_a_process_that_exits`] for why the filter is mandatory), and deliberately takes NO
+/// `spawn_lock()`: see [`spawn_async_blocker`].
+#[cfg(feature = "tokio")]
+#[test]
+fn fixture_control_block() {
+    let Some(addr) = std::env::var_os(FIXTURE_CONTROL_BLOCK_ADDR_ENV) else {
+        return; // picked up by an ordinary suite run — deliberately inert
+    };
+    use std::io::{Read, Write};
+
+    let mut sock = std::net::TcpStream::connect(addr.to_str().expect("utf8 addr")).expect("connect control socket");
+    sock.write_all(b"R").expect("write readiness tag");
+    sock.flush().expect("flush readiness tag");
+    let mut sink = [0u8; 1];
+    let _ = sock.read(&mut sink);
+}
+
+/// Spawn [`fixture_control_block`] through `cosca::tokio` and return its handle plus the control
+/// socket, already past the readiness tag — so the child is provably executing its own code.
+///
+/// **Takes no `spawn_lock()`, deliberately.** That lock is a plain non-reentrant mutex and
+/// cosca's own async spawn takes it internally, so a helper holding it across a cosca spawn
+/// deadlocks on its own thread. Every existing helper that takes it spawns via
+/// `std::process::Command`; the cosca-spawning helpers do not.
+///
+/// Uncontained (so the tree teardown is a verified no-op) and stdin INHERITED (so closing the
+/// parent's stdio cannot make the child exit on its own). Spawned via `executable()`, which puts
+/// Windows on the raw `CreateProcessW` backend.
+#[cfg(feature = "tokio")]
+pub(crate) fn spawn_async_blocker() -> (crate::tokio::Child, std::net::TcpStream) {
+    use std::io::Read as _;
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind control listener");
+    let addr = listener.local_addr().expect("local_addr").to_string();
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = crate::tokio::Command::new();
+    cmd.executable(&exe)
+        .args(fixture_argv(FIXTURE_CONTROL_BLOCK_TEST))
+        .env(FIXTURE_CONTROL_BLOCK_ADDR_ENV, &addr);
+    let child = cmd.spawn().expect("spawn the control-block fixture");
+    let (mut sock, _) = listener.accept().expect("accept the control socket");
+    let mut tag = [0u8; 1];
+    sock.read_exact(&mut tag).expect("read the readiness tag");
+    assert_eq!(&tag, b"R", "unexpected control tag");
+    (child, sock)
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -8,6 +8,9 @@ mod graceful;
 mod proc_source;
 pub(crate) use proc_source::ProcSource;
 
+#[path = "child/reaper.rs"]
+mod reaper;
+
 use std::collections::BTreeMap;
 use std::process::ExitStatus;
 
@@ -27,12 +30,13 @@ pub(super) type FdPipes = BTreeMap<Fd, ParentEnd>;
 #[cfg(windows)]
 pub(super) type FdPipes = BTreeMap<Fd, super::stdio::OwnedStd>;
 
-/// The `expect` behind the two backend accessors: nothing takes `proc`, so both are infallible.
-const PROC_TAKEN: &str = "the async child's process backend is never taken";
+/// The `expect` behind the two backend accessors: only `Drop` takes `proc`, and nothing runs on
+/// the handle after that, so both are infallible.
+const PROC_TAKEN: &str = "the async child's process backend is taken only by Drop";
 
 #[derive(Debug)]
 pub struct Child {
-    /// `Option` only so the backend can be moved out of a `&mut self` receiver; nothing does.
+    /// `Option` so `Drop` can move the backend into the reaper job; nothing else takes it.
     /// Read it through `proc_mut()` / `proc()`, never directly.
     proc: Option<ProcSource>,
     id: ProcessId,
@@ -620,31 +624,39 @@ impl Child {
     }
 }
 
-/// Hard-kills the contained tree, then blocks until the root has exited — the same shape as the
-/// sync [`Child`](crate::Child)'s `Drop`. What differs, deliberately, is who collects the status:
-/// see the reap below.
+/// Signals the tree and the root and does NOT wait: the child is not necessarily gone when
+/// `drop` returns, and neither is it necessarily reaped. A caller that must observe the teardown
+/// calls [`kill`](Child::kill)/[`kill_tree`](Child::kill_tree) and then awaits
+/// [`wait`](Child::wait)/[`wait_tree`](Child::wait_tree).
+///
+/// The reap itself is still guaranteed: the wait is handed to a small fixed pool of reaper
+/// threads (currently four) that starts on the first kill-on-drop drop and persists for the
+/// process's life. Under thread exhaustion the pool cannot start and the child is left to the
+/// runtime's orphan handling instead, logged per child; each drop then costs at most that many
+/// failing spawn syscalls.
+///
+/// The sync [`Child`](crate::Child)'s `Drop` still blocks; that divergence is deliberate.
 impl Drop for Child {
     fn drop(&mut self) {
+        // The opt-out/`detach()` contract: nothing is signalled and nothing is logged.
         if !self.kill_on_drop {
             return;
+        }
+        #[cfg(test)]
+        let probe = reaper::test_probe::take();
+        #[cfg(test)]
+        if let Some(p) = probe.as_ref() {
+            let _ = p.entered.send(std::thread::current().id());
         }
         // Tree teardown — the SOLE coverage for descendants (the root's own kill below reaches
         // only the root), so surface a real mechanism failure in debug. A no-op for an
         // uncontained child.
         //
-        // MUST stay on the dropping thread, and the reason is mechanism-specific — deferring it
-        // to a background thread or an awaitable teardown would take the guarantee away.
-        //
-        // Windows job object: a nested contained descendant is spawned into its OWN process group
-        // (`windows::group_flags`), so a consumer's `terminate_tree` — `CTRL_BREAK` to the ROOT's
-        // group — never reaches it, and `TerminateJobObject` here is the only thing that does.
-        //
-        // Unix: reach is identical either way. A nested contained descendant is `Delegated` and
-        // creates no group of its own, so `killpg` reaches it; a descendant that escaped by
-        // calling `setsid` itself is out of `hard_kill`'s reach too, since that is the same
-        // `killpg`. (The cgroup and fd-marker mechanisms sweep the same membership for both
-        // signals.) What this adds there is force, not reach: `SIGTERM` is catchable, `SIGKILL`
-        // is not.
+        // MUST stay on the dropping thread, before the handle is dismembered: on Windows a job
+        // object's kill is the only signal reaching a nested descendant that leads its own console
+        // group (console control events stop at that boundary). On Unix this and `terminate_tree`
+        // have the same radius. The contract either way: the tree is signalled before `drop`
+        // returns.
         let tree = self.attached.hard_kill();
         if let Err(e) = &tree {
             debug_assert!(
@@ -654,16 +666,11 @@ impl Drop for Child {
             log::warn!("Child::drop: contained-tree teardown did not fully succeed: {e}");
         }
         let _ = tree;
-        // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
-        // the dropping thread; the child is SIGKILL'd so it exits at once.
-        //
-        // The sync twin (`crate::Child`'s `Drop`) collects the status itself; this one must not —
-        // tokio owns the child and its own reaping, so the wait is non-reaping (`WNOWAIT`) and the
-        // collection is left to tokio's field-drop. `src/tokio/` mirrors the sync surface by hand
-        // with nothing enforcing parity, so that difference is deliberate, not drift.
+
         let pid = self.id.pid();
-        let proc = self.proc_mut();
-        // Already reaped: no signal to issue and no exit to wait for.
+        let mut proc = self.proc.take().expect(PROC_TAKEN);
+        // Already reaped: no signal to issue and no exit to wait for. The remaining resources
+        // release on this thread, with this handle.
         if proc.is_reaped() {
             return;
         }
@@ -673,9 +680,23 @@ impl Drop for Child {
             if !matches!(proc.try_wait(), Ok(Some(_))) {
                 log::warn!("async child {pid} could not be terminated on drop; leaving it running");
             }
+            // An unsignalled child is never submitted: its wait is unbounded, and a worker parked
+            // on it would never come back. Its resources release with this handle instead.
             return;
         }
-        proc.wait_and_reap(pid);
+        // Every field holding an OS resource travels with the backend, so its release stays
+        // ordered after the reap, as it is on this handle today.
+        reaper::submit(reaper::ReapJob {
+            proc,
+            attached: std::mem::take(&mut self.attached),
+            pipes: std::mem::take(&mut self.pipes),
+            owned_std: std::mem::take(&mut self.owned_std),
+            pid,
+            #[cfg(test)]
+            origin: std::thread::current().id(),
+            #[cfg(test)]
+            probe,
+        });
     }
 }
 

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -711,6 +711,8 @@ impl Drop for Child {
             force_panic: false,
             #[cfg(test)]
             force_release_panic: false,
+            #[cfg(test)]
+            force_glue_panic: false,
         });
     }
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -652,13 +652,28 @@ impl Child {
 /// calls [`kill`](Child::kill)/[`kill_tree`](Child::kill_tree) and then awaits
 /// [`wait`](Child::wait)/[`wait_tree`](Child::wait_tree).
 ///
-/// The reap itself is still guaranteed: the wait is handed to a small fixed pool of reaper
-/// threads (currently four) that starts on the first kill-on-drop drop and persists for the
-/// process's life. Under thread exhaustion the pool cannot start and the child is left to the
-/// runtime's orphan handling instead, logged per child; each drop then costs at most that many
-/// failing spawn syscalls.
+/// The reap is handed to a small fixed pool of reaper threads (currently four) that starts on
+/// the first kill-on-drop drop and persists for the process's life. It is guaranteed except on
+/// the two paths below, both of which are loud. Under thread exhaustion the pool cannot start,
+/// and the child goes to the runtime's orphan handling instead — an `error` per child, and each
+/// drop then costs at most that many failing spawn syscalls.
 ///
-/// The sync [`Child`](crate::Child)'s `Drop` still blocks; that divergence is deliberate.
+/// # Known limitation: `fork()` without `exec`
+///
+/// **A process that forks after this pool has started, and then keeps running Rust code in the
+/// child, loses the reap silently in that child.** `fork` duplicates only the calling thread, so
+/// the child inherits the pool's job queue with none of its workers; sends into it still succeed
+/// (the receiver handles exist in the copied address space), so nothing errors and nothing is
+/// logged, and every child handle dropped there queues forever, pinning its process handle,
+/// containment resource and stdio for the life of that process. It affects daemonizing and
+/// pre-fork worker models. It does **not** affect ordinary subprocess spawning — `fork`+`exec`
+/// and `posix_spawn` replace the child image immediately — nor Windows, which has no `fork`.
+///
+/// Until it is fixed, a forking consumer should either fork before its first kill-on-drop drop,
+/// or `kill` and `await` [`wait`](Child::wait) explicitly in the forked child rather than relying
+/// on `Drop`. The sync [`Child`](crate::Child) is unaffected: it reaps on the dropping thread.
+///
+/// That divergence from the sync `Child`, which still blocks, is otherwise deliberate.
 impl Drop for Child {
     fn drop(&mut self) {
         // The opt-out/`detach()` contract: nothing is signalled and nothing is logged.

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -628,8 +628,9 @@ impl Drop for Child {
         if !self.kill_on_drop {
             return;
         }
-        // Tree teardown — the SOLE coverage for descendants (reap_now only guarantees the root),
-        // so surface a real mechanism failure in debug. A no-op for an uncontained child.
+        // Tree teardown — the SOLE coverage for descendants (the root's own kill below reaches
+        // only the root), so surface a real mechanism failure in debug. A no-op for an
+        // uncontained child.
         //
         // MUST stay on the dropping thread, and the reason is mechanism-specific — deferring it
         // to a background thread or an awaitable teardown would take the guarantee away.
@@ -654,15 +655,27 @@ impl Drop for Child {
         }
         let _ = tree;
         // Guaranteed reap of the root on the real exit event (no park dependence). Briefly blocks
-        // the dropping thread; the child is SIGKILL'd so it exits at once. Dispatches per backend
-        // (tokio field-drop reap vs the raw handle's kill-then-wait).
+        // the dropping thread; the child is SIGKILL'd so it exits at once.
         //
         // The sync twin (`crate::Child`'s `Drop`) collects the status itself; this one must not —
         // tokio owns the child and its own reaping, so the wait is non-reaping (`WNOWAIT`) and the
         // collection is left to tokio's field-drop. `src/tokio/` mirrors the sync surface by hand
         // with nothing enforcing parity, so that difference is deliberate, not drift.
         let pid = self.id.pid();
-        self.proc_mut().reap_now_on_drop(pid);
+        let proc = self.proc_mut();
+        // Already reaped: no signal to issue and no exit to wait for.
+        if proc.is_reaped() {
+            return;
+        }
+        // No `debug_assert` here: a failed kill is a designed outcome the branch below serves (a
+        // higher-integrity elevated child), and asserting would panic inside a destructor.
+        if proc.start_kill().is_err() {
+            if !matches!(proc.try_wait(), Ok(Some(_))) {
+                log::warn!("async child {pid} could not be terminated on drop; leaving it running");
+            }
+            return;
+        }
+        proc.wait_and_reap(pid);
     }
 }
 

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -676,7 +676,18 @@ impl Drop for Child {
         }
         // No `debug_assert` here: a failed kill is a designed outcome the branch below serves (a
         // higher-integrity elevated child), and asserting would panic inside a destructor.
-        if proc.start_kill().is_err() {
+        //
+        // The test seam REPLACES the kill rather than masking its result — a masked kill would
+        // still have signalled the child, and the branch below is about one that was not.
+        #[cfg(test)]
+        let killed = if reaper::fault::take_force_kill_failure() {
+            Err(Error::Io(std::io::Error::other("forced kill failure (test seam)")))
+        } else {
+            proc.start_kill()
+        };
+        #[cfg(not(test))]
+        let killed = proc.start_kill();
+        if killed.is_err() {
             if !matches!(proc.try_wait(), Ok(Some(_))) {
                 log::warn!("async child {pid} could not be terminated on drop; leaving it running");
             }
@@ -696,6 +707,10 @@ impl Drop for Child {
             origin: std::thread::current().id(),
             #[cfg(test)]
             probe,
+            #[cfg(test)]
+            force_panic: false,
+            #[cfg(test)]
+            force_release_panic: false,
         });
     }
 }

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -34,24 +34,45 @@ pub(super) type FdPipes = BTreeMap<Fd, super::stdio::OwnedStd>;
 /// the handle after that, so both are infallible.
 const PROC_TAKEN: &str = "the async child's process backend is taken only by Drop";
 
-#[derive(Debug)]
-pub struct Child {
+/// Every field of a [`Child`] that owns an OS resource, **declared in the order they must be
+/// released**: the backend first, so the pid stays pinned for the whole wait and each other
+/// release is ordered after the reap.
+///
+/// This grouping is the parity contract with [`reaper::ReapJob`], which carries one of these
+/// verbatim: `Drop` hands the whole group over, so a resource-owning field added here travels to
+/// the reaper — and is released in the right order — with no other edit. Adding one directly to
+/// `Child` instead would silently keep its release on the dropping thread.
+#[derive(Debug, Default)]
+pub(crate) struct OsResources {
     /// `Option` so `Drop` can move the backend into the reaper job; nothing else takes it.
-    /// Read it through `proc_mut()` / `proc()`, never directly.
-    proc: Option<ProcSource>,
-    id: ProcessId,
-    attached: Attached,
-    kill_on_drop: bool,
-    containment: Containment,
-    graceful: crate::graceful::GracefulMechanism,
+    /// Read it through [`proc_mut`](OsResources::proc_mut), never directly.
+    pub(crate) proc: Option<ProcSource>,
+    pub(crate) attached: Attached,
     /// Parent ends of fd >= 3 pipes, read by [`fd_read_end`](Child::fd_read_end) /
     /// [`fd_write_end`](Child::fd_write_end). Unix: `command-fds`-wired reactor pipes; Windows: the
     /// raw backend's overlapped async ends (empty on the std path, which routes fd >= 3 to the raw
     /// backend).
-    pipes: FdPipes,
+    pub(crate) pipes: FdPipes,
     /// Our-owned parent ends of piped std-slot MERGE TARGETS (the spawn pre-pass owns those
     /// pipes; tokio's internal ones cannot be shared), keyed by the target slot.
-    owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
+    pub(crate) owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
+}
+
+impl OsResources {
+    /// The process backend. The single `expect` site: `Drop` is the only thing that empties this,
+    /// and it is the last reader.
+    pub(crate) fn proc_mut(&mut self) -> &mut ProcSource {
+        self.proc.as_mut().expect(PROC_TAKEN)
+    }
+}
+
+#[derive(Debug)]
+pub struct Child {
+    os: OsResources,
+    id: ProcessId,
+    kill_on_drop: bool,
+    containment: Containment,
+    graceful: crate::graceful::GracefulMechanism,
     /// The achieved elevation state, or `None` if elevation was not requested (mirrors the sync
     /// `Child`). Drives the universal-teardown kill mapping.
     elevation: Option<crate::elevation::ElevationReport>,
@@ -68,14 +89,16 @@ impl Child {
         owned_std: BTreeMap<Fd, super::stdio::OwnedStd>,
     ) -> Child {
         Child {
-            proc: Some(proc),
+            os: OsResources {
+                proc: Some(proc),
+                attached: attachment.attached,
+                pipes,
+                owned_std,
+            },
             id,
-            attached: attachment.attached,
             kill_on_drop,
             containment: attachment.containment,
             graceful: attachment.graceful,
-            pipes,
-            owned_std,
             elevation: None,
         }
     }
@@ -83,12 +106,12 @@ impl Child {
     /// The process backend. `pub(super)`: the sibling `pump` module borrows it for
     /// `communicate`'s `wait` future, and `child::graceful` for its pid-pinning guard.
     pub(super) fn proc_mut(&mut self) -> &mut ProcSource {
-        self.proc.as_mut().expect(PROC_TAKEN)
+        self.os.proc_mut()
     }
     /// Shared read-only accessor for the two `pins_pid` guards, which hold `&self`.
     #[cfg(windows)]
     pub(super) fn proc(&self) -> &ProcSource {
-        self.proc.as_ref().expect(PROC_TAKEN)
+        self.os.proc.as_ref().expect(PROC_TAKEN)
     }
 
     /// Attach the elevation report — set by the spawn arms before the deferred password write, so
@@ -175,7 +198,7 @@ impl Child {
     #[cfg(unix)]
     fn take_owned_out(&mut self, fd: Fd) -> Option<super::stdio::OutInner> {
         use std::os::fd::OwnedFd;
-        match self.owned_std.remove(&fd)? {
+        match self.os.owned_std.remove(&fd)? {
             ParentEnd::Reader(r) => match ::tokio::net::unix::pipe::Receiver::from_owned_fd(OwnedFd::from(r)) {
                 Ok(recv) => Some(super::stdio::OutInner::Owned(recv)),
                 Err(e) => {
@@ -187,7 +210,7 @@ impl Child {
                 }
             },
             end => {
-                self.owned_std.insert(fd, end); // wrong direction — put it back (fd_read_end mirror)
+                self.os.owned_std.insert(fd, end); // wrong direction — put it back (fd_read_end mirror)
                 None
             }
         }
@@ -198,10 +221,10 @@ impl Child {
     /// (and no `from_raw_handle`, which would double-register the IOCP handle) exists here.
     #[cfg(windows)]
     fn take_owned_out(&mut self, fd: Fd) -> Option<super::stdio::OutInner> {
-        match self.owned_std.remove(&fd)? {
+        match self.os.owned_std.remove(&fd)? {
             super::stdio::OwnedStd::Read(r) => Some(super::stdio::OutInner::Owned(r)),
             end => {
-                self.owned_std.insert(fd, end); // wrong direction — put it back (fd_read_end mirror)
+                self.os.owned_std.insert(fd, end); // wrong direction — put it back (fd_read_end mirror)
                 None
             }
         }
@@ -213,7 +236,7 @@ impl Child {
     #[cfg(unix)]
     fn take_owned_in(&mut self, fd: Fd) -> Option<super::stdio::InInner> {
         use std::os::fd::OwnedFd;
-        match self.owned_std.remove(&fd)? {
+        match self.os.owned_std.remove(&fd)? {
             ParentEnd::Writer(w) => match ::tokio::net::unix::pipe::Sender::from_owned_fd(OwnedFd::from(w)) {
                 Ok(send) => Some(super::stdio::InInner::Owned(send)),
                 Err(e) => {
@@ -225,7 +248,7 @@ impl Child {
                 }
             },
             end => {
-                self.owned_std.insert(fd, end); // wrong direction — put it back (fd_write_end mirror)
+                self.os.owned_std.insert(fd, end); // wrong direction — put it back (fd_write_end mirror)
                 None
             }
         }
@@ -235,10 +258,10 @@ impl Child {
     /// (see [`take_owned_out`](Child::take_owned_out)).
     #[cfg(windows)]
     fn take_owned_in(&mut self, fd: Fd) -> Option<super::stdio::InInner> {
-        match self.owned_std.remove(&fd)? {
+        match self.os.owned_std.remove(&fd)? {
             super::stdio::OwnedStd::Write(w) => Some(super::stdio::InInner::Owned(w)),
             end => {
-                self.owned_std.insert(fd, end); // wrong direction — put it back (fd_write_end mirror)
+                self.os.owned_std.insert(fd, end); // wrong direction — put it back (fd_write_end mirror)
                 None
             }
         }
@@ -262,7 +285,7 @@ impl Child {
     pub fn fd_read_end(&mut self, fd: impl Into<crate::stdio::Fd>) -> Option<::tokio::net::unix::pipe::Receiver> {
         use std::os::fd::OwnedFd;
         let fd = fd.into();
-        match self.pipes.remove(&fd)? {
+        match self.os.pipes.remove(&fd)? {
             crate::child::ParentEnd::Reader(r) => {
                 match ::tokio::net::unix::pipe::Receiver::from_owned_fd(OwnedFd::from(r)) {
                     Ok(recv) => Some(recv),
@@ -276,7 +299,7 @@ impl Child {
                 }
             }
             end => {
-                self.pipes.insert(fd, end); // wrong direction — put it back (sync mirror)
+                self.os.pipes.insert(fd, end); // wrong direction — put it back (sync mirror)
                 None
             }
         }
@@ -300,7 +323,7 @@ impl Child {
     pub fn fd_write_end(&mut self, fd: impl Into<crate::stdio::Fd>) -> Option<::tokio::net::unix::pipe::Sender> {
         use std::os::fd::OwnedFd;
         let fd = fd.into();
-        match self.pipes.remove(&fd)? {
+        match self.os.pipes.remove(&fd)? {
             crate::child::ParentEnd::Writer(w) => {
                 match ::tokio::net::unix::pipe::Sender::from_owned_fd(OwnedFd::from(w)) {
                     Ok(send) => Some(send),
@@ -314,7 +337,7 @@ impl Child {
                 }
             }
             end => {
-                self.pipes.insert(fd, end);
+                self.os.pipes.insert(fd, end);
                 None
             }
         }
@@ -333,12 +356,12 @@ impl Child {
     #[cfg(windows)]
     pub fn fd_read_end(&mut self, fd: impl Into<Fd>) -> Option<super::stdio::ChildStdout> {
         let fd = fd.into();
-        match self.pipes.remove(&fd)? {
+        match self.os.pipes.remove(&fd)? {
             super::stdio::OwnedStd::Read(r) => Some(super::stdio::ChildStdout {
                 inner: super::stdio::OutInner::Owned(r),
             }),
             end => {
-                self.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
+                self.os.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
                 None
             }
         }
@@ -356,12 +379,12 @@ impl Child {
     #[cfg(windows)]
     pub fn fd_write_end(&mut self, fd: impl Into<Fd>) -> Option<super::stdio::ChildStdin> {
         let fd = fd.into();
-        match self.pipes.remove(&fd)? {
+        match self.os.pipes.remove(&fd)? {
             super::stdio::OwnedStd::Write(w) => Some(super::stdio::ChildStdin {
                 inner: super::stdio::InInner::Owned(w),
             }),
             end => {
-                self.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
+                self.os.pipes.insert(fd, end); // wrong direction — put it back (Unix mirror)
                 None
             }
         }
@@ -371,7 +394,7 @@ impl Child {
     /// against the held handle, not "any job"). `pub` so integration tests can call it.
     #[cfg(windows)]
     pub fn test_job_handle_contains_self(&self) -> bool {
-        crate::containment::windows::job_contains_pid(&self.attached, self.id.pid())
+        crate::containment::windows::job_contains_pid(&self.os.attached, self.id.pid())
     }
 
     /// Block until the child exits, returning its status. For a bounded wait use
@@ -425,7 +448,7 @@ impl Child {
         // mechanisms `carries_recyclable_pgid` covers, and why this is `#[cfg(unix)]`).
         #[cfg(unix)]
         debug_assert!(
-            !self.attached.carries_recyclable_pgid() || {
+            !self.os.attached.carries_recyclable_pgid() || {
                 let now = ProcessId::of(self.id.pid());
                 let now_liveness = match now {
                     crate::identity::Resolved::Found(id) => id.is_alive(),
@@ -440,7 +463,7 @@ impl Child {
              unrelated process group",
             self.id.pid()
         );
-        let group_result = self.attached.hard_kill();
+        let group_result = self.os.attached.hard_kill();
         // Backstop for the TreeWalk mechanism: its hard_kill kills the root by identity, which
         // no-ops if `ProcessId::of` transiently fails to resolve — this handle-based kill
         // covers that, so its failure is contract-relevant.
@@ -518,7 +541,7 @@ impl Child {
         // `#[cfg(unix)]` gate (`carries_recyclable_pgid` does not exist on Windows).
         #[cfg(unix)]
         debug_assert!(
-            !self.attached.carries_recyclable_pgid() || {
+            !self.os.attached.carries_recyclable_pgid() || {
                 let now = ProcessId::of(self.id.pid());
                 let now_liveness = match now {
                     crate::identity::Resolved::Found(id) => id.is_alive(),
@@ -533,7 +556,7 @@ impl Child {
              unrelated process group",
             self.id.pid()
         );
-        self.attached.terminate(self.id.pid())
+        self.os.attached.terminate(self.id.pid())
     }
 
     /// The refusal both cooperative ops answer with once this handle has stopped pinning the
@@ -557,12 +580,12 @@ impl Child {
 
     /// Guard for the `_tree` operations (single-sourced with the sync `Child`).
     fn require_contained(&self) -> Result<(), Error> {
-        crate::containment::require_contained(self.containment, &self.attached)
+        crate::containment::require_contained(self.containment, &self.os.attached)
     }
 
     /// Guard for `wait_tree`/`wait_tree_timeout` (single-sourced with the sync `Child`).
     fn require_drainable(&self) -> Result<(), Error> {
-        crate::containment::require_drainable(self.containment, &self.attached)
+        crate::containment::require_drainable(self.containment, &self.os.attached)
     }
 
     /// Block until every member of the contained tree has EXITED — not reaped; a status is
@@ -575,7 +598,7 @@ impl Child {
     /// blocking watcher promptly instead of parking out the wait.
     pub async fn wait_tree(&self) -> Result<crate::containment::TreeDrain, Error> {
         self.require_drainable()?;
-        super::wait::wait_tree_drained_dispatch(&self.attached, None).await
+        super::wait::wait_tree_drained_dispatch(&self.os.attached, None).await
     }
 
     /// Like [`wait_tree`](Child::wait_tree) but bounded by `timeout`.
@@ -587,7 +610,7 @@ impl Child {
     ) -> Result<crate::containment::TreeDrain, Error> {
         self.require_drainable()?;
         let deadline = crate::wait::deadline_from(timeout);
-        super::wait::wait_tree_drained_dispatch(&self.attached, deadline).await
+        super::wait::wait_tree_drained_dispatch(&self.os.attached, deadline).await
     }
 }
 
@@ -595,7 +618,7 @@ impl Child {
     /// Leave the child (and its contained tree) running after this handle drops.
     pub fn detach(&mut self) {
         self.kill_on_drop = false;
-        self.attached.disarm();
+        self.os.attached.disarm();
     }
 }
 
@@ -657,7 +680,7 @@ impl Drop for Child {
         // group (console control events stop at that boundary). On Unix this and `terminate_tree`
         // have the same radius. The contract either way: the tree is signalled before `drop`
         // returns.
-        let tree = self.attached.hard_kill();
+        let tree = self.os.attached.hard_kill();
         if let Err(e) = &tree {
             debug_assert!(
                 !crate::child::is_teardown_mechanism_failure(e),
@@ -668,10 +691,12 @@ impl Drop for Child {
         let _ = tree;
 
         let pid = self.id.pid();
-        let mut proc = self.proc.take().expect(PROC_TAKEN);
-        // Already reaped: no signal to issue and no exit to wait for. The remaining resources
-        // release on this thread, with this handle.
-        if proc.is_reaped() {
+        // The WHOLE resource group moves, so a field added to `OsResources` is carried here
+        // without touching this function. On every early return below it drops in group order,
+        // on this thread — exactly where it dropped before the reap moved off it.
+        let mut os = std::mem::take(&mut self.os);
+        // Already reaped: no signal to issue and no exit to wait for.
+        if os.proc_mut().is_reaped() {
             return;
         }
         // No `debug_assert` here: a failed kill is a designed outcome the branch below serves (a
@@ -683,25 +708,20 @@ impl Drop for Child {
         let killed = if reaper::fault::take_force_kill_failure() {
             Err(Error::Io(std::io::Error::other("forced kill failure (test seam)")))
         } else {
-            proc.start_kill()
+            os.proc_mut().start_kill()
         };
         #[cfg(not(test))]
-        let killed = proc.start_kill();
+        let killed = os.proc_mut().start_kill();
         if killed.is_err() {
-            if !matches!(proc.try_wait(), Ok(Some(_))) {
+            if !matches!(os.proc_mut().try_wait(), Ok(Some(_))) {
                 log::warn!("async child {pid} could not be terminated on drop; leaving it running");
             }
             // An unsignalled child is never submitted: its wait is unbounded, and a worker parked
             // on it would never come back. Its resources release with this handle instead.
             return;
         }
-        // Every field holding an OS resource travels with the backend, so its release stays
-        // ordered after the reap, as it is on this handle today.
         reaper::submit(reaper::ReapJob {
-            proc,
-            attached: std::mem::take(&mut self.attached),
-            pipes: std::mem::take(&mut self.pipes),
-            owned_std: std::mem::take(&mut self.owned_std),
+            os,
             pid,
             #[cfg(test)]
             origin: std::thread::current().id(),

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -276,7 +276,7 @@ impl Child {
         let (drained, root_exited, watch_err) = if let Some(e) = take_forced_watch_error() {
             (false, false, Some(e))
         } else if self.containment().can_observe_drain() {
-            match crate::tokio::wait::wait_tree_drained_dispatch(&self.attached, crate::wait::deadline_from(grace))
+            match crate::tokio::wait::wait_tree_drained_dispatch(&self.os.attached, crate::wait::deadline_from(grace))
                 .await
             {
                 Ok(verdict) if verdict.permits_skipping_sweep() => (true, true, None),

--- a/src/tokio/child/proc_source.rs
+++ b/src/tokio/child/proc_source.rs
@@ -87,13 +87,12 @@ impl ProcSource {
         }
     }
 
-    /// Guaranteed synchronous teardown for `Drop`: kill, then block until the child has exited.
-    /// **Invariant:** no `wait()` future for this child is in flight when this runs.
-    pub(crate) fn reap_now_on_drop(&mut self, pid: u32) {
+    /// `true` once the backend has collected the child's status, so no reap remains.
+    pub(crate) fn is_reaped(&self) -> bool {
         match self {
-            ProcSource::Tokio(c) => super::reap_now(c, pid, true),
+            ProcSource::Tokio(c) => c.id().is_none(),
             #[cfg(windows)]
-            ProcSource::Raw(r) => r.reap_blocking(),
+            ProcSource::Raw(r) => r.is_reaped(),
         }
     }
 
@@ -101,15 +100,15 @@ impl ProcSource {
     /// caller's own successful kill is what bounds the wait.
     /// **Invariant:** no `wait()` future for this child is in flight when this runs.
     ///
-    /// Unix-only, so it needs no `Raw` arm: that backend exists only on Windows, and the sole
-    /// caller ([`Child::wait_and_reap_blocking`](super::Child::wait_and_reap_blocking)) is the
-    /// POSIX elevated-spawn cleanup path. That child was never awaited, so `done_ok` is `false`
-    /// (matching the other never-awaited callers): an already-reaped one is a broken precondition,
-    /// not a case to return quietly from — which is the shape this entry exists to remove.
-    #[cfg(unix)]
+    /// `done_ok` is `false` for every caller: both reach here only past an
+    /// [`is_reaped`](ProcSource::is_reaped) check or on a child that was never awaited, so an
+    /// already-reaped one is a broken precondition, not a case to return quietly from — the shape
+    /// this entry exists to remove.
     pub(crate) fn wait_and_reap(&mut self, pid: u32) {
         match self {
             ProcSource::Tokio(c) => super::wait_and_reap(c, pid, false),
+            #[cfg(windows)]
+            ProcSource::Raw(r) => r.wait_and_reap(),
         }
     }
 

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -36,6 +36,17 @@
 //! the runtime's orphan handling would not have managed it either. Process exit with jobs still
 //! queued is benign, since the roots are already signalled and the OS reaps them.
 //!
+//! **Known limitation: this pool is not fork-safe.** `fork` duplicates only the calling thread,
+//! so a child forked after publication inherits the populated cell and none of the workers. The
+//! send still SUCCEEDS — the receiver handles exist in the copied address space, so the channel
+//! is not disconnected and the degraded release path never fires — and every job queued in that
+//! child is unreaped, unlogged, and holds its resources for the life of the process. Measured, on
+//! Linux, not inferred. It is a real regression against the synchronous reap this replaced, which
+//! was fork-safe by construction. Windows has no `fork`; `fork`+`exec` and `posix_spawn` are
+//! unaffected because the image is replaced at once. A `pthread_atfork` child handler is the
+//! shape of the fix, but neither the cell nor the init lock survives one as written — see
+//! issue #121. `Drop`'s rustdoc carries the consumer-facing statement.
+//!
 //! The backlog `debug` log fires on healthy bursts too — it reports depth, not a fault, and no
 //! decision reads it.
 
@@ -52,8 +63,7 @@ pub(crate) struct ReapJob {
     pub(crate) origin: std::thread::ThreadId,
     #[cfg(test)]
     pub(crate) probe: Option<test_probe::DropProbe>,
-    /// Seeded panic in the wait region. Sampled at submit time on the dropping thread — a
-    /// thread-local armed by the test is invisible on a worker.
+    /// Seeded panic in the wait region; see `submit_to` for why it is sampled, not read here.
     #[cfg(test)]
     pub(crate) force_panic: bool,
     /// Seeded panic in the release region. Set directly on a hand-built job, so it needs no
@@ -89,7 +99,6 @@ impl Pool {
             );
         }
         if let Err(e) = self.tx.send(job) {
-            // Unreachable: a published pool's sender lives in a `static` and never drops.
             debug_assert!(false, "a published reaper pool's channel cannot disconnect");
             release(e.into_inner());
         }
@@ -250,7 +259,7 @@ fn release(job: ReapJob) {
     );
     #[cfg(test)]
     let probe = job.probe;
-    drop(job.os); // group order, single-sourced by `OsResources`
+    drop(job.os);
     #[cfg(test)]
     if let Some(p) = probe {
         let _ = p.outcome.send(test_probe::ReapOutcome::Released);
@@ -317,9 +326,7 @@ pub(crate) fn run_teardown(job: ReapJob) {
         if force_release_panic {
             panic!("forced release-region panic (test seam)");
         }
-        // One drop, ordered by `OsResources`' own declaration order — `proc` first, so the pid
-        // stays pinned for the whole wait and every other release lands after the reap.
-        drop(os);
+        drop(os); // one drop, ordered by `OsResources`' own declaration
         #[cfg(test)]
         if let Some(p) = probe {
             let _ = p.outcome.send(if waited.is_err() {
@@ -358,9 +365,8 @@ pub(crate) mod fault {
         FORCE_SPAWN_FAILURES.with(|f| f.replace(0))
     }
 
-    /// Force the NEXT teardown to panic in its wait region. Sampled at submit time into
-    /// [`ReapJob::force_panic`](super::ReapJob::force_panic), because the region it models runs
-    /// on a worker.
+    /// Force the NEXT teardown to panic in its wait region, via
+    /// [`ReapJob::force_panic`](super::ReapJob::force_panic).
     pub(crate) fn set_force_teardown_panic(on: bool) {
         FORCE_TEARDOWN_PANIC.with(|f| f.set(on));
     }

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -39,19 +39,13 @@
 //! The backlog `debug` log fires on healthy bursts too — it reports depth, not a fault, and no
 //! decision reads it.
 
-use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use crate::containment::Attached;
-use crate::stdio::Fd;
-
-/// Everything `Drop` hands over: the process backend plus every field that holds an OS resource
-/// and drops after it today, so the release order survives the handoff.
+/// Everything `Drop` hands over. The resource group is carried whole and in its own declaration
+/// order, so both what travels and the order it is released in live in exactly one place —
+/// [`OsResources`](super::OsResources).
 pub(crate) struct ReapJob {
-    pub(crate) proc: super::ProcSource,
-    pub(crate) attached: Attached,
-    pub(crate) pipes: super::FdPipes,
-    pub(crate) owned_std: BTreeMap<Fd, crate::tokio::stdio::OwnedStd>,
+    pub(crate) os: super::OsResources,
     pub(crate) pid: u32,
     /// The thread `Drop` ran on. `run_teardown` gates only when it is executing elsewhere.
     #[cfg(test)]
@@ -256,10 +250,7 @@ fn release(job: ReapJob) {
     );
     #[cfg(test)]
     let probe = job.probe;
-    drop(job.proc);
-    drop(job.attached);
-    drop(job.pipes);
-    drop(job.owned_std);
+    drop(job.os); // group order, single-sourced by `OsResources`
     #[cfg(test)]
     if let Some(p) = probe {
         let _ = p.outcome.send(test_probe::ReapOutcome::Released);
@@ -285,14 +276,11 @@ pub(crate) fn run_teardown(job: ReapJob) {
     let force_release_panic = job.force_release_panic;
     #[cfg(test)]
     let force_glue_panic = job.force_glue_panic;
-    let mut proc = job.proc;
-    let attached = job.attached;
-    let pipes = job.pipes;
-    let owned_std = job.owned_std;
+    let mut os = job.os;
     let pid = job.pid;
 
-    // `proc` is BORROWED into this region, never moved: an unwind must not destroy a resource
-    // whose release the region below owns and orders.
+    // `os` is BORROWED into this region, never moved: an unwind must not destroy a resource whose
+    // release the region below owns and orders.
     let waited = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         #[cfg(test)]
         if let Some(p) = probe.as_ref() {
@@ -311,7 +299,7 @@ pub(crate) fn run_teardown(job: ReapJob) {
         if force_panic {
             panic!("forced teardown panic (test seam)");
         }
-        proc.wait_and_reap(pid);
+        os.proc_mut().wait_and_reap(pid);
     }));
 
     // The glue. Only a seeded fault reaches this, and only to give `work`'s recovery guard the
@@ -329,12 +317,9 @@ pub(crate) fn run_teardown(job: ReapJob) {
         if force_release_panic {
             panic!("forced release-region panic (test seam)");
         }
-        // `Child`'s declaration order — `proc` first, so the pid stays pinned for the whole wait
-        // and every other release stays ordered after the reap.
-        drop(proc);
-        drop(attached);
-        drop(pipes);
-        drop(owned_std);
+        // One drop, ordered by `OsResources`' own declaration order — `proc` first, so the pid
+        // stays pinned for the whole wait and every other release lands after the reap.
+        drop(os);
         #[cfg(test)]
         if let Some(p) = probe {
             let _ = p.outcome.send(if waited.is_err() {

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -22,6 +22,14 @@ pub(crate) struct ReapJob {
     pub(crate) origin: std::thread::ThreadId,
     #[cfg(test)]
     pub(crate) probe: Option<test_probe::DropProbe>,
+    /// Seeded panic in the wait region. Sampled at submit time on the dropping thread — a
+    /// thread-local armed by the test is invisible on a worker.
+    #[cfg(test)]
+    pub(crate) force_panic: bool,
+    /// Seeded panic in the release region. Set directly on a hand-built job, so it needs no
+    /// thread-local of its own.
+    #[cfg(test)]
+    pub(crate) force_release_panic: bool,
 }
 
 /// A wedged child occupies one worker and no other; the rest keep draining the shared queue. Not
@@ -173,6 +181,13 @@ fn work(rx: crossbeam_channel::Receiver<ReapJob>) {
 }
 
 fn submit_to(lazy: &LazyPool, job: ReapJob) {
+    // Sampled HERE, on the submitting thread: the region it models runs on a worker, where a
+    // thread-local armed by the test is invisible.
+    #[cfg(test)]
+    let job = ReapJob {
+        force_panic: fault::take_force_teardown_panic(),
+        ..job
+    };
     match lazy.get() {
         Some(pool) => pool.dispatch(job),
         None => release(job),
@@ -220,6 +235,10 @@ pub(crate) fn run_teardown(job: ReapJob) {
     let origin = job.origin;
     #[cfg(test)]
     let probe = job.probe;
+    #[cfg(test)]
+    let force_panic = job.force_panic;
+    #[cfg(test)]
+    let force_release_panic = job.force_release_panic;
     let mut proc = job.proc;
     let attached = job.attached;
     let pipes = job.pipes;
@@ -242,12 +261,20 @@ pub(crate) fn run_teardown(job: ReapJob) {
                 let _ = p.gate.recv(); // a dropped sender is also a release
             }
         }
+        #[cfg(test)]
+        if force_panic {
+            panic!("forced teardown panic (test seam)");
+        }
         proc.wait_and_reap(pid);
     }));
 
     let released = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if waited.is_err() {
             log::error!("reaping child {pid} panicked; releasing its resources anyway");
+        }
+        #[cfg(test)]
+        if force_release_panic {
+            panic!("forced release-region panic (test seam)");
         }
         // `Child`'s declaration order — `proc` first, so the pid stays pinned for the whole wait
         // and every other release stays ordered after the reap.
@@ -280,6 +307,8 @@ pub(crate) mod fault {
 
     thread_local! {
         static FORCE_SPAWN_FAILURES: Cell<usize> = const { Cell::new(0) };
+        static FORCE_TEARDOWN_PANIC: Cell<bool> = const { Cell::new(false) };
+        static FORCE_KILL_FAILURE: Cell<bool> = const { Cell::new(false) };
     }
 
     /// Fail the first `n` `Builder::spawn` attempts of the NEXT init entered from THIS thread.
@@ -289,6 +318,25 @@ pub(crate) mod fault {
     }
     pub(crate) fn take_force_spawn_failures() -> usize {
         FORCE_SPAWN_FAILURES.with(|f| f.replace(0))
+    }
+
+    /// Force the NEXT teardown to panic in its wait region. Sampled at submit time into
+    /// [`ReapJob::force_panic`](super::ReapJob::force_panic), because the region it models runs
+    /// on a worker.
+    pub(crate) fn set_force_teardown_panic(on: bool) {
+        FORCE_TEARDOWN_PANIC.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_teardown_panic() -> bool {
+        FORCE_TEARDOWN_PANIC.with(|f| f.replace(false))
+    }
+
+    /// Force the NEXT root `start_kill` in `Drop` on THIS thread to report failure. It REPLACES
+    /// the kill rather than masking its result, so the child really is left unsignalled.
+    pub(crate) fn set_force_kill_failure(on: bool) {
+        FORCE_KILL_FAILURE.with(|f| f.set(on));
+    }
+    pub(crate) fn take_force_kill_failure() -> bool {
+        FORCE_KILL_FAILURE.with(|f| f.replace(false))
     }
 }
 

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -213,6 +213,10 @@ pub(crate) fn run_teardown(job: ReapJob) {
     // `proc` is BORROWED into this region, never moved: an unwind must not destroy a resource
     // whose release the region below owns and orders.
     let waited = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        #[cfg(test)]
+        if let Some(p) = probe.as_ref() {
+            let _ = p.started.send(std::thread::current().id());
+        }
         // Executing elsewhere ⇒ a test may hold the teardown until it has observed the
         // not-yet-reaped state. On the dropping thread the teardown was inlined, so skipping the
         // gate lets that broken world fail an assertion instead of deadlocking.
@@ -273,6 +277,9 @@ pub(crate) mod test_probe {
     pub(crate) struct DropProbe {
         /// The dropping thread's id, sent from `Drop` before the handoff.
         pub(crate) entered: std::sync::mpsc::Sender<std::thread::ThreadId>,
+        /// The executing thread's id, sent by the teardown before it gates: "a worker took this
+        /// job". A released job never sends it, so the receiver's `Err` is the negative edge.
+        pub(crate) started: std::sync::mpsc::Sender<std::thread::ThreadId>,
         /// Held teardowns wait here; a dropped sender releases them.
         pub(crate) gate: std::sync::mpsc::Receiver<()>,
         pub(crate) outcome: std::sync::mpsc::Sender<ReapOutcome>,

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -58,6 +58,9 @@ struct LazyPool {
     bound: usize,
     cell: OnceLock<Pool>,
     init: Mutex<()>,
+    /// Init attempts that reached their spawn loop. Observability only — no decision reads it.
+    #[cfg(test)]
+    inits: std::sync::atomic::AtomicUsize,
 }
 
 impl LazyPool {
@@ -66,6 +69,8 @@ impl LazyPool {
             bound,
             cell: OnceLock::new(),
             init: Mutex::new(()),
+            #[cfg(test)]
+            inits: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -96,9 +101,20 @@ impl LazyPool {
                 }
             };
             if self.cell.get().is_none() {
+                #[cfg(test)]
+                self.inits.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                // Consumed here, on the submitting thread this init runs on.
+                #[cfg(test)]
+                let mut forced = fault::take_force_spawn_failures();
                 let (tx, rx) = crossbeam_channel::unbounded::<ReapJob>();
                 let mut started = 0usize;
                 for _ in 0..self.bound {
+                    #[cfg(test)]
+                    if forced > 0 {
+                        forced -= 1;
+                        failures.push(std::io::Error::other("forced reaper spawn failure (test seam)"));
+                        continue;
+                    }
                     let rx = rx.clone();
                     match std::thread::Builder::new()
                         .name("cosca-reaper".to_owned())
@@ -254,6 +270,25 @@ pub(crate) fn run_teardown(job: ReapJob) {
         let _ = std::panic::catch_unwind(|| {
             log::error!("releasing child {pid}'s resources panicked; its wait had already completed");
         });
+    }
+}
+
+/// Fault seams for the off-nominal paths. Take-semantics, matching `crate::wait::fault`.
+#[cfg(test)]
+pub(crate) mod fault {
+    use std::cell::Cell;
+
+    thread_local! {
+        static FORCE_SPAWN_FAILURES: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Fail the first `n` `Builder::spawn` attempts of the NEXT init entered from THIS thread.
+    /// Init runs on the submitting thread, so the thread-local is visible where it is read.
+    pub(crate) fn set_force_spawn_failures(n: usize) {
+        FORCE_SPAWN_FAILURES.with(|f| f.set(n));
+    }
+    pub(crate) fn take_force_spawn_failures() -> usize {
+        FORCE_SPAWN_FAILURES.with(|f| f.replace(0))
     }
 }
 

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -99,8 +99,10 @@ impl Pool {
             );
         }
         if let Err(e) = self.tx.send(job) {
-            debug_assert!(false, "a published reaper pool's channel cannot disconnect");
+            // Recover FIRST: in a debug build the assert below panics, and ordered ahead of the
+            // release it would cost this job the very recovery the branch exists for.
             release(e.into_inner());
+            debug_assert!(false, "a published reaper pool's channel cannot disconnect");
         }
     }
 }

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -1,7 +1,43 @@
 //! The wait-and-reap half of the async [`Child`](super::Child)'s teardown.
 //!
-//! `Drop` issues every signal on the dropping thread and hands what remains here, so the wait —
-//! and only the wait — runs on a reaper thread.
+//! **The split.** `Drop` issues every signal on the dropping thread and hands what remains here,
+//! so the wait — and only the wait — moves. The tree kill stays put for one mechanism-specific
+//! reason: on Windows a job object's kill is the only signal that reaches a nested descendant
+//! leading its own console group, and console control events stop at that boundary. (On Unix
+//! `hard_kill` and `terminate_tree` have the same radius.)
+//!
+//! **The invariant, and its owner.** *Every job sent is eventually received.* The channel is the
+//! only scheduler; a pool exists only at full width; every receiver predates any send and never
+//! exits after publication. Its owner is the init critical section, which writes the cell once,
+//! last, under a single predicate. No counter, no growth decision, no idle accounting.
+//!
+//! The job carries the process backend and every field whose release must stay ordered after the
+//! reap, not a bare pid: the backend pins the pid for the whole wait, and a bare pid would let
+//! the runtime's orphan queue reap it and the OS recycle it onto another of our children — under
+//! our own `waitid`.
+//!
+//! **Footprint.** A few parked threads for the process's life after the first kill-on-drop drop.
+//! Their stacks are reserved, not committed, and deliberately left at the default size: the
+//! teardown logs into an arbitrary consumer logger, and its panic path may capture a backtrace.
+//!
+//! **Degraded mode, which must not become ordinary.** Publication is all-or-nothing: a pool that
+//! cannot start every worker abandons — the started workers are joined on the queue's disconnect
+//! edge, each spawn's `io::Error` is logged (outside the init guard, so no dropping thread
+//! convoys behind a consumer's `Log` impl), the job in hand is released to the runtime's orphan
+//! handling, and the cell stays empty so the NEXT submit retries. Reaching it needs a spawn
+//! failure, and it re-arms its own retry. Its worst case is a machine so thread-starved that
+//! every drop performs that many failing spawn syscalls under the lock — syscalls only, no
+//! arbitrary code.
+//!
+//! **At the bound, jobs queue rather than being released.** A queued job pins the process
+//! handle (or, on Unix, the zombie and its pid), the containment resource — a cgroup leaf, a
+//! job-object handle, or the marker fds — and the pipe and stdio handles. That is still the
+//! better trade: every worker being wedged means the reap could not have completed anyway, and
+//! the runtime's orphan handling would not have managed it either. Process exit with jobs still
+//! queued is benign, since the roots are already signalled and the OS reaps them.
+//!
+//! The backlog `debug` log fires on healthy bursts too — it reports depth, not a fault, and no
+//! decision reads it.
 
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -66,6 +66,11 @@ pub(crate) struct ReapJob {
     /// thread-local of its own.
     #[cfg(test)]
     pub(crate) force_release_panic: bool,
+    /// Seeded panic in the GLUE between the two regions — the one place a panic escapes
+    /// [`run_teardown`]. It models a future edit breaking the two-region structure, which is the
+    /// only input [`work`]'s recovery guard has.
+    #[cfg(test)]
+    pub(crate) force_glue_panic: bool,
 }
 
 /// A wedged child occupies one worker and no other; the rest keep draining the shared queue. Not
@@ -206,11 +211,14 @@ impl LazyPool {
 fn work(rx: crossbeam_channel::Receiver<ReapJob>) {
     while let Ok(job) = rx.recv() {
         // Defense in depth against a future edit breaking `run_teardown`'s no-unwind contract:
-        // loud, never a silent absorb.
+        // loud, never a silent absorb — and never fatal to this worker. The whole recovery,
+        // ASSERT INCLUDED, sits inside a catch: a worker that died here would shrink a published
+        // pool permanently, since nothing replenishes one. The assert still reaches the default
+        // panic hook, so it stays as loud as any other.
         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_teardown(job))).is_err() {
-            debug_assert!(false, "run_teardown unwound despite its no-unwind contract");
             let _ = std::panic::catch_unwind(|| {
                 log::error!("a reaper teardown unwound despite its no-unwind contract");
+                debug_assert!(false, "run_teardown unwound despite its no-unwind contract");
             });
         }
     }
@@ -275,6 +283,8 @@ pub(crate) fn run_teardown(job: ReapJob) {
     let force_panic = job.force_panic;
     #[cfg(test)]
     let force_release_panic = job.force_release_panic;
+    #[cfg(test)]
+    let force_glue_panic = job.force_glue_panic;
     let mut proc = job.proc;
     let attached = job.attached;
     let pipes = job.pipes;
@@ -303,6 +313,13 @@ pub(crate) fn run_teardown(job: ReapJob) {
         }
         proc.wait_and_reap(pid);
     }));
+
+    // The glue. Only a seeded fault reaches this, and only to give `work`'s recovery guard the
+    // one input it can ever have.
+    #[cfg(test)]
+    if force_glue_panic {
+        panic!("forced glue panic (test seam)");
+    }
 
     let released = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if waited.is_err() {

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -1,0 +1,298 @@
+//! The wait-and-reap half of the async [`Child`](super::Child)'s teardown.
+//!
+//! `Drop` issues every signal on the dropping thread and hands what remains here, so the wait —
+//! and only the wait — runs on a reaper thread.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::containment::Attached;
+use crate::stdio::Fd;
+
+/// Everything `Drop` hands over: the process backend plus every field that holds an OS resource
+/// and drops after it today, so the release order survives the handoff.
+pub(crate) struct ReapJob {
+    pub(crate) proc: super::ProcSource,
+    pub(crate) attached: Attached,
+    pub(crate) pipes: super::FdPipes,
+    pub(crate) owned_std: BTreeMap<Fd, crate::tokio::stdio::OwnedStd>,
+    pub(crate) pid: u32,
+    /// The thread `Drop` ran on. `run_teardown` gates only when it is executing elsewhere.
+    #[cfg(test)]
+    pub(crate) origin: std::thread::ThreadId,
+    #[cfg(test)]
+    pub(crate) probe: Option<test_probe::DropProbe>,
+}
+
+/// A wedged child occupies one worker and no other; the rest keep draining the shared queue. Not
+/// a throughput device — an ordinary reap waits microseconds on an already-killed child.
+const REAPER_POOL_THREADS: usize = 4;
+
+/// A published pool: the sending half of the one queue its workers share.
+struct Pool {
+    tx: crossbeam_channel::Sender<ReapJob>,
+}
+
+impl Pool {
+    /// Hand the job to whichever worker takes it next.
+    fn dispatch(&self, job: ReapJob) {
+        let backlog = self.tx.len();
+        if backlog > 0 {
+            // Fires on healthy bursts too — this is a depth reading, not a fault. No decision
+            // reads it.
+            log::debug!(
+                "child {} queued behind {backlog} reaps (pool width {REAPER_POOL_THREADS})",
+                job.pid
+            );
+        }
+        if let Err(e) = self.tx.send(job) {
+            // Unreachable: a published pool's sender lives in a `static` and never drops.
+            debug_assert!(false, "a published reaper pool's channel cannot disconnect");
+            release(e.into_inner());
+        }
+    }
+}
+
+/// The pool behind a `submit`, started on first use.
+struct LazyPool {
+    bound: usize,
+    cell: OnceLock<Pool>,
+    init: Mutex<()>,
+}
+
+impl LazyPool {
+    const fn new(bound: usize) -> LazyPool {
+        LazyPool {
+            bound,
+            cell: OnceLock::new(),
+            init: Mutex::new(()),
+        }
+    }
+
+    /// The pool, starting it on first use. **Publishes iff `started == bound`**; any other
+    /// outcome abandons, and `None` tells the caller to release the job in hand and leaves the
+    /// cell empty so the next submit retries.
+    ///
+    /// The guard covers only the re-check, the channel, the spawns and the publish decision —
+    /// exclusivity is the whole point of keeping the spawns inside it. Joining abandoned workers
+    /// and every log call happen after it drops, so no dropping thread convoys behind another's
+    /// join or behind a consumer's `Log` impl.
+    fn get(&self) -> Option<&Pool> {
+        if let Some(pool) = self.cell.get() {
+            return Some(pool);
+        }
+        // Handed out of the critical section (see above).
+        let mut abandoned: Vec<std::thread::JoinHandle<()>> = Vec::new();
+        let mut failures: Vec<std::io::Error> = Vec::new();
+        let mut published = false;
+        {
+            let guard = match self.init.lock() {
+                Ok(guard) => guard,
+                // The guarded state is a single once-only `cell.set` taken as the last step, so
+                // it is consistent by construction.
+                Err(poisoned) => {
+                    debug_assert!(false, "the reaper init lock cannot be poisoned");
+                    poisoned.into_inner()
+                }
+            };
+            if self.cell.get().is_none() {
+                let (tx, rx) = crossbeam_channel::unbounded::<ReapJob>();
+                let mut started = 0usize;
+                for _ in 0..self.bound {
+                    let rx = rx.clone();
+                    match std::thread::Builder::new()
+                        .name("cosca-reaper".to_owned())
+                        .spawn(move || work(rx))
+                    {
+                        Ok(handle) => {
+                            started += 1;
+                            abandoned.push(handle);
+                        }
+                        Err(e) => failures.push(e),
+                    }
+                }
+                // The single publication predicate. On any other outcome `tx` and `rx` drop with
+                // this block, disconnecting the queue, so the started workers exit and the joins
+                // below are bounded.
+                if started == self.bound {
+                    match self.cell.set(Pool { tx }) {
+                        // A published pool's workers are immortal: drop the handles, never join.
+                        Ok(()) => {
+                            abandoned.clear();
+                            published = true;
+                        }
+                        Err(_) => debug_assert!(false, "the reaper cell was set past its own in-lock re-check"),
+                    }
+                }
+            }
+            drop(guard);
+        }
+        for handle in abandoned {
+            let _ = handle.join();
+        }
+        for e in failures {
+            log::error!("starting a reaper thread failed: {e}");
+        }
+        if published {
+            log::debug!("reaper pool started ({} threads)", self.bound);
+        }
+        self.cell.get()
+    }
+}
+
+/// A reaper worker. Immortal once its pool is published: [`run_teardown`] cannot unwind, and the
+/// only exit is the queue's disconnect — the pre-publication abandon edge, since a published
+/// pool's sender lives in a `static`.
+fn work(rx: crossbeam_channel::Receiver<ReapJob>) {
+    while let Ok(job) = rx.recv() {
+        // Defense in depth against a future edit breaking `run_teardown`'s no-unwind contract:
+        // loud, never a silent absorb.
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_teardown(job))).is_err() {
+            debug_assert!(false, "run_teardown unwound despite its no-unwind contract");
+            let _ = std::panic::catch_unwind(|| {
+                log::error!("a reaper teardown unwound despite its no-unwind contract");
+            });
+        }
+    }
+}
+
+fn submit_to(lazy: &LazyPool, job: ReapJob) {
+    match lazy.get() {
+        Some(pool) => pool.dispatch(job),
+        None => release(job),
+    }
+}
+
+/// Hand `job` to the process-global reaper pool, starting it if this is the first kill-on-drop
+/// drop of the process.
+pub(crate) fn submit(job: ReapJob) {
+    static GLOBAL: LazyPool = LazyPool::new(REAPER_POOL_THREADS);
+    submit_to(&GLOBAL, job);
+}
+
+/// Degraded mode: the pool could not start at full width. The root is already signalled, so the
+/// remaining cost is the reap — handed to tokio's orphan handling (a no-op on Windows, which has
+/// nothing to reap). `error`, not `warn`: the crate is knowingly giving up its own guarantee.
+fn release(job: ReapJob) {
+    log::error!(
+        "no reaper thread is available; child {} is left to the runtime's orphan handling (it is \
+         already signalled)",
+        job.pid
+    );
+    #[cfg(test)]
+    let probe = job.probe;
+    drop(job.proc);
+    drop(job.attached);
+    drop(job.pipes);
+    drop(job.owned_std);
+    #[cfg(test)]
+    if let Some(p) = probe {
+        let _ = p.outcome.send(test_probe::ReapOutcome::Released);
+    }
+}
+
+/// Wait for the root's exit, reap it, then release the job's resources in `Child`'s own field
+/// order. **Never kills:** the signal was already issued on the dropping thread, and a second
+/// kill can fail (Windows denies terminating an already-exiting process), which every
+/// kill-then-wait path reads as "do not wait" — silently losing the reap.
+///
+/// **Never unwinds.** Two `catch_unwind` regions — the wait, then the release — with glue that is
+/// only moves, matches and further `catch_unwind` calls. Every log call sits inside a region,
+/// because a consumer's `Log` impl is untrusted.
+pub(crate) fn run_teardown(job: ReapJob) {
+    #[cfg(test)]
+    let origin = job.origin;
+    #[cfg(test)]
+    let probe = job.probe;
+    let mut proc = job.proc;
+    let attached = job.attached;
+    let pipes = job.pipes;
+    let owned_std = job.owned_std;
+    let pid = job.pid;
+
+    // `proc` is BORROWED into this region, never moved: an unwind must not destroy a resource
+    // whose release the region below owns and orders.
+    let waited = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Executing elsewhere ⇒ a test may hold the teardown until it has observed the
+        // not-yet-reaped state. On the dropping thread the teardown was inlined, so skipping the
+        // gate lets that broken world fail an assertion instead of deadlocking.
+        #[cfg(test)]
+        if std::thread::current().id() != origin {
+            if let Some(p) = probe.as_ref() {
+                let _ = p.gate.recv(); // a dropped sender is also a release
+            }
+        }
+        proc.wait_and_reap(pid);
+    }));
+
+    let released = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if waited.is_err() {
+            log::error!("reaping child {pid} panicked; releasing its resources anyway");
+        }
+        // `Child`'s declaration order — `proc` first, so the pid stays pinned for the whole wait
+        // and every other release stays ordered after the reap.
+        drop(proc);
+        drop(attached);
+        drop(pipes);
+        drop(owned_std);
+        #[cfg(test)]
+        if let Some(p) = probe {
+            let _ = p.outcome.send(if waited.is_err() {
+                test_probe::ReapOutcome::Panicked
+            } else {
+                test_probe::ReapOutcome::Reaped(std::thread::current().id())
+            });
+        }
+    }));
+    if released.is_err() {
+        // Wrapped for the same reason the other log calls are: an untrusted `Log` impl must not
+        // be the thing that finally unwinds this function.
+        let _ = std::panic::catch_unwind(|| {
+            log::error!("releasing child {pid}'s resources panicked; its wait had already completed");
+        });
+    }
+}
+
+/// Observation seam for the drop handoff. `#[cfg(test)]`, not `#[doc(hidden)] pub`: nothing
+/// test-only reaches a downstream build, so no gate can ever block in a consumer's `Drop`.
+///
+/// A held [`DropProbe::gate`] parks one worker of the process-global pool indefinitely, and the
+/// pool is shared with every other test in the binary — see `reaper_tests`' header for the
+/// budget that keeps.
+#[cfg(test)]
+pub(crate) mod test_probe {
+    use std::cell::RefCell;
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub(crate) enum ReapOutcome {
+        Reaped(std::thread::ThreadId),
+        Released,
+        Panicked,
+    }
+
+    pub(crate) struct DropProbe {
+        /// The dropping thread's id, sent from `Drop` before the handoff.
+        pub(crate) entered: std::sync::mpsc::Sender<std::thread::ThreadId>,
+        /// Held teardowns wait here; a dropped sender releases them.
+        pub(crate) gate: std::sync::mpsc::Receiver<()>,
+        pub(crate) outcome: std::sync::mpsc::Sender<ReapOutcome>,
+    }
+
+    thread_local! {
+        static PROBE: RefCell<Option<DropProbe>> = const { RefCell::new(None) };
+    }
+
+    /// Arm a probe for the NEXT `Child::drop` on THIS thread (take-semantics, matching
+    /// `crate::wait::fault`).
+    pub(crate) fn arm(probe: DropProbe) {
+        PROBE.with(|p| *p.borrow_mut() = Some(probe));
+    }
+
+    pub(crate) fn take() -> Option<DropProbe> {
+        PROBE.with(|p| p.borrow_mut().take())
+    }
+}
+
+#[cfg(test)]
+#[path = "reaper_tests.rs"]
+mod reaper_tests;

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -3,12 +3,15 @@
 //!
 //! **Gate-holding budget.** The pool behind `submit` is process-global and shared with every
 //! other test in this binary, so no test may reason about its worker count or its idleness. A
-//! worker of it is held *indefinitely* only behind a held probe gate, and probes are private to
-//! this module, so the budget is local: at most `REAPER_POOL_THREADS - 1` tests here may hold a
-//! gate on the global pool concurrently. Currently exactly one does
-//! (`drop_signals_the_root_and_returns_before_the_reap`); the pool-shape tests hold their gates
-//! on their own [`private_pool`]s instead. Every other drop in the binary occupies a global
-//! worker only for a killed child's prompt exit.
+//! worker of it is parked *indefinitely* only behind a held probe gate, so the budget is
+//! `REAPER_POOL_THREADS - 1` concurrent holders — at full width, a later drop's job would queue
+//! behind holders that are themselves waiting, and libtest runs these in parallel.
+//!
+//! The budget is spent by [`arm_probe`] and nothing else. Exactly one test calls it
+//! (`drop_signals_the_root_and_returns_before_the_reap`, which holds across a blocking socket
+//! read — the gate IS its discriminator), leaving two of the three slots free. Every other
+//! global-pool test takes [`arm_probe_ungated`], which hands back no gate to hold; the
+//! pool-shape tests gate their own [`private_pool`]s, which are nobody else's.
 
 use std::sync::mpsc;
 use std::thread::ThreadId;
@@ -114,11 +117,23 @@ fn release_and_reap(ends: ProbeEnds) {
     );
 }
 
-/// Arm a probe for the next `Child::drop` on this thread and keep its ends.
+/// Arm a probe for the next `Child::drop` on this thread and keep its ends, GATE HELD — so the
+/// teardown parks a worker of the process-global pool until this test releases it. Spends one of
+/// the gate-holding budget in the file header; prefer [`arm_probe_ungated`].
 fn arm_probe() -> ProbeEnds {
     let (probe, ends) = probe_pair();
     arm(probe);
     ends
+}
+
+/// As [`arm_probe`], but the gate is released before it can ever be held, so the teardown runs
+/// straight through and the global worker is occupied only for the killed child's prompt exit.
+/// The right choice for any test that observes nothing while the teardown is held — and it hands
+/// back no gate, so such a test cannot spend the budget by accident.
+fn arm_probe_ungated() -> (mpsc::Receiver<ThreadId>, mpsc::Receiver<ReapOutcome>) {
+    let ends = arm_probe();
+    drop(ends.gate);
+    (ends.entered, ends.outcome)
 }
 
 #[tokio::test]
@@ -182,15 +197,14 @@ async fn drop_signals_the_root_and_returns_before_the_reap() {
 
 #[tokio::test]
 async fn drop_reaps_on_a_worker_thread() {
-    let ends = arm_probe();
+    let (entered, outcome) = arm_probe_ungated();
     let (child, _sock) = spawn_async_blocker();
     #[cfg(unix)]
     let id = child.id();
     drop(child);
 
-    let dropping = ends.entered.recv().expect("Drop must reach the handoff");
-    drop(ends.gate);
-    let outcome = ends.outcome.recv().expect("the teardown must report an outcome");
+    let dropping = entered.recv().expect("Drop must reach the handoff");
+    let outcome = outcome.recv().expect("the teardown must report an outcome");
     // Thread ids FIRST: an inlined teardown is the failure under test, and asserting the
     // identity first would fail it for an incidental reason instead.
     match outcome {
@@ -422,15 +436,14 @@ async fn concurrent_first_submits_share_one_init() {
 
 #[tokio::test]
 async fn teardown_panic_is_caught_and_reported() {
-    let ends = arm_probe();
+    let (entered, outcome) = arm_probe_ungated();
     let (child, _sock) = spawn_async_blocker();
     super::fault::set_force_teardown_panic(true);
     drop(child);
 
-    ends.entered.recv().expect("Drop must reach the handoff");
-    drop(ends.gate);
+    entered.recv().expect("Drop must reach the handoff");
     assert_eq!(
-        ends.outcome
+        outcome
             .recv()
             .expect("without the wait region's catch the worker unwinds and no outcome arrives"),
         ReapOutcome::Panicked,
@@ -467,16 +480,15 @@ async fn release_region_panic_does_not_unwind_run_teardown() {
 #[tokio::test]
 async fn unkillable_root_is_not_submitted() {
     use std::io::{Read as _, Write as _};
-    let ends = arm_probe();
+    // Ungated: nothing is submitted here, and a broken world that DID submit must not wedge a
+    // worker instead of failing the assertion below.
+    let (entered, outcome) = arm_probe_ungated();
     let (child, mut sock) = spawn_async_blocker();
     let id = child.id();
     super::fault::set_force_kill_failure(true);
     drop(child);
 
-    ends.entered.recv().expect("Drop must reach the handoff");
-    // Nothing is submitted, so nothing gates; releasing anyway keeps a broken world that DID
-    // submit from wedging a worker instead of failing the assertion below.
-    drop(ends.gate);
+    entered.recv().expect("Drop must reach the handoff");
     // Race-free: the seam REPLACED the kill, so the child was never signalled.
     assert_eq!(
         id.is_alive(),
@@ -501,7 +513,7 @@ async fn unkillable_root_is_not_submitted() {
     // The probe's outcome sender dropped with the job that was never built. A submitted job would
     // by now have reaped the exited child and reported `Reaped`.
     assert!(
-        ends.outcome.recv().is_err(),
+        outcome.recv().is_err(),
         "a child whose kill failed must not be submitted"
     );
 }

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -79,10 +79,10 @@ fn bare_job(origin: ThreadId, probe: Option<DropProbe>) -> super::ReapJob {
     };
     let pid = proc.id().expect("a freshly spawned child has a pid");
     super::ReapJob {
-        proc: super::super::ProcSource::Tokio(proc),
-        attached: crate::containment::Attached::None,
-        pipes: Default::default(),
-        owned_std: Default::default(),
+        os: super::super::OsResources {
+            proc: Some(super::super::ProcSource::Tokio(proc)),
+            ..Default::default()
+        },
         pid,
         origin,
         probe,

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -88,6 +88,7 @@ fn bare_job(origin: ThreadId, probe: Option<DropProbe>) -> super::ReapJob {
         probe,
         force_panic: false,
         force_release_panic: false,
+        force_glue_panic: false,
     }
 }
 
@@ -502,5 +503,45 @@ async fn unkillable_root_is_not_submitted() {
     assert!(
         ends.outcome.recv().is_err(),
         "a child whose kill failed must not be submitted"
+    );
+}
+
+/// `work`'s recovery guard exists for exactly one input: a `run_teardown` that unwound. Its whole
+/// value is that the worker survives it — a dead worker shrinks a published pool permanently,
+/// silently, and nothing replenishes it. Run on a channel and thread this test OWNS, so the
+/// global pool is never perturbed and `join` is available as the edge.
+#[tokio::test]
+async fn a_worker_survives_a_teardown_that_unwinds() {
+    let origin = std::thread::current().id();
+    let (tx, rx) = crossbeam_channel::unbounded::<super::ReapJob>();
+    let worker = std::thread::spawn(move || super::work(rx));
+
+    // A teardown that unwinds out of both regions, through the glue.
+    let (probe, ends) = probe_pair();
+    drop(ends.gate);
+    let mut job = bare_job(origin, Some(probe));
+    job.force_glue_panic = true;
+    tx.send(job).expect("the worker's receiver is live");
+    assert!(
+        ends.outcome.recv().is_err(),
+        "a teardown that unwinds past the release region reports no outcome"
+    );
+
+    // A second job the SAME worker must still take.
+    let (probe, ends) = probe_pair();
+    drop(ends.gate);
+    tx.send(bare_job(origin, Some(probe)))
+        .expect("the worker's receiver must have outlived the unwinding teardown");
+
+    // Dropping the sender is the edge in BOTH worlds: a live worker drains the queue and then
+    // returns on the disconnect; a worker the guard killed has already returned, panicking. So
+    // `join` always terminates, and its `Err` IS the dead-worker signal.
+    drop(tx);
+    worker
+        .join()
+        .expect("the recovery guard must not unwind out of `work` and kill the worker");
+    assert!(
+        matches!(ends.outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "the surviving worker must keep draining the queue"
     );
 }

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -1,0 +1,142 @@
+//! Probe-based coverage of the drop handoff and the reaper pool. These are unit tests because
+//! the probe is `#[cfg(test)]`: an integration test has no edge to wait on.
+//!
+//! **Gate-holding budget.** The pool behind `submit` is process-global and shared with every
+//! other test in this binary, so no test may reason about its worker count or its idleness. A
+//! worker is held *indefinitely* only behind a held probe gate, and probes are private to this
+//! module, so the budget is local: at most `REAPER_POOL_THREADS - 1` tests here may hold a gate
+//! concurrently. Currently exactly one does
+//! (`drop_signals_the_root_and_returns_before_the_reap`). Every other drop in the binary occupies
+//! a worker only for a killed child's prompt exit.
+
+use std::sync::mpsc;
+
+use super::test_probe::{arm, DropProbe, ReapOutcome};
+// Windows has no zombie, and a pid outlives its last handle by an asynchronous kernel rundown
+// that nothing in user mode signals. So identity-after-teardown is a Unix-only property, as the
+// `#[cfg(unix)]` `async_drop_leaves_no_zombie` this coverage came from already recorded.
+#[cfg(unix)]
+use crate::identity::{ProcessId, Resolved};
+use crate::test_child::spawn_async_blocker;
+
+/// Failure bound on an external kernel event — a killed child's exit — surfaced through the
+/// named `expect`/`panic!` below. Not a synchronisation device: the edge is the socket's EOF.
+const CHILD_EXIT_BOUND: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The three ends a test keeps: the dropping thread's id, the gate release, and the outcome.
+struct ProbeEnds {
+    entered: mpsc::Receiver<std::thread::ThreadId>,
+    gate: mpsc::Sender<()>,
+    outcome: mpsc::Receiver<ReapOutcome>,
+}
+
+fn probe_pair() -> (DropProbe, ProbeEnds) {
+    let (entered_tx, entered) = mpsc::channel();
+    let (gate, gate_rx) = mpsc::channel();
+    let (outcome_tx, outcome) = mpsc::channel();
+    (
+        DropProbe {
+            entered: entered_tx,
+            gate: gate_rx,
+            outcome: outcome_tx,
+        },
+        ProbeEnds { entered, gate, outcome },
+    )
+}
+
+/// Arm a probe for the next `Child::drop` on this thread and keep its ends.
+fn arm_probe() -> ProbeEnds {
+    let (probe, ends) = probe_pair();
+    arm(probe);
+    ends
+}
+
+#[tokio::test]
+async fn drop_signals_the_root_and_returns_before_the_reap() {
+    use std::io::Read as _;
+    let ends = arm_probe();
+    let (child, mut sock) = spawn_async_blocker();
+    #[cfg(unix)]
+    let id = child.id();
+    drop(child);
+
+    // Guard: `Drop` reached the handoff at all. Without it an early return would leave every
+    // assertion below observing nothing and passing vacuously.
+    let dropping = ends.entered.recv().expect("Drop must reach the handoff");
+    assert_eq!(
+        dropping,
+        std::thread::current().id(),
+        "#[tokio::test] is current-thread"
+    );
+
+    // The root was SIGNALLED on the dropping thread and has exited: its control socket is shut.
+    // The gate is still held, so no worker can have done this.
+    sock.set_read_timeout(Some(CHILD_EXIT_BOUND))
+        .expect("bound the killed child's exit");
+    let mut buf = [0u8; 1];
+    match sock.read(&mut buf) {
+        Ok(0) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+        other => panic!("root not signalled on the dropping thread before Drop returned: {other:?}"),
+    }
+
+    // `Drop` returned before the teardown. Race-free rather than merely not-yet-observed: we
+    // still hold the gate SENDER, so a teardown on a worker CANNOT have reported, while an
+    // inlined one provably reported before `drop` returned. This is the whole discriminator on
+    // Windows, where the identity comparison below cannot tell the two worlds apart.
+    assert!(
+        matches!(ends.outcome.try_recv(), Err(mpsc::TryRecvError::Empty)),
+        "Drop must return before the teardown runs"
+    );
+    // Unix sharpens it: the child has exited but is still an unreaped zombie, so its identity
+    // resolves. Reuse-immune — the comparison is pid + start token.
+    #[cfg(unix)]
+    assert_eq!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "the exited child must still be an unreaped zombie while the teardown is gated"
+    );
+
+    drop(ends.gate);
+    assert!(
+        matches!(ends.outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "the released teardown must reap"
+    );
+    #[cfg(unix)]
+    assert_ne!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "after the teardown the child's identity must be gone"
+    );
+}
+
+#[tokio::test]
+async fn drop_reaps_on_a_worker_thread() {
+    let ends = arm_probe();
+    let (child, _sock) = spawn_async_blocker();
+    #[cfg(unix)]
+    let id = child.id();
+    drop(child);
+
+    let dropping = ends.entered.recv().expect("Drop must reach the handoff");
+    drop(ends.gate);
+    let outcome = ends.outcome.recv().expect("the teardown must report an outcome");
+    // Thread ids FIRST: an inlined teardown is the failure under test, and asserting the
+    // identity first would fail it for an incidental reason instead.
+    match outcome {
+        ReapOutcome::Reaped(executing) => assert_ne!(
+            executing, dropping,
+            "the reap must run on a worker thread, not the dropping thread"
+        ),
+        other => panic!("expected Reaped, got {other:?}"),
+    }
+    // The no-zombie property, sequenced after a real edge rather than after a blocking `Drop`.
+    // A zombie still resolves to `Found(id)` (Linux `/proc` persists); a reaped pid resolves to
+    // `Gone` or, if recycled, a DIFFERENT identity — so a recycled pid never false-passes.
+    #[cfg(unix)]
+    assert_ne!(
+        ProcessId::of(id.pid()),
+        Resolved::Found(id),
+        "the teardown must fully reap the child (no lingering process or zombie at its identity)"
+    );
+}

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -323,3 +323,96 @@ async fn pool_width_follows_its_bound() {
         release_and_reap(e);
     }
 }
+
+/// Submit one UNGATED job to `pool` and keep its outcome — the shape the degraded-mode tests use.
+/// A dropped gate sender is a release, so a job that does reach a worker never blocks.
+fn submit_ungated(pool: &'static super::LazyPool) -> mpsc::Receiver<ReapOutcome> {
+    let (probe, ends) = probe_pair();
+    drop(ends.gate);
+    super::submit_to(pool, bare_job(std::thread::current().id(), Some(probe)));
+    ends.outcome
+}
+
+#[tokio::test]
+async fn any_spawn_failure_abandons_the_pool_and_the_next_dispatch_retries() {
+    let pool = private_pool(super::REAPER_POOL_THREADS);
+
+    super::fault::set_force_spawn_failures(1);
+    let outcome = submit_ungated(pool);
+    // `release` runs synchronously before `submit_to` returns, so this needs no edge to wait on.
+    assert_eq!(
+        outcome.try_recv(),
+        Ok(ReapOutcome::Released),
+        "a pool that could not start every worker must abandon and release the job in hand"
+    );
+
+    let outcome = submit_ungated(pool);
+    assert!(
+        matches!(outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "the abandoned pool leaves its cell empty, so the next dispatch must retry the init"
+    );
+    // Last, so it cannot shadow the retry assertion above: a seam nothing read would still be
+    // armed here, and neither init consumed it.
+    assert_eq!(
+        super::fault::take_force_spawn_failures(),
+        0,
+        "the seam must have been consumed — a flag nothing read cannot fail this test"
+    );
+}
+
+#[tokio::test]
+async fn total_spawn_failure_releases_the_job_in_hand() {
+    // Its OWN pool: a second pool in one test would shadow an init mutation. This one exercises
+    // the join-of-zero-started path, where the test above joins three.
+    let pool = private_pool(super::REAPER_POOL_THREADS);
+
+    super::fault::set_force_spawn_failures(super::REAPER_POOL_THREADS);
+    let outcome = submit_ungated(pool);
+    assert_eq!(
+        outcome.try_recv(),
+        Ok(ReapOutcome::Released),
+        "with no worker started at all the job must be released in hand"
+    );
+    assert_eq!(
+        super::fault::take_force_spawn_failures(),
+        0,
+        "the seam must have been consumed"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_first_submits_share_one_init() {
+    let pool = private_pool(super::REAPER_POOL_THREADS);
+    let submitters = super::REAPER_POOL_THREADS + 2;
+    let origin = std::thread::current().id();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(submitters));
+
+    let mut outcomes = Vec::new();
+    let mut handles = Vec::new();
+    for _ in 0..submitters {
+        let (probe, ends) = probe_pair();
+        drop(ends.gate);
+        outcomes.push(ends.outcome);
+        // Built on the test thread: tokio's process spawn needs a runtime, the submitters do not.
+        let job = bare_job(origin, Some(probe));
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            super::submit_to(pool, job);
+        }));
+    }
+    for h in handles {
+        h.join().expect("a submitting thread must not panic");
+    }
+    for outcome in outcomes {
+        assert!(
+            matches!(outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+            "a submitter that spuriously saw no pool would have released its job instead"
+        );
+    }
+    assert_eq!(
+        pool.inits.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "the in-lock re-check must admit exactly one init"
+    );
+}

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -86,6 +86,8 @@ fn bare_job(origin: ThreadId, probe: Option<DropProbe>) -> super::ReapJob {
         pid,
         origin,
         probe,
+        force_panic: false,
+        force_release_panic: false,
     }
 }
 
@@ -414,5 +416,91 @@ async fn concurrent_first_submits_share_one_init() {
         pool.inits.load(std::sync::atomic::Ordering::Relaxed),
         1,
         "the in-lock re-check must admit exactly one init"
+    );
+}
+
+#[tokio::test]
+async fn teardown_panic_is_caught_and_reported() {
+    let ends = arm_probe();
+    let (child, _sock) = spawn_async_blocker();
+    super::fault::set_force_teardown_panic(true);
+    drop(child);
+
+    ends.entered.recv().expect("Drop must reach the handoff");
+    drop(ends.gate);
+    assert_eq!(
+        ends.outcome
+            .recv()
+            .expect("without the wait region's catch the worker unwinds and no outcome arrives"),
+        ReapOutcome::Panicked,
+        "a panicking teardown must be caught and reported"
+    );
+    assert!(
+        !super::fault::take_force_teardown_panic(),
+        "the fault must have been consumed at submit time"
+    );
+}
+
+#[tokio::test]
+async fn release_region_panic_does_not_unwind_run_teardown() {
+    let (probe, ends) = probe_pair();
+    drop(ends.gate); // released up front: this test is about the region after the wait
+    let mut job = bare_job(std::thread::current().id(), Some(probe));
+    job.force_release_panic = true;
+
+    // `join`'s `Err` IS the thread-death edge, so the broken world fails deterministically with
+    // no cross-thread race.
+    let h = std::thread::spawn(move || super::run_teardown(job));
+    assert!(
+        h.join().is_ok(),
+        "run_teardown must not unwind out of its release region"
+    );
+    // Vacuity pin: had the seeded panic not fired, the release region would have completed and
+    // sent `Reaped` — turning this red.
+    assert!(
+        ends.outcome.recv().is_err(),
+        "the panicking release region must drop the probe unsent"
+    );
+}
+
+#[tokio::test]
+async fn unkillable_root_is_not_submitted() {
+    use std::io::{Read as _, Write as _};
+    let ends = arm_probe();
+    let (child, mut sock) = spawn_async_blocker();
+    let id = child.id();
+    super::fault::set_force_kill_failure(true);
+    drop(child);
+
+    ends.entered.recv().expect("Drop must reach the handoff");
+    // Nothing is submitted, so nothing gates; releasing anyway keeps a broken world that DID
+    // submit from wedging a worker instead of failing the assertion below.
+    drop(ends.gate);
+    // Race-free: the seam REPLACED the kill, so the child was never signalled.
+    assert_eq!(
+        id.is_alive(),
+        crate::identity::Liveness::Alive,
+        "an unkillable root must be left running"
+    );
+    assert!(
+        !super::fault::take_force_kill_failure(),
+        "the fault must have been consumed"
+    );
+
+    // Release it so it exits of its own accord — the real edge a submitted job would complete on.
+    sock.write_all(b"x").expect("release the unsignalled child");
+    sock.set_read_timeout(Some(CHILD_EXIT_BOUND))
+        .expect("bound the released child's exit");
+    let mut buf = [0u8; 1];
+    match sock.read(&mut buf) {
+        Ok(0) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+        other => panic!("the released child did not exit: {other:?}"),
+    }
+    // The probe's outcome sender dropped with the job that was never built. A submitted job would
+    // by now have reaped the exited child and reported `Reaped`.
+    assert!(
+        ends.outcome.recv().is_err(),
+        "a child whose kill failed must not be submitted"
     );
 }

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -3,13 +3,15 @@
 //!
 //! **Gate-holding budget.** The pool behind `submit` is process-global and shared with every
 //! other test in this binary, so no test may reason about its worker count or its idleness. A
-//! worker is held *indefinitely* only behind a held probe gate, and probes are private to this
-//! module, so the budget is local: at most `REAPER_POOL_THREADS - 1` tests here may hold a gate
-//! concurrently. Currently exactly one does
-//! (`drop_signals_the_root_and_returns_before_the_reap`). Every other drop in the binary occupies
-//! a worker only for a killed child's prompt exit.
+//! worker of it is held *indefinitely* only behind a held probe gate, and probes are private to
+//! this module, so the budget is local: at most `REAPER_POOL_THREADS - 1` tests here may hold a
+//! gate on the global pool concurrently. Currently exactly one does
+//! (`drop_signals_the_root_and_returns_before_the_reap`); the pool-shape tests hold their gates
+//! on their own [`private_pool`]s instead. Every other drop in the binary occupies a global
+//! worker only for a killed child's prompt exit.
 
 use std::sync::mpsc;
+use std::thread::ThreadId;
 
 use super::test_probe::{arm, DropProbe, ReapOutcome};
 // Windows has no zombie, and a pid outlives its last handle by an asynchronous kernel rundown
@@ -23,25 +25,90 @@ use crate::test_child::spawn_async_blocker;
 /// named `expect`/`panic!` below. Not a synchronisation device: the edge is the socket's EOF.
 const CHILD_EXIT_BOUND: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// The three ends a test keeps: the dropping thread's id, the gate release, and the outcome.
+/// The four ends a test keeps: the dropping thread's id, the executing worker's id, the gate
+/// release, and the outcome.
 struct ProbeEnds {
-    entered: mpsc::Receiver<std::thread::ThreadId>,
+    entered: mpsc::Receiver<ThreadId>,
+    started: mpsc::Receiver<ThreadId>,
     gate: mpsc::Sender<()>,
     outcome: mpsc::Receiver<ReapOutcome>,
 }
 
 fn probe_pair() -> (DropProbe, ProbeEnds) {
     let (entered_tx, entered) = mpsc::channel();
+    let (started_tx, started) = mpsc::channel();
     let (gate, gate_rx) = mpsc::channel();
     let (outcome_tx, outcome) = mpsc::channel();
     (
         DropProbe {
             entered: entered_tx,
+            started: started_tx,
             gate: gate_rx,
             outcome: outcome_tx,
         },
-        ProbeEnds { entered, gate, outcome },
+        ProbeEnds {
+            entered,
+            started,
+            gate,
+            outcome,
+        },
     )
+}
+
+/// A pool of this test's own, so its worker count and idleness are facts the test may reason
+/// about — which the process-global one never is. Leaked: a published pool's sender must never
+/// drop, or its workers would exit on the disconnect.
+fn private_pool(bound: usize) -> &'static super::LazyPool {
+    Box::leak(Box::new(super::LazyPool::new(bound)))
+}
+
+/// A job built by hand around a bare `::tokio::process::Child` that exits of its own accord —
+/// NOT by emptying a `cosca` handle, whose own `Drop` would then hit `PROC_TAKEN` and panic the
+/// test. The teardown never kills, so the child's own exit is what ends the wait.
+fn bare_job(origin: ThreadId, probe: Option<DropProbe>) -> super::ReapJob {
+    let proc = {
+        // The same lock every cosca-originated spawn in this binary takes: a macOS fork landing
+        // while another test's fd-marker write end is open would transiently inherit it.
+        let _guard = crate::child::spawn::spawn_lock();
+        ::tokio::process::Command::new(std::env::current_exe().expect("current_exe"))
+            .args(["--exact", "__cosca_no_such_test__"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn a child that exits")
+    };
+    let pid = proc.id().expect("a freshly spawned child has a pid");
+    super::ReapJob {
+        proc: super::super::ProcSource::Tokio(proc),
+        attached: crate::containment::Attached::None,
+        pipes: Default::default(),
+        owned_std: Default::default(),
+        pid,
+        origin,
+        probe,
+    }
+}
+
+/// The ends of `count` jobs submitted to `pool`, each gated by this test.
+fn submit_gated(pool: &'static super::LazyPool, count: usize) -> Vec<ProbeEnds> {
+    let origin = std::thread::current().id();
+    (0..count)
+        .map(|_| {
+            let (probe, ends) = probe_pair();
+            super::submit_to(pool, bare_job(origin, Some(probe)));
+            ends
+        })
+        .collect()
+}
+
+/// Release one gated job and take its reap — how a test hands its worker back.
+fn release_and_reap(ends: ProbeEnds) {
+    let ProbeEnds { gate, outcome, .. } = ends;
+    drop(gate);
+    assert!(
+        matches!(outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "a released job must reap"
+    );
 }
 
 /// Arm a probe for the next `Child::drop` on this thread and keep its ends.
@@ -139,4 +206,120 @@ async fn drop_reaps_on_a_worker_thread() {
         Resolved::Found(id),
         "the teardown must fully reap the child (no lingering process or zombie at its identity)"
     );
+}
+
+#[tokio::test]
+async fn teardown_reports_the_executing_thread_not_the_origin() {
+    let (probe, ends) = probe_pair();
+    drop(ends.gate); // a dropped sender is a release, so the teardown never blocks
+    let origin = std::thread::current().id();
+    let job = bare_job(origin, Some(probe));
+
+    // `h.thread().id()` is a value the TEST holds without asking the executing thread, and it
+    // differs from `origin` — so an implementation reporting `job.origin` fails here. Calling
+    // `run_teardown` synchronously and comparing against `thread::current().id()` would be two
+    // evaluations of one expression and could not fail.
+    let h = std::thread::spawn(move || super::run_teardown(job));
+    let executing = h.thread().id();
+    h.join().expect("the teardown thread must not panic");
+
+    assert_ne!(executing, origin, "the teardown must run off the origin thread");
+    assert_eq!(
+        ends.outcome.recv().expect("the teardown must report an outcome"),
+        ReapOutcome::Reaped(executing),
+        "the reported thread must be the EXECUTING one, not the job's origin"
+    );
+}
+
+#[tokio::test]
+async fn each_wedged_job_occupies_its_own_worker_and_the_extra_job_queues() {
+    let bound = super::REAPER_POOL_THREADS;
+    let pool = private_pool(bound);
+    let mut ends = submit_gated(pool, bound + 1);
+    let extra = ends.pop().expect("bound + 1 jobs were submitted");
+
+    // Every one of the first `bound` jobs is picked up: each wedged job occupies its OWN worker.
+    // A pool that failed to publish releases in hand instead, dropping this sender unsent — an
+    // immediate, loud `Err`.
+    let workers: Vec<ThreadId> = ends
+        .iter()
+        .map(|e| {
+            e.started
+                .recv()
+                .expect("each of the first `bound` jobs must be taken by a worker of its own")
+        })
+        .collect();
+    // Race-free: every worker is wedged on a gate THIS test holds, so none can take the extra.
+    assert!(
+        matches!(extra.started.try_recv(), Err(mpsc::TryRecvError::Empty)),
+        "with every worker wedged, the extra job must queue rather than run"
+    );
+
+    // Free exactly one worker; the queue drains onto it and no other.
+    let first = ends.remove(0);
+    drop(first.gate);
+    assert_eq!(
+        first.outcome.recv().expect("the released job must report an outcome"),
+        ReapOutcome::Reaped(workers[0]),
+        "the released job reaps on the worker that took it"
+    );
+    assert_eq!(
+        extra
+            .started
+            .recv()
+            .expect("the queued job must be taken once a worker frees up"),
+        workers[0],
+        "the freed worker is the one that drains the queue"
+    );
+
+    release_and_reap(extra);
+    for e in ends {
+        release_and_reap(e);
+    }
+}
+
+/// The positive control that makes the published width falsifiable with no mutation at all: it
+/// runs at a width DIFFERENT from the constant, so hardcoding either the spawn loop or the
+/// predicate to `REAPER_POOL_THREADS` makes this pool abandon and the first `started.recv()` errs.
+/// Hardcoding BOTH — the only way a wider-than-bound pool can exist — publishes four workers, and
+/// the queued job then starts on one of the two THIS test never gated.
+#[tokio::test]
+async fn pool_width_follows_its_bound() {
+    const BOUND: usize = 2;
+    let pool = private_pool(BOUND);
+    let mut ends = submit_gated(pool, BOUND + 1);
+    let extra = ends.pop().expect("BOUND + 1 jobs were submitted");
+
+    let workers: Vec<ThreadId> = ends
+        .iter()
+        .map(|e| e.started.recv().expect("a pool of BOUND must take BOUND jobs at once"))
+        .collect();
+    // Race-free: both workers are wedged on gates THIS test holds.
+    assert!(
+        matches!(extra.started.try_recv(), Err(mpsc::TryRecvError::Empty)),
+        "a pool of BOUND must not take a BOUND + 1'th job"
+    );
+
+    // Free exactly one worker and see which one takes the queue. Blocking, so it is an edge in
+    // BOTH worlds: a wider pool has already handed the job to a worker this test never gated, and
+    // reports that thread instead — where the `Empty` above only catches it by timing.
+    let first = ends.remove(0);
+    drop(first.gate);
+    assert!(
+        matches!(first.outcome.recv(), Ok(ReapOutcome::Reaped(_))),
+        "the released job must reap"
+    );
+    assert_eq!(
+        extra
+            .started
+            .recv()
+            .expect("the queued job must be taken once a worker frees up"),
+        workers[0],
+        "a pool of BOUND has no third worker to take the queued job"
+    );
+
+    release_and_reap(extra);
+    for e in ends {
+        release_and_reap(e);
+    }
 }

--- a/src/tokio/spawn.rs
+++ b/src/tokio/spawn.rs
@@ -134,8 +134,10 @@ pub(crate) fn spawn(cmd: &mut Command) -> Result<Child, Error> {
     let mut tcmd = ::tokio::process::Command::new(std::ffi::OsStr::new(""));
     *tcmd.as_std_mut() = std_cmd;
     // tokio's own `kill_on_drop` is intentionally left at its `false` default: cosca's
-    // `Child::drop` (attached.hard_kill + reap_now) is the SOLE teardown owner. Forwarding the
-    // builder's `kill_on_drop` to `tcmd` would make tokio fire its own kill and race reap_now.
+    // `Child::drop` is the SOLE owner of the kill, and the reaper's `run_teardown` of the
+    // wait-and-release that follows it. Forwarding the builder's `kill_on_drop` to `tcmd` would
+    // add a second, unsequenced kill inside that release region, where nothing orders it against
+    // the wait.
 
     // Merge pre-pass: a piped STD slot targeted by a merge cannot stay tokio-owned (tokio's
     // internal pipe end is not ours to dup into the merging slots), so build OUR pipe for it

--- a/src/tokio/spawn/windows_raw.rs
+++ b/src/tokio/spawn/windows_raw.rs
@@ -46,8 +46,9 @@ pub(crate) struct RawAsyncChild {
     /// Memoized once the child has exited, so a second `wait`/`try_wait` is immediate and cannot
     /// re-read a status off a (post-close) recycled handle.
     exited: Option<ExitStatus>,
-    /// A runas (UAC-elevated) child a lower-integrity parent may be unable to terminate: `Drop`
-    /// tears it down best-effort WITHOUT blocking, so an unkillable elevated child never hangs.
+    /// A runas (UAC-elevated) child a lower-integrity parent may be unable to terminate. Drives
+    /// [`start_kill`](RawAsyncChild::start_kill)'s `can_terminate` probe, which is the sole owner
+    /// of "this child is genuinely unkillable" — nothing waits on one.
     runas: bool,
     #[cfg(test)]
     observer: Option<WaitObserver>,
@@ -65,7 +66,7 @@ impl RawAsyncChild {
         }
     }
 
-    /// A runas (UAC-elevated) child, torn down best-effort (never blocking) on `Drop`.
+    /// A runas (UAC-elevated) child, whose kill may be refused (see the `runas` field).
     pub(crate) fn new_runas(proc: OwnedHandle, pid: u32) -> RawAsyncChild {
         RawAsyncChild {
             proc: Arc::new(proc),
@@ -188,39 +189,24 @@ impl RawAsyncChild {
         }
     }
 
-    /// Synchronous kill-then-reap for `Drop` (no reactor, no `wait()` future in flight). A plain
-    /// child is `TerminateProcess`d so the wait returns at once. A runas child a lower-integrity
-    /// parent cannot terminate is torn down best-effort WITHOUT blocking (universal teardown).
-    pub(crate) fn reap_blocking(&mut self) {
+    /// `true` once this backend has collected the child's exit status, so no wait remains.
+    pub(crate) fn is_reaped(&self) -> bool {
+        self.exited.is_some()
+    }
+
+    /// Wait for the child's exit; the caller has already signalled it. **Never kills:** a second
+    /// `TerminateProcess` on an already-exiting child returns `ACCESS_DENIED`, and the classified
+    /// kill decision (including a genuinely-undeniable runas child) was already made by
+    /// [`start_kill`](RawAsyncChild::start_kill)'s `can_terminate` probe.
+    pub(crate) fn wait_and_reap(&mut self) {
         if self.exited.is_some() {
             return;
         }
-        if self.runas {
-            // SAFETY: our live, owned process handle.
-            match unsafe { TerminateProcess(self.handle(), 1) } {
-                Ok(()) => {
-                    // It will exit; the wait is bounded by a real termination event.
-                    // SAFETY: our live, owned process handle.
-                    let _ = unsafe { WaitForSingleObject(self.handle(), INFINITE) };
-                }
-                Err(e) if e.code() == windows::core::HRESULT::from_win32(ERROR_ACCESS_DENIED.0) => {
-                    if !matches!(self.try_wait(), Ok(Some(_))) {
-                        log::warn!(
-                            "elevated async child {} could not be terminated on drop; leaving it running",
-                            self.pid
-                        );
-                    }
-                }
-                Err(e) => log::warn!("terminating elevated async child {} on drop failed: {e:?}", self.pid),
-            }
-            return;
-        }
-        let _ = self.start_kill();
-        // SAFETY: our live, owned process handle; INFINITE is bounded by the kill above.
+        // SAFETY: our live, owned process handle; INFINITE is bounded by the caller's kill.
         let waited = unsafe { WaitForSingleObject(self.handle(), INFINITE) };
         debug_assert!(
             waited == WAIT_OBJECT_0,
-            "raw async Drop did not observe child {} exit: {waited:?}",
+            "raw async teardown did not observe child {} exit: {waited:?}",
             self.pid
         );
         let _ = waited;

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -232,15 +232,10 @@ async fn async_drop_tears_down_a_contained_tree() {
         cosca::Containment::None,
         "contained spawn must engage a mechanism"
     );
-    let root_id = child.id();
     drop(child);
-    // The root is deterministically dead — reap_now blocked until its exit before Drop returned.
-    assert_eq!(
-        root_id.is_alive(),
-        cosca::identity::Liveness::Dead,
-        "the contained root must be torn down by Drop"
-    );
-    // The grandchild's death is proven by its control-socket EOF: a survivor blocks the read (a CI failure).
+    // No post-drop liveness assertion: `Drop` signals and does not wait, and `start_kill` is
+    // asynchronous. Each process's death is proven by its own control-socket EOF: a survivor
+    // blocks the read (a CI failure).
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {
@@ -253,15 +248,15 @@ async fn async_drop_tears_down_a_contained_tree() {
 
 #[tokio::test]
 async fn async_drop_after_wait_still_tears_down_the_tree() {
-    // After awaiting the root's exit it is already reaped (reap_now is then a no-op), so the tree
-    // teardown must come from attached.hard_kill() on Drop — proven by the grandchild's EOF.
+    // After awaiting the root's exit it is already reaped, so `Drop` submits no job at all and the
+    // tree teardown must come from attached.hard_kill() — proven by the grandchild's EOF.
     use std::io::{Read as _, Write as _};
     let (mut child, mut root, mut grand) = common::spawn_grandchild_async(true);
     let root_id = child.id();
     root.write_all(b"x").expect("release the root so it exits");
     child.wait().await.expect("wait reaps the root");
     assert_eq!(root_id.is_alive(), cosca::identity::Liveness::Dead, "root exited");
-    drop(child); // root already reaped → reap_now no-op; attached.hard_kill must still kill the grandchild
+    drop(child); // root already reaped → nothing submitted; attached.hard_kill must still kill the grandchild
     let mut buf = [0u8; 1];
     match grand.read(&mut buf) {
         Ok(0) => {}
@@ -297,7 +292,7 @@ async fn async_detach_leaves_the_tree_running() {
 #[tokio::test]
 async fn async_kill_on_drop_false_leaves_the_root_running() {
     // `kill_on_drop(false)` hits the async Drop early-return with `attached` STILL ARMED (unlike
-    // detach(), which also disarms). Drop must NOT run the teardown (hard_kill + reap_now), so the
+    // detach(), which also disarms). Drop must NOT run the teardown (hard_kill + the root's kill), so the
     // root stays alive. Proven by positive liveness on the never-signaled root (race-free, mirroring
     // async_detach_leaves_the_tree_running). UNCONTAINED on purpose: a Windows JobObject's
     // KILL_ON_JOB_CLOSE fires when the job handle field drops (only `disarm()` clears it, and
@@ -322,23 +317,9 @@ async fn async_kill_on_drop_false_leaves_the_root_running() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn async_drop_leaves_no_zombie() {
-    // The guaranteed-reap contract: after Drop the child is FULLY reaped (reap_now waited for exit,
-    // then tokio's field-drop collected the zombie). Reuse-immune proof: the child's original
-    // identity (pid + start token) is gone. A zombie would still resolve to `Some(id)` (Linux /proc
-    // persists); a reaped pid resolves to `None` or, if recycled, a different identity — so a
-    // recycled pid never false-fails (no pid-reuse race, which a bare-pid `waitpid` would risk).
-    let (child, _sock) = common::spawn_blocker_async();
-    let id = child.id();
-    drop(child);
-    assert_ne!(
-        cosca::identity::ProcessId::of(id.pid()),
-        cosca::identity::Resolved::Found(id),
-        "Drop must fully reap the child (no lingering process/zombie at its identity)"
-    );
-}
+// `async_drop_leaves_no_zombie` moved to `drop_reaps_on_a_worker_thread` in
+// `src/tokio/child/reaper_tests.rs`: once `Drop` returns before the reap, only the
+// `#[cfg(test)]` probe offers an edge to sequence the no-zombie check after.
 
 // Arbitrary fd (n>=3) — Unix only, wired via command-fds (async mirror of spawn_io.rs) =====
 
@@ -687,13 +668,9 @@ async fn async_windows_contained_spawn_runs_then_job_tears_down() {
         cosca::Containment::JobObject,
         "Windows Strongest => JobObject"
     );
-    let root_id = child.id();
     drop(child);
-    assert_eq!(
-        root_id.is_alive(),
-        cosca::identity::Liveness::Dead,
-        "the contained root must be torn down by Drop"
-    );
+    // As in `async_drop_tears_down_a_contained_tree`: `Drop` does not wait, so the control-socket
+    // EOFs are the real edges.
     for (who, s) in [("root", &mut root), ("grandchild", &mut grand)] {
         let mut buf = [0u8; 1];
         match s.read(&mut buf) {


### PR DESCRIPTION
Closes #105. Supersedes #113 (same problem, different scheduler).

`cosca::tokio::Child::drop` blocked the dropping thread waiting for the child to
exit. On an async runtime that parks a worker, and `Drop` *is* the teardown on
abort and runtime-shutdown paths, where the caller can neither await nor cancel.

Every **signal** stays on the dropping thread — the tree hard-kill and the root's
`start_kill`. Only the **wait** moves, onto a fixed pool of four `cosca-reaper`
threads. After `drop` returns the child is signalled but not necessarily gone;
the reap is still guaranteed, just not synchronously.

## Why the scheduler looks like this

The scheduling this replaces failed four times, each time answering "will a
worker pick this up?" from mutable state that was a copy of the truth. Here the
question does not exist: workers are started eagerly, all-or-nothing, before any
send is possible, and never exit. `submit` is a channel send. There are no
counters, no growth predicate and no atomics in production state — the channel is
the only scheduler.

Publication is `started == bound` and nothing else. Any other outcome abandons:
the started workers are joined on the queue's disconnect edge, each spawn's
`io::Error` is logged, the job in hand is released to the runtime's orphan
handling, and the cell stays empty so the next submit retries. All-or-nothing
rather than partial width because a one-wide pool has no bulkhead — one
never-exiting child would park the only worker and every later drop would enqueue
forever while `Drop` reported success.

`run_teardown` never unwinds: two `catch_unwind` regions (the wait, then the
ordered release) with glue that is only moves, matches and further `catch_unwind`
calls, and every log call inside a region because a consumer's `Log` impl is
untrusted.

## Also here

- The async backends' teardown splits into kill and wait-only reap;
  `RawAsyncChild`'s best-effort runas `TerminateProcess` branch is deleted, so
  `start_kill`'s `can_terminate` probe is the sole owner of "genuinely
  unkillable". A child whose kill failed is never submitted — a worker parked on
  an unsignalled child would never come back.
- `tests/tokio_io.rs` loses two post-drop `Dead` assertions (the control-socket
  EOFs are the real edges) and retires `async_drop_leaves_no_zombie`, whose
  no-zombie check now runs in `drop_reaps_on_a_worker_thread` sequenced after a
  real edge.
- `Command::kill_on_drop` and the sync `Child::drop` comment now state the
  divergence instead of claiming both handles block.

## Tests

11 unit tests in `src/tokio/child/reaper_tests.rs`: the drop handoff, the
executing-thread report, the bulkhead and at-bound queueing, a width-2 positive
control, abandon/retry/total-failure/concurrent-init, both panic regions, and the
unkillable-root refusal. Every one was mutation-proved — the mutation run and
reverted, and checked to reach the assertion it targets rather than dying at an
earlier one.


## Review round

- **The recovery guard killed its own worker.** `work`'s `debug_assert!(false, ..)` sat outside
  the catch, so in every debug build a `run_teardown` that unwound took the worker with it —
  silently shrinking a published pool that nothing replenishes, and never reaching the log it was
  meant to produce. The assert now sits inside the recovery region. Pinned by
  `a_worker_survives_a_teardown_that_unwinds`. `Pool::dispatch` had the same shape and now
  recovers before it asserts.
- **Known limitation: the pool is not fork-safe** (#121). A child forked after publication
  inherits the queue and none of the workers, and the send still succeeds, so the degraded path
  never fires. Measured on Linux, documented in `Drop`'s rustdoc, `Command::kill_on_drop` and the
  module header. Not fixed here.
- The fixture's stdio is nulled, so its libtest banner no longer lands in the parent binary's
  output — the cause of the inflated test counts.
- `Child`'s four OS-resource-owning fields are grouped into `OsResources`, carried whole by
  `ReapJob`, so what travels to the reaper and the order it is released in have one owner.
