### PR TITLE
feat(quote): add a Windows argv splitter to mirror posix::split

### DIFF
--- a/src/quote/windows.rs
+++ b/src/quote/windows.rs
@@ -3,20 +3,27 @@
 //! Operates on UTF-16 code units so the algorithm is testable on any host;
 //! a `#[cfg(windows)]` test validates it against the real OS parser.
 //!
-//! This module builds the command-line string for PE images launched via
-//! `CreateProcess`, implementing exactly the quoting rules that
-//! `CommandLineToArgvW` reverses (MSVCRT / Win32 argv parsing). It does NOT
-//! handle `cmd.exe` metacharacter escaping: `.bat`/`.cmd` invocation (the
-//! actual BatBadBut / CVE-2024-24576 vector) requires a separate escaping
-//! layer, which this module does not provide.
+//! This module builds ([`join_wide`]) and parses ([`split_wide`]) the
+//! command-line string for PE images launched via `CreateProcess`,
+//! implementing exactly the quoting rules `CommandLineToArgvW` uses in both
+//! directions (MSVCRT / Win32 argv parsing). It does NOT handle `cmd.exe`
+//! metacharacter escaping: `.bat`/`.cmd` invocation (the actual BatBadBut /
+//! CVE-2024-24576 vector) requires a separate escaping layer, which this
+//! module does not provide.
+
+use crate::error::QuoteError;
 
 const SPACE: u16 = b' ' as u16;
 const TAB: u16 = b'\t' as u16;
 const QUOTE: u16 = b'"' as u16;
 const BACKSLASH: u16 = b'\\' as u16;
 
+fn is_blank(c: u16) -> bool {
+    c == SPACE || c == TAB
+}
+
 fn needs_quotes(arg: &[u16]) -> bool {
-    arg.is_empty() || arg.iter().any(|&c| c == SPACE || c == TAB)
+    arg.is_empty() || arg.iter().any(|&c| is_blank(c))
 }
 
 /// Join argv into a single command-line string per the MSVCRT rules that
