### PR TITLE
build: publish 0.3.0 to crates.io (closes #127)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "cosca"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "command-fds",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosca"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Anna Zhukova"]
 description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation."


### PR DESCRIPTION
Bumps `Cargo.toml` + `Cargo.lock` to 0.3.0. Minor: two features since v0.2.0 (#99 graceful signal, #110 Windows creation-flags hatch), public API purely additive, no breaking changes.

Unblocks the final gate of bindreams/hole#816 — hole cannot `cargo publish` garter while it pins cosca as a bare git rev.

Verified before cutting: main was pinned into hole and run against hole's suite on three platforms — windows/amd64 2737 tests, darwin/arm64 2600, linux/amd64 356. Zero failures attributable to the change. Details in #127.