### PR TITLE
refactor(tokio): size the reaper pool at the bulkhead width of 2

### DIFF
--- a/src/child/graceful.rs
+++ b/src/child/graceful.rs
@@ -327,10 +327,9 @@ impl Child {
 
 /// Test-only fault-injection seam for a forced `terminate_tree` failure inside
 /// `graceful_shutdown_tree`, mirroring `crate::wait::fault`'s shape. Duplicated (not shared)
-/// with `crate::tokio::child::graceful::fault` — see this crate's `#61` implementation plan,
-/// Task 7, "Structural note", for why: `mod graceful;` is private in both `src/child.rs` and
-/// `src/tokio/child.rs`, so a seam here is not nameable from the tokio tree without widening
-/// that visibility, which is out of scope here.
+/// with `crate::tokio::child::graceful::fault`: `mod graceful;` is private in both
+/// `src/child.rs` and `src/tokio/child.rs`, so a seam here is not nameable from the tokio tree
+/// without widening that visibility.
 #[cfg(test)]
 pub(crate) mod fault {
     use std::cell::Cell;

--- a/src/tokio/child.rs
+++ b/src/tokio/child.rs
@@ -652,7 +652,7 @@ impl Child {
 /// calls [`kill`](Child::kill)/[`kill_tree`](Child::kill_tree) and then awaits
 /// [`wait`](Child::wait)/[`wait_tree`](Child::wait_tree).
 ///
-/// The reap is handed to a small fixed pool of reaper threads (currently four) that starts on
+/// The reap is handed to a small fixed pool of reaper threads (currently two) that starts on
 /// the first kill-on-drop drop and persists for the process's life. It is guaranteed except on
 /// the two paths below, both of which are loud. Under thread exhaustion the pool cannot start,
 /// and the child goes to the runtime's orphan handling instead — an `error` per child, and each

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -224,12 +224,16 @@ impl Child {
     ///
     /// **Windows, once the root's exit has been observed**, the cooperative half is refused
     /// outright — this handle has stopped pinning the root's pid, see
-    /// [`terminate_tree`](Child::terminate_tree) — and that refusal is held on the same terms,
-    /// for a different reason. Nothing was sent, so nothing is owed a reply; the grace is spent
-    /// because the ROOT's OWN EXIT propagates, and a descendant reading a pipe whose write end
-    /// the root held gets EOF and exits on its own. The wait is the window that lets such a tree
-    /// finish shutting itself down; sweeping at once would kill a clean shutdown in progress.
-    /// Whatever is still alive at the end of it is swept as usual.
+    /// [`terminate_tree`](Child::terminate_tree). That refusal is held rather than returned:
+    /// nothing was sent, so nothing is owed a reply, and the sweep still has to run.
+    ///
+    /// **What the grace then buys is a property of the mechanism, and one arm buys nothing.**
+    /// On a **job object** the wait watches the whole tree, so descendants that the root's own
+    /// exit is already ending — one reading a pipe whose write end the root held gets EOF and
+    /// exits on its own — are given the window to finish, and the sweep takes only what is left.
+    /// On **`TreeWalk`** there is no drain edge, so the wait watches the ROOT alone; the root
+    /// has already exited by this refusal's own precondition, the watch resolves at once, and
+    /// the sweep follows immediately. Descendants get no window there, whatever `grace` says.
     ///
     /// # Runtime
     ///
@@ -254,12 +258,9 @@ impl Child {
         // per-member rationale it shares.
         //
         // One shape reaches this arm that the sync twin cannot produce: the unpinned-pid refusal
-        // (`Child::unpinned_pid_refusal`, Windows), where NO signal was sent at all — so the
-        // reason to hold is not that a response to ours may still arrive. It is that the root has
-        // already exited and its exit PROPAGATES: a descendant reading a pipe whose write end the
-        // root held gets EOF and exits on its own. The grace is the window that lets such a tree
-        // finish shutting itself down, and force-sweeping immediately would kill a clean shutdown
-        // in progress — worse than spending a grace period on a tree that was not going to exit.
+        // (`Child::unpinned_pid_refusal`, Windows), where NO signal was sent at all. Held anyway
+        // — not because a reply may still arrive, but for the sweep and, on a drain-observing
+        // mechanism, the window; see this function's rustdoc for what it costs per mechanism.
         let term = match term_result {
             Ok(()) => Ok(()),
             Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
@@ -371,10 +372,9 @@ impl Child {
 
 /// Test-only fault-injection seam for a forced `terminate_tree` failure inside
 /// `graceful_shutdown_tree`, mirroring `crate::wait::fault`'s shape. Duplicated (not shared)
-/// with `crate::child::graceful::fault` — see this crate's `#61` implementation plan, Task 7,
-/// "Structural note", for why: `mod graceful;` is private in both `src/child.rs` and
+/// with `crate::child::graceful::fault`: `mod graceful;` is private in both `src/child.rs` and
 /// `src/tokio/child.rs`, so a seam here is not nameable from the sync tree without widening
-/// that visibility, which is out of scope here.
+/// that visibility.
 #[cfg(test)]
 pub(crate) mod fault {
     use std::cell::Cell;

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -233,7 +233,8 @@ impl Child {
     /// exits on its own — are given the window to finish, and the sweep takes only what is left.
     /// On **`TreeWalk`** there is no drain edge, so the wait watches the ROOT alone; the root
     /// has already exited by this refusal's own precondition, the watch resolves at once, and
-    /// the sweep follows immediately. Descendants get no window there, whatever `grace` says.
+    /// the sweep follows immediately. Descendants get no window there, whatever `grace` says
+    /// (bindreams/cosca#125).
     ///
     /// # Runtime
     ///

--- a/src/tokio/child/graceful.rs
+++ b/src/tokio/child/graceful.rs
@@ -222,6 +222,15 @@ impl Child {
     /// immediately: no signal is confirmed sent, so there is nothing for a grace wait or
     /// sweep to act on yet.
     ///
+    /// **Windows, once the root's exit has been observed**, the cooperative half is refused
+    /// outright — this handle has stopped pinning the root's pid, see
+    /// [`terminate_tree`](Child::terminate_tree) — and that refusal is held on the same terms,
+    /// for a different reason. Nothing was sent, so nothing is owed a reply; the grace is spent
+    /// because the ROOT's OWN EXIT propagates, and a descendant reading a pipe whose write end
+    /// the root held gets EOF and exits on its own. The wait is the window that lets such a tree
+    /// finish shutting itself down; sweeping at once would kill a clean shutdown in progress.
+    /// Whatever is still alive at the end of it is swept as usual.
+    ///
     /// # Runtime
     ///
     /// On Unix, needs a runtime with the IO **and** time drivers enabled (the
@@ -240,9 +249,17 @@ impl Child {
         #[cfg(not(test))]
         let term_result = self.terminate_tree();
 
-        // Hold-and-continue ONLY for the error shapes #61's fix can produce as ORDINARY
-        // outcomes — see the sync `src/child/graceful.rs` twin's identical match for the full
-        // rationale.
+        // Hold-and-continue ONLY for the error shapes that are ORDINARY outcomes rather than a
+        // dead mechanism — see the sync `src/child/graceful.rs` twin's identical match for the
+        // per-member rationale it shares.
+        //
+        // One shape reaches this arm that the sync twin cannot produce: the unpinned-pid refusal
+        // (`Child::unpinned_pid_refusal`, Windows), where NO signal was sent at all — so the
+        // reason to hold is not that a response to ours may still arrive. It is that the root has
+        // already exited and its exit PROPAGATES: a descendant reading a pipe whose write end the
+        // root held gets EOF and exits on its own. The grace is the window that lets such a tree
+        // finish shutting itself down, and force-sweeping immediately would kill a clean shutdown
+        // in progress — worse than spending a grace period on a tree that was not going to exit.
         let term = match term_result {
             Ok(()) => Ok(()),
             Err(e @ Error::Containment { .. }) | Err(e @ Error::Unassessable { source: None, .. }) => {
@@ -363,8 +380,11 @@ pub(crate) mod fault {
     use std::cell::Cell;
 
     /// Which `terminate_tree` failure to fabricate on the next call, on this thread.
-    /// `Containment` and `UnassessablePerMember` exercise the hold-and-continue path this
-    /// task adds — both ORDINARY #61 outcomes, a signal was attempted. `Unsupported` and
+    /// `Containment` and `UnassessablePerMember` exercise the hold-and-continue path — both
+    /// per-member #61 outcomes, where a signal WAS attempted. The third shape that arm admits,
+    /// the unpinned-pid refusal (nothing sent at all), needs no seam: a real reaped child
+    /// produces it, and `windows_async_tree_graceful_ops_refuse_once_the_backend_has_reaped`
+    /// drives it that way. `Unsupported` and
     /// `UnassessableMechanism` exercise fail-fast paths: `Unsupported` models the
     /// PRE-EXISTING console-less-caller shape (`NoConsole`/`Unsupported`) this task must not
     /// touch; `UnassessableMechanism` models `Error::Unassessable { source: Some(_), .. }` —

--- a/src/tokio/child/graceful_tests.rs
+++ b/src/tokio/child/graceful_tests.rs
@@ -465,6 +465,55 @@ async fn windows_async_tree_graceful_ops_refuse_once_the_backend_has_reaped() {
     );
 }
 
+// The held refusal buys a shutdown window only where a tree drain can be observed. `TreeWalk`
+// has none, so the grace-wait watches the ROOT alone — and this refusal's precondition IS that
+// the root has already exited, so the watch resolves at once and the sweep follows immediately.
+// The assertion is on elapsed time because that is the entire claim: checking only for `Ok`
+// passes just as well in the world where the full grace is spent.
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_async_treewalk_grants_no_grace_window_once_the_backend_has_reaped() {
+    // Wide enough that the two worlds are three orders of magnitude apart, so the split below
+    // cannot be reached by jitter: this path is measured in milliseconds.
+    const GRACE: Duration = Duration::from_secs(10);
+    let mut cmd = crate::tokio::Command::new();
+    cmd.args(["ping", "-n", "30", "127.0.0.1"]);
+    cmd.contain_with(crate::ContainMode::TreeWalk);
+    let mut child = cmd.spawn().expect("spawn");
+    assert_eq!(
+        child.containment(),
+        crate::Containment::TreeWalk,
+        "the subject must be the mechanism that has no drain edge to watch"
+    );
+    let id = child.id();
+    child.kill().expect("kill");
+    child.wait().await.expect("reap"); // tokio unpins the pid here
+
+    crate::log_capture::install();
+    let mark = crate::log_capture::mark();
+    let started = std::time::Instant::now();
+    child
+        .graceful_shutdown_tree(GRACE)
+        .await
+        .expect("a swept tree supersedes the held refusal");
+    let elapsed = started.elapsed();
+
+    // Non-vacuity, first: a `terminate_tree` that returned `Ok` would produce the same fast,
+    // green run, and this test would then be measuring a path it never entered.
+    assert!(
+        crate::log_capture::contains_since(
+            mark,
+            &format!("graceful_shutdown_tree({pid}): terminate_tree refused", pid = id.pid())
+        ),
+        "the refusal must have reached the hold-and-continue arm"
+    );
+    assert!(
+        elapsed < GRACE / 2,
+        "the root-only watch must resolve at once on an already-exited root rather than spend \
+         the grace: took {elapsed:?} of {GRACE:?}"
+    );
+}
+
 // The pid guard must not swallow the refusals that never address a pid. An uncontained Windows
 // child records `GracefulMechanism::None` — permanent and pid-independent — so it must keep
 // answering `Unsupported` (what its own doc promises, and what the sync mirror returns for the

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -90,6 +90,17 @@ pub(crate) struct ReapJob {
 /// it; a larger number would imply a guarantee the pool cannot deliver.
 const REAPER_POOL_THREADS: usize = 2;
 
+// The floor above, enforced rather than left standing as prose. Two structural reasons:
+//
+// 1. Width 1 IS the failure this pool exists to prevent — one child that never exits stalls all
+//    future cleanup, permanently. "2 is the smallest width that is not that" is a correctness
+//    claim, so it is a contract assertion, at compile time.
+// 2. `pool_width_follows_its_bound` is the positive control for the published width and needs a
+//    private bound STRICTLY BELOW this constant; that bound is 1. Dropping to 1 here would not
+//    fail that test — it would silently vacate it, leaving a control that proves nothing. The
+//    coupling is invisible from either site alone.
+const _: () = assert!(REAPER_POOL_THREADS >= 2);
+
 /// A published pool: the sending half of the one queue its workers share.
 struct Pool {
     tx: crossbeam_channel::Sender<ReapJob>,

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -77,9 +77,18 @@ pub(crate) struct ReapJob {
     pub(crate) force_glue_panic: bool,
 }
 
-/// A wedged child occupies one worker and no other; the rest keep draining the shared queue. Not
-/// a throughput device — an ordinary reap waits microseconds on an already-killed child.
-const REAPER_POOL_THREADS: usize = 4;
+/// A bulkhead, not a rate. Nothing waits on a reap — `Drop` has already returned — and an
+/// ordinary one waits microseconds on an already-killed child, so a single worker services
+/// thousands a second. What a width buys is that a child killed but never exiting (blocked in the
+/// kernel on something that never returns: a hung mount, a dead device) parks its own worker and
+/// no other. Width 1 is one such child stalling all future cleanup permanently; **2 is the
+/// smallest width that is not that.**
+///
+/// Every worker past the second helps only against several INDEPENDENT wedges at once, while the
+/// real causes correlate — one hung mount wedges every child that touches it, and no fixed width
+/// survives that. So this bounds the damage of one pathological child and claims nothing beyond
+/// it; a larger number would imply a guarantee the pool cannot deliver.
+const REAPER_POOL_THREADS: usize = 2;
 
 /// A published pool: the sending half of the one queue its workers share.
 struct Pool {

--- a/src/tokio/child/reaper.rs
+++ b/src/tokio/child/reaper.rs
@@ -90,15 +90,10 @@ pub(crate) struct ReapJob {
 /// it; a larger number would imply a guarantee the pool cannot deliver.
 const REAPER_POOL_THREADS: usize = 2;
 
-// The floor above, enforced rather than left standing as prose. Two structural reasons:
-//
-// 1. Width 1 IS the failure this pool exists to prevent — one child that never exits stalls all
-//    future cleanup, permanently. "2 is the smallest width that is not that" is a correctness
-//    claim, so it is a contract assertion, at compile time.
-// 2. `pool_width_follows_its_bound` is the positive control for the published width and needs a
-//    private bound STRICTLY BELOW this constant; that bound is 1. Dropping to 1 here would not
-//    fail that test — it would silently vacate it, leaving a control that proves nothing. The
-//    coupling is invisible from either site alone.
+// The floor above as a contract assertion: width 1 is the failure this pool exists to prevent.
+// It is also half of a coupling — `pool_width_follows_its_bound` is a control only while its own
+// bound stays strictly below this constant, and lowering the width here would vacate that test
+// GREEN rather than fail it. The reciprocal assert lives at the test.
 const _: () = assert!(REAPER_POOL_THREADS >= 2);
 
 /// A published pool: the sending half of the one queue its workers share.

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -300,13 +300,18 @@ async fn each_wedged_job_occupies_its_own_worker_and_the_extra_job_queues() {
 /// The positive control that makes the published width falsifiable with no mutation at all: it
 /// runs at a width BELOW the constant, so hardcoding either the spawn loop or the predicate to
 /// `REAPER_POOL_THREADS` makes this pool abandon and the first `started.recv()` errs. Hardcoding
-/// BOTH — the only way a wider-than-bound pool can exist — publishes `REAPER_POOL_THREADS`
-/// workers, and the queued job then starts on one THIS test never gated. Below the constant, not
-/// above: a bound over it would leave the broken world SHORT of workers, and this test would then
-/// block on a `started.recv()` that never arrives instead of failing.
+/// BOTH — the only way a wider-than-bound pool can exist — publishes more workers than this test
+/// gates, so every job is taken at once and NOTHING ever queues; the worker-id `assert_eq!` at
+/// the end is what fails there (measured), while the `Empty` check before it catches that world
+/// only by timing. Below the constant, not above: a bound over it would leave the broken world
+/// SHORT of workers, and this test would then block on a `started.recv()` that never arrives
+/// instead of failing.
 #[tokio::test]
 async fn pool_width_follows_its_bound() {
     const BOUND: usize = 1;
+    // The reciprocal of `reaper.rs`'s width floor, so the coupling is enforced from both ends:
+    // widening the pool must not drag BOUND up to match, which vacates this control green.
+    const _: () = assert!(BOUND < super::REAPER_POOL_THREADS);
     let pool = private_pool(BOUND);
     let mut ends = submit_gated(pool, BOUND + 1);
     let extra = ends.pop().expect("BOUND + 1 jobs were submitted");

--- a/src/tokio/child/reaper_tests.rs
+++ b/src/tokio/child/reaper_tests.rs
@@ -7,11 +7,13 @@
 //! `REAPER_POOL_THREADS - 1` concurrent holders — at full width, a later drop's job would queue
 //! behind holders that are themselves waiting, and libtest runs these in parallel.
 //!
-//! The budget is spent by [`arm_probe`] and nothing else. Exactly one test calls it
-//! (`drop_signals_the_root_and_returns_before_the_reap`, which holds across a blocking socket
-//! read — the gate IS its discriminator), leaving two of the three slots free. Every other
-//! global-pool test takes [`arm_probe_ungated`], which hands back no gate to hold; the
-//! pool-shape tests gate their own [`private_pool`]s, which are nobody else's.
+//! At today's width that budget is ONE, and it is fully spent: it is claimed by [`arm_probe`]
+//! and nothing else, and the sole caller — `drop_signals_the_root_and_returns_before_the_reap`,
+//! which holds across a blocking socket read, the gate being its discriminator — takes it. There
+//! is no margin. A second gated holder is not a tight fit but a wedged binary: it needs the width
+//! raised or that test moved onto a [`private_pool`] of its own. Every other global-pool test
+//! takes [`arm_probe_ungated`], which hands back no gate to hold, so the budget cannot be spent
+//! by accident; the pool-shape tests gate their own private pools, which are nobody else's.
 
 use std::sync::mpsc;
 use std::thread::ThreadId;
@@ -118,8 +120,8 @@ fn release_and_reap(ends: ProbeEnds) {
 }
 
 /// Arm a probe for the next `Child::drop` on this thread and keep its ends, GATE HELD — so the
-/// teardown parks a worker of the process-global pool until this test releases it. Spends one of
-/// the gate-holding budget in the file header; prefer [`arm_probe_ungated`].
+/// teardown parks a worker of the process-global pool until this test releases it. Spends the
+/// file header's whole gate-holding budget; prefer [`arm_probe_ungated`].
 fn arm_probe() -> ProbeEnds {
     let (probe, ends) = probe_pair();
     arm(probe);
@@ -296,13 +298,15 @@ async fn each_wedged_job_occupies_its_own_worker_and_the_extra_job_queues() {
 }
 
 /// The positive control that makes the published width falsifiable with no mutation at all: it
-/// runs at a width DIFFERENT from the constant, so hardcoding either the spawn loop or the
-/// predicate to `REAPER_POOL_THREADS` makes this pool abandon and the first `started.recv()` errs.
-/// Hardcoding BOTH — the only way a wider-than-bound pool can exist — publishes four workers, and
-/// the queued job then starts on one of the two THIS test never gated.
+/// runs at a width BELOW the constant, so hardcoding either the spawn loop or the predicate to
+/// `REAPER_POOL_THREADS` makes this pool abandon and the first `started.recv()` errs. Hardcoding
+/// BOTH — the only way a wider-than-bound pool can exist — publishes `REAPER_POOL_THREADS`
+/// workers, and the queued job then starts on one THIS test never gated. Below the constant, not
+/// above: a bound over it would leave the broken world SHORT of workers, and this test would then
+/// block on a `started.recv()` that never arrives instead of failing.
 #[tokio::test]
 async fn pool_width_follows_its_bound() {
-    const BOUND: usize = 2;
+    const BOUND: usize = 1;
     let pool = private_pool(BOUND);
     let mut ends = submit_gated(pool, BOUND + 1);
     let extra = ends.pop().expect("BOUND + 1 jobs were submitted");
@@ -311,7 +315,7 @@ async fn pool_width_follows_its_bound() {
         .iter()
         .map(|e| e.started.recv().expect("a pool of BOUND must take BOUND jobs at once"))
         .collect();
-    // Race-free: both workers are wedged on gates THIS test holds.
+    // Race-free: every worker is wedged on a gate THIS test holds.
     assert!(
         matches!(extra.started.try_recv(), Err(mpsc::TryRecvError::Empty)),
         "a pool of BOUND must not take a BOUND + 1'th job"
@@ -332,7 +336,7 @@ async fn pool_width_follows_its_bound() {
             .recv()
             .expect("the queued job must be taken once a worker frees up"),
         workers[0],
-        "a pool of BOUND has no third worker to take the queued job"
+        "a pool of BOUND has no spare worker to take the queued job"
     );
 
     release_and_reap(extra);
@@ -380,7 +384,7 @@ async fn any_spawn_failure_abandons_the_pool_and_the_next_dispatch_retries() {
 #[tokio::test]
 async fn total_spawn_failure_releases_the_job_in_hand() {
     // Its OWN pool: a second pool in one test would shadow an init mutation. This one exercises
-    // the join-of-zero-started path, where the test above joins three.
+    // the join-of-zero-started path, where the test above joins the ones that did start.
     let pool = private_pool(super::REAPER_POOL_THREADS);
 
     super::fault::set_force_spawn_failures(super::REAPER_POOL_THREADS);
@@ -400,6 +404,8 @@ async fn total_spawn_failure_releases_the_job_in_hand() {
 #[tokio::test]
 async fn concurrent_first_submits_share_one_init() {
     let pool = private_pool(super::REAPER_POOL_THREADS);
+    // More submitters than the pool has workers, whatever the width: the losers of the init race
+    // are genuine losers, and the assertion below is that none of them ran an init of its own.
     let submitters = super::REAPER_POOL_THREADS + 2;
     let origin = std::thread::current().id();
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(submitters));


### PR DESCRIPTION
Closes #123.

## The width

`REAPER_POOL_THREADS` 4 → 2, with the derivation in the doc: nothing waits on a reap, so the width is a bulkhead and not a rate; width 1 lets one killed-but-never-exiting child stall all future cleanup permanently, and 2 is the smallest width that is not that. Workers past the second only help against several *independent* wedges at once, while the real causes correlate — so the doc says out loud that the pool bounds the damage of one pathological child and claims nothing beyond it. `Drop`'s rustdoc said "currently four"; it now says two.

That floor is enforced, not just written down: `const _: () = assert!(REAPER_POOL_THREADS >= 2)`. Width 1 is the specific structural failure the pool exists to prevent, which makes it a contract assertion rather than a preference — the compile-time form of what this codebase already does with provably-unreachable states. Its second job is described below.

## The gate budget

The `reaper_tests` header claimed `REAPER_POOL_THREADS - 1` holders with "two of the three slots free". Checked against the code before rewriting it:

- `arm_probe`, the only gate-holding entry, has exactly one caller — `drop_signals_the_root_and_returns_before_the_reap`. Every other global-pool test goes through `arm_probe_ungated`, which drops the gate before returning.
- `test_probe` is reachable from nowhere else in the crate: `reaper.rs`, `reaper_tests.rs` and the `Drop` impl are its only mentions.
- Nothing else parks a global worker indefinitely. `Drop` never submits an unsignalled child — it returns early when `start_kill` fails, for exactly this reason — so every queued job's wait is bounded by a kill that landed.

So the budget is one, one test holds it, there is no margin, and the header now says so along with what a second holder would need.

## A second-order consequence, and it would have been silent

This change was scoped as a constant plus some test-count adjustments. It is not: **a control test's entire validity was coupled to the constant's value, and the failure mode was a test that still passes while proving nothing.**

`pool_width_follows_its_bound` is the positive control for the published width, and it works by running a private pool at a width *different* from the constant. `BOUND` was 2. At the new width that equals the constant, so a build with the spawn loop or the publish predicate hardcoded to `REAPER_POOL_THREADS` would behave identically to a correct one — the control goes vacuous and stays green. `BOUND` is now 1, and deliberately *below* the constant rather than above: a bound above it leaves the broken world short of workers, and the test would then block forever on a `started.recv()` that never arrives instead of failing.

That coupling is invisible from either site alone, which is why the compile-time assert names the test: with `BOUND` at 1, a future drop of the constant to 1 would vacate the control the same silent way. This is the defect class the surrounding work has been chasing, found inside the change meant to close it out.

`concurrent_first_submits_share_one_init` submits `REAPER_POOL_THREADS + 2`, so four submitters rather than six. It still exercises what it claims — more submitters than workers, released together by a barrier, asserting `inits == 1`, which is a property of the in-lock re-check and not of the worker count. A one-line comment now records the requirement so a future width change is measured against it.

## Not in the issue: a rationale that did not match its code

The async `graceful_shutdown_tree` holds `Error::Unassessable { source: None }` and continues to the grace wait and the sweep. On Windows one producer of that shape is `unpinned_pid_refusal`: the cooperative half is refused because the handle stopped pinning the root's pid when its exit was observed. The arm's recorded rationale, inherited from the sync twin, was that these shapes mean "a signal WAS attempted and reachable members WERE reached". On that path none was.

The replacement rationale is now **scoped by mechanism**, because the general form was also false. On a job object the grace-wait watches the whole tree, so descendants that the root's own exit is already ending get a real window. On `TreeWalk` there is no drain edge, so the wait watches the root alone — and the root has already exited by this refusal's own precondition, so the watch resolves at once and the sweep follows immediately. Measured at 20 ms of a 10 s grace. A single unscoped claim promised every caller a window that one arm never delivers, which is the same defect class this PR exists to remove.

`windows_async_treewalk_grants_no_grace_window_once_the_backend_has_reaped` now covers that arm — `ContainMode::TreeWalk`, non-zero grace, asserting on elapsed time. Nothing covered it before: the only existing test uses the job-object arm and passes `Duration::ZERO`.

**No behaviour changes.** Making the code deliver the window `TreeWalk` never had would mean waiting a chosen duration with no edge to observe, which this repo forbids; whether such a tree should get a real grace window at all is being filed as its own question rather than decided here.

The sync twin is untouched — the sync `Child` pins the pid for its whole life, so the shape cannot reach it there.

## Verification

- Suite before and after, on Windows natively and on Linux under WSL (`--features tokio`; the reaper tests exercise `#[cfg(unix)]` paths that never run natively here). Zero failures in all four runs, and every real test binary reports an identical pass count before and after. The only textual delta is one extra re-exec'd fixture summary line — #122's output pollution; the two names a naive line diff calls "missing" are present in the logs, prefixed by a fixture's output.
- `cargo clippy --all-targets --locked -- -D warnings` over {`x86_64-pc-windows-msvc`, `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`} × {default, `tokio`, `--all-features`}: 9/9 clean, re-run after every change.
- `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` on all three targets: clean.
- Neither assert is vacuous. Setting the constant to 1 fails the build with `assertion failed: REAPER_POOL_THREADS >= 2`; raising `BOUND` to 2 fails it with `assertion failed: BOUND < super::REAPER_POOL_THREADS`. The coupling is enforced from both ends, since one end plus a hardcoded assumption about the other is what needed fixing in the first place.
- The new `TreeWalk` test is mutation-proven twice. Making the root-only arm spend the grace fails it at the timing assertion (`took 10.0123642s of 10s`); removing the `pins_pid` guard so no refusal is produced fails it before that, when the unguarded console event at a bare pid returns `The parameter is incorrect`. Both mutations reverted and re-verified.

## Mutation proof for the rest

The constant's *value* has no behaviour a test can stage — the pathology it defends against is a child that never exits — and the tests that observe a width bound their own private pools. The header rewrite and the corrected rationale are prose. No test was invented to cover them.