@@ -65,7 +72,7 @@ fn append_arg(cmd: &mut Vec<u16>, arg: &[u16]) {
 /// Returns `None` only for empty/whitespace-only input.
 pub fn first_token_and_rest_wide(cmd: &[u16]) -> Option<(Vec<u16>, Vec<u16>)> {
     let mut i = 0usize;
-    while i < cmd.len() && (cmd[i] == SPACE || cmd[i] == TAB) {
+    while i < cmd.len() && is_blank(cmd[i]) {
         i += 1;
     }
     if i >= cmd.len() {
@@ -82,13 +89,13 @@ pub fn first_token_and_rest_wide(cmd: &[u16]) -> Option<(Vec<u16>, Vec<u16>)> {
             i += 1; // consume the closing quote
         }
     } else {
-        while i < cmd.len() && cmd[i] != SPACE && cmd[i] != TAB {
+        while i < cmd.len() && !is_blank(cmd[i]) {
             first.push(cmd[i]);
             i += 1;
         }
     }
     // Skip the whitespace separating the first token from the rest.
-    while i < cmd.len() && (cmd[i] == SPACE || cmd[i] == TAB) {
+    while i < cmd.len() && is_blank(cmd[i]) {
         i += 1;
     }
     Some((first, cmd[i..].to_vec()))
@@ -107,6 +114,142 @@ pub fn first_token_and_rest_wide(cmd: &[u16]) -> Option<(Vec<u16>, Vec<u16>)> {
 /// are literal here (no escaping).
 pub fn first_token_wide(cmd: &[u16]) -> Option<Vec<u16>> {
     first_token_and_rest_wide(cmd).map(|(first, _)| first)
+}
+
+/// Split a Windows command line into argv — the inverse of [`join_wide`] and
+/// of the real `CommandLineToArgvW` (shell32.dll), mirroring
+/// [`crate::quote::posix::split`]'s shape over UTF-16 code units.
+///
+/// # `argv[0]`
+///
+/// `argv[0]` is parsed by [`first_token_and_rest_wide`] — see its docs (and
+/// [`first_token_wide`]'s) for the exact OS deviation on leading
+/// whitespace/empty input and the program-token quoting rule.
+///
+/// # `argv[1..]`
+///
+/// Parsed with the full MSVCRT backslash/quote rules `CommandLineToArgvW`
+/// applies past the first argument: a run of `n` backslashes immediately
+/// before a `"` collapses to `n/2` literal backslashes, and the quote either
+/// becomes a literal `"` (`n` odd) or toggles "inside quotes" (`n` even) —
+/// this much is documented and is the direct inverse of `append_arg`
+/// ([`join_wide`]'s internal encoder). Beyond that, *bare* (non-backslash-
+/// escaped) quotes are counted by a running total that persists across the
+/// whole token — ordinary characters do not touch it, and neither does a
+/// backslash-escaped quote — and is undocumented but not arbitrary: verified
+/// against Wine's/ReactOS's `CommandLineToArgvW` source
+/// (`dll/win32/shell32/wine/shell32_main.c`), the total resets to 0 in
+/// exactly two cases: as soon as it reaches 3 (emitting one literal `"`), or
+/// when a maximal run of *consecutive* bare quotes ends while the total sits
+/// at 2 (no literal `"` either way). Because the total is not reset by
+/// ordinary characters in between, the same two-bare-quote shape means
+/// different output depending on what came before: `a""b` -> `ab` (a fresh
+/// run of exactly 2 bare quotes — the total goes 0->1->2 and the run ends
+/// there, hitting the reset-at-2 case, no literal `"`), but `"a""b"` -> `a"b`
+/// (the opening `"` already left the total at 1, so the embedded `""` — part
+/// of the same consecutive run as far as the total is concerned — pushes it
+/// 1->2->3, hitting the reset-at-3 case instead: one literal `"` is
+/// emitted). This differs from the simpler even/odd-only rule the MSVCRT
+/// `main()` startup parser uses (reimplemented by `std::env::args()`), which
+/// is a different, more limited parser than shell32's actual
+/// `CommandLineToArgvW`.
+///
+/// # Errors
+///
+/// `CommandLineToArgvW`'s grammar has no error states — an unterminated
+/// quote just runs to the end, and a backslash not before a quote is always
+/// literal — so this function always returns `Ok`. It still returns
+/// `Result<_, QuoteError>` to match [`crate::quote::posix::split`]'s shape;
+/// no Windows-specific [`crate::error::QuoteErrorKind`] variant exists.
+pub fn split_wide(cmd: &[u16]) -> Result<Vec<Vec<u16>>, QuoteError> {
+    let Some((first, rest)) = first_token_and_rest_wide(cmd) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(1);
+    out.push(first);
+    out.extend(split_rest_wide(&rest));
+    Ok(out)
+}
+
+/// Parse `argv[1..]` from the remainder of a command line, after `argv[0]`
+/// and its separating whitespace have already been removed. See
+/// [`split_wide`]'s doc comment for the exact rules, including the mod-3
+/// bare-quote-run rule. Ported directly from the verified
+/// `CommandLineToArgvW` reference algorithm, using eager backslash-writing
+/// plus retroactive `Vec::truncate` in place of that algorithm's in-place
+/// pointer rewind.
+fn split_rest_wide(rest: &[u16]) -> Vec<Vec<u16>> {
+    let mut out: Vec<Vec<u16>> = Vec::new();
+    let n = rest.len();
+    let mut i = 0usize;
+
+    while i < n && is_blank(rest[i]) {
+        i += 1;
+    }
+    if i >= n {
+        return out;
+    }
+
+    let mut buf: Vec<u16> = Vec::new();
+    let mut qcount: usize = 0;
+    let mut bcount: usize = 0;
+
+    while i < n {
+        let c = rest[i];
+        if is_blank(c) && qcount == 0 {
+            out.push(std::mem::take(&mut buf));
+            bcount = 0;
+            while i < n && is_blank(rest[i]) {
+                i += 1;
+            }
+            if i >= n {
+                return out;
+            }
+        } else if c == BACKSLASH {
+            buf.push(c);
+            bcount += 1;
+            i += 1;
+        } else if c == QUOTE {
+            // `buf` currently ends with exactly `bcount` backslashes just
+            // pushed by the branch above (bcount is reset to 0 on every
+            // other branch), so both truncations below are in-bounds.
+            debug_assert!(buf.len() >= bcount, "backslash run exceeds buffer length");
+            if bcount.is_multiple_of(2) {
+                // Even run: the backslashes just written collapse to half as
+                // many literal backslashes; the quote toggles "inside quotes".
+                let new_len = buf.len() - bcount / 2;
+                buf.truncate(new_len);
+                qcount += 1;
+            } else {
+                // Odd run: collapses to (bcount - 1) / 2 literal backslashes
+                // plus one literal quote.
+                let new_len = buf.len() - (bcount / 2 + 1);
+                buf.truncate(new_len);
+                buf.push(QUOTE);
+            }
+            i += 1;
+            bcount = 0;
+            // Count further consecutive bare quotes: every 3 collapse to one
+            // literal `"`; `qcount` already accounts for the quote above.
+            while i < n && rest[i] == QUOTE {
+                qcount += 1;
+                if qcount == 3 {
+                    buf.push(QUOTE);
+                    qcount = 0;
+                }
+                i += 1;
+            }
+            if qcount == 2 {
+                qcount = 0;
+            }
+        } else {
+            buf.push(c);
+            bcount = 0;
+            i += 1;
+        }
+    }
+    out.push(buf);
+    out
 }
 
 #[cfg(test)]

--- a/src/quote/windows_tests.rs
+++ b/src/quote/windows_tests.rs
@@ -1,4 +1,4 @@
-use crate::quote::windows::{first_token_and_rest_wide, first_token_wide, join_wide};
+use crate::quote::windows::{first_token_and_rest_wide, first_token_wide, join_wide, split_wide};
 
 fn w(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()
@@ -7,6 +7,12 @@ fn jw(args: &[&str]) -> String {
     let wides: Vec<Vec<u16>> = args.iter().map(|a| w(a)).collect();
     let refs: Vec<&[u16]> = wides.iter().map(|v| v.as_slice()).collect();
     String::from_utf16(&join_wide(&refs)).unwrap()
+}
+fn sw(s: &str) -> Vec<Vec<u16>> {
+    split_wide(&w(s)).unwrap()
+}
+fn sw_strings(s: &str) -> Vec<String> {
+    sw(s).into_iter().map(|t| String::from_utf16(&t).unwrap()).collect()
 }
 
 #[test]
@@ -71,6 +77,146 @@ fn backslashes_before_quote_are_doubled_plus_one() {
 fn trailing_backslashes_doubled_before_closing_quote() {
     assert_eq!(jw(&["a\\ b"]), "\"a\\ b\""); // single backslash, space forces quotes
     assert_eq!(jw(&["a b\\"]), "\"a b\\\\\""); // trailing \ doubled before closing "
+}
+
+// split_wide ================================================================
+
+#[test]
+fn split_wide_empty_input_returns_empty_vec() {
+    assert_eq!(split_wide(&[]).unwrap(), Vec::<Vec<u16>>::new());
+}
+
+#[test]
+fn split_wide_whitespace_only_input_returns_empty_vec() {
+    assert_eq!(sw("   \t "), Vec::<Vec<u16>>::new());
+}
+
+#[test]
+fn split_wide_simple_args() {
+    assert_eq!(sw_strings("a b c"), vec!["a", "b", "c"]);
+}
+
+#[test]
+fn split_wide_skips_leading_whitespace_before_argv0() {
+    // Same deliberate deviation `first_token_wide` already documents.
+    assert_eq!(sw_strings("   cmd arg"), vec!["cmd", "arg"]);
+}
+
+#[test]
+fn split_wide_tab_separates_rest_args() {
+    assert_eq!(sw_strings("prog\ta\tb"), vec!["prog", "a", "b"]);
+}
+
+#[test]
+fn split_wide_quoted_arg_with_embedded_space() {
+    assert_eq!(sw_strings("prog \"a b\""), vec!["prog", "a b"]);
+}
+
+#[test]
+fn split_wide_empty_quoted_arg_between_args() {
+    assert_eq!(sw_strings("prog \"\" x"), vec!["prog", "", "x"]);
+}
+
+#[test]
+fn split_wide_adjacent_empty_quotes_concatenate() {
+    // a""b -> ab: a fresh run of exactly 2 bare quotes (the mod-3 counter
+    // goes 0->1->2 and the run ends there) resets with no literal `"`.
+    assert_eq!(sw_strings("prog a\"\"b"), vec!["prog", "ab"]);
+}
+
+#[test]
+fn split_wide_triple_quote_run_yields_one_literal_quote() {
+    // The undocumented shell32 mod-3 rule: 3 consecutive bare quotes collapse
+    // to one literal `"` with no net toggle of "inside quotes".
+    assert_eq!(sw_strings("prog a\"\"\"b"), vec!["prog", "a\"b"]);
+}
+
+#[test]
+fn split_wide_double_quote_inside_quoted_region_embeds_literal_quote() {
+    // The classic "double a quote to embed one" idiom: "a""b" -> a"b.
+    assert_eq!(sw_strings("prog \"a\"\"b\""), vec!["prog", "a\"b"]);
+}
+
+#[test]
+fn split_wide_backslash_before_quote_odd_count() {
+    // One backslash before a quote: (1-1)/2 = 0 literal backslashes, quote is literal.
+    assert_eq!(sw_strings("prog a\\\"b"), vec!["prog", "a\"b"]);
+}
+
+#[test]
+fn split_wide_backslash_before_quote_even_count() {
+    // Two backslashes before a quote: 2/2 = 1 literal backslash, quote toggles.
+    assert_eq!(sw_strings("prog a\\\\\"b"), vec!["prog", "a\\b"]);
+}
+
+#[test]
+fn split_wide_trailing_backslash_stays_literal() {
+    assert_eq!(sw_strings("prog a\\"), vec!["prog", "a\\"]);
+}
+
+#[test]
+fn split_wide_backslashes_before_whitespace_stay_literal() {
+    // Not just end-of-input: backslashes not immediately followed by a quote
+    // are always literal, including right before a token-ending whitespace.
+    assert_eq!(sw_strings("prog a\\\\ b"), vec!["prog", "a\\\\", "b"]);
+}
+
+#[test]
+fn split_wide_argv0_only_no_further_args() {
+    assert_eq!(sw_strings("prog"), vec!["prog"]);
+}
+
+#[test]
+fn split_wide_trailing_whitespace_after_last_arg_yields_no_spurious_empty_token() {
+    assert_eq!(sw_strings("prog a   "), vec!["prog", "a"]);
+}
+
+#[test]
+fn split_wide_unterminated_quote_in_rest_arg_consumes_to_end() {
+    // Mirrors `unterminated_opening_quote_consumes_to_end` for argv[0], but
+    // through the args[1..] parser's own qcount/bcount state machine.
+    assert_eq!(sw_strings("prog \"abc"), vec!["prog", "abc"]);
+}
+
+#[test]
+fn split_wide_trailing_backslash_run_before_unterminated_opening_quote() {
+    // Exercises the truncate-on-EOF interaction: an even backslash run
+    // (halved to 1 literal `\`) immediately before a bare opening quote that
+    // toggles "inside quotes" and is then never closed (consumes to end, no
+    // literal `"` emitted since this quote was a toggle, not an escape).
+    assert_eq!(sw_strings("prog abc\\\\\""), vec!["prog", "abc\\"]);
+}
+
+#[test]
+fn split_wide_round_trips_join_wide_for_rest_args() {
+    let cases: Vec<Vec<&str>> = vec![
+        vec!["a", "b"],
+        vec!["a b", "a\"b", "a\\b", "a\\\"b", "trail\\", "", "tab\tx"],
+        vec!["a\\\\\\\\b"],
+    ];
+    for rest in cases {
+        let joined = jw(&rest);
+        let full = format!("prog {joined}");
+        let result = sw_strings(&full);
+        let mut expected = vec!["prog".to_string()];
+        expected.extend(rest.iter().map(|s| s.to_string()));
+        assert_eq!(result, expected, "round-trip mismatch for {rest:?}");
+    }
+}
+
+#[test]
+fn split_wide_lone_surrogate_passes_through_verbatim() {
+    // 0xD800 is an unpaired surrogate: legal as a raw code unit, not valid on
+    // its own in a Rust `String`. Confirms split_wide doesn't require valid
+    // UTF-16 and doesn't treat it as a delimiter/quote/backslash.
+    let mut cmd: Vec<u16> = w("prog a");
+    cmd.push(0xD800u16);
+    cmd.push(b'b' as u16);
+    let result = split_wide(&cmd).unwrap();
+    let mut expected_arg = w("a");
+    expected_arg.push(0xD800u16);
+    expected_arg.push(b'b' as u16);
+    assert_eq!(result, vec![w("prog"), expected_arg]);
 }
 
 #[cfg(windows)]
@@ -155,6 +301,67 @@ mod roundtrip {
             let expected: Vec<Vec<u16>> = wides.clone();
             assert_eq!(parsed, expected, "round-trip mismatch for {:?}", case);
         }
+    }
+
+    #[test]
+    fn split_wide_matches_os_parse_for_representative_cases() {
+        let cases: Vec<Vec<&str>> = vec![
+            vec!["plain", "args"],
+            vec!["has space", "a\"b", "a\\b", "a\\\"b", "trail\\", "", "tab\tx"],
+            vec!["prefix", "a\\\\\\\\ b"],
+        ];
+        for case in cases {
+            let wides: Vec<Vec<u16>> = case.iter().map(|a| w(a)).collect();
+            let refs: Vec<&[u16]> = wides.iter().map(|v| v.as_slice()).collect();
+            let line = join_wide(&refs);
+            let os_result = os_parse(&line);
+            let our_result = split_wide(&line).unwrap();
+            assert_eq!(our_result, os_result, "split_wide disagrees with OS for {:?}", case);
+            assert_eq!(
+                our_result, wides,
+                "split_wide disagrees with original argv for {:?}",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn split_wide_matches_os_parse_for_adversarial_quote_runs() {
+        // Hand-written lines exercising the shell32 mod-3 rule for runs of
+        // consecutive bare quotes, plus unterminated-quote edge cases — none
+        // producible by our own `join_wide`, which never emits 3+ adjacent
+        // unescaped quotes or an unclosed quoted region.
+        let lines = [
+            "prog a\"\"\"b",
+            "prog \"a\"\" b\"",
+            "prog \"\"\"",
+            "prog a\"\"\"\"b",
+            "prog \"\"\"x",
+            "prog \"abc",
+            "prog abc\\\\\"",
+        ];
+        for line in lines {
+            let cmd = w(line);
+            let os_result = os_parse(&cmd);
+            let our_result = split_wide(&cmd).unwrap();
+            assert_eq!(our_result, os_result, "split_wide disagrees with OS for {line:?}");
+        }
+    }
+
+    #[test]
+    fn split_wide_deviates_from_os_like_first_token_on_leading_whitespace() {
+        // Same deviation as `first_token_wide`, now exercised through the
+        // full splitter: we skip leading whitespace before argv[0]; the OS
+        // does not.
+        let input = w("   cmd arg");
+        let os_result = os_parse(&input);
+        let our_result = split_wide(&input).unwrap();
+        assert_ne!(our_result, os_result, "deviation should still exist for split_wide");
+        assert_eq!(
+            our_result,
+            vec![w("cmd"), w("arg")],
+            "split_wide should skip leading whitespace and return [\"cmd\", \"arg\"]"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #129.

Adds `quote::windows::split_wide`, the inverse of `join_wide` / the real `CommandLineToArgvW`, mirroring `posix::split`'s shape over UTF-16 code units.

## What this does

- `argv[0]` reuses `first_token_and_rest_wide` (already-documented deviation from the OS: leading whitespace skipped, empty/whitespace-only input -> `Ok(vec![])`, matching `posix::split`'s own "empty vec" convention).
- `argv[1..]` implements the full MSVCRT backslash/quote rules, including the undocumented shell32 mod-3 rule for runs of consecutive bare quotes (verified against Wine's/ReactOS's `CommandLineToArgvW` source), which differs from the simpler even/odd rule the MSVCRT `main()` startup parser (and `std::env::args()`) uses.
- Always returns `Ok` (the real API's grammar has no error states) — `Result` is kept only for shape parity with `posix::split`.
- Out of scope, per the module's existing boundary: `cmd.exe` metacharacter handling for `.bat`/`.cmd` (BatBadBut / CVE-2024-24576).

## Testing

- Host-independent unit tests in `src/quote/windows_tests.rs` (round-trip against `join_wide`, quote-run edge cases including the mod-3 rule, backslash-before-quote parity, empty/whitespace-only input, trailing backslashes, unterminated quotes, lone-surrogate passthrough).
- `cfg(windows)` differential tests against the real `CommandLineToArgvW` via the existing `os_parse` FFI oracle, including adversarial quote-run cases not producible by our own `join_wide`.