### PR TITLE
feat(containment): expose the Job Object primitive for callers that spawn the process themselves

### DIFF
--- a/src/containment.rs
+++ b/src/containment.rs
@@ -287,6 +287,13 @@ pub(crate) mod cgroup;
 #[path = "containment/windows.rs"]
 pub(crate) mod windows;
 
+/// The public Job Object primitive — see [`job::Job`].
+#[cfg(windows)]
+#[path = "containment/job.rs"]
+pub(crate) mod job;
+#[cfg(windows)]
+pub use job::Job;
+
 #[path = "containment/enumerate.rs"]
 pub(crate) mod enumerate;
 

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -118,10 +118,9 @@ impl Attached {
                 Ok(())
             }
             #[cfg(windows)]
-            Attached::JobObject(job) => {
-                job.hard_kill();
-                Ok(())
-            }
+            Attached::JobObject(job) => job.hard_kill().map_err(|e| Error::Containment {
+                detail: format!("terminate the job's process tree: {e}"),
+            }),
             #[cfg(target_os = "macos")]
             Attached::FdMarker(m) => m.hard_kill(),
             Attached::TreeWalk(root) => {

--- a/src/containment/dispatch.rs
+++ b/src/containment/dispatch.rs
@@ -118,9 +118,7 @@ impl Attached {
                 Ok(())
             }
             #[cfg(windows)]
-            Attached::JobObject(job) => job.hard_kill().map_err(|e| Error::Containment {
-                detail: format!("terminate the job's process tree: {e}"),
-            }),
+            Attached::JobObject(job) => job.hard_kill().map_err(Error::Io),
             #[cfg(target_os = "macos")]
             Attached::FdMarker(m) => m.hard_kill(),
             Attached::TreeWalk(root) => {

--- a/src/containment/job.rs
+++ b/src/containment/job.rs
@@ -75,9 +75,7 @@ impl Job {
     /// teardown, and once this closes the handle there is nothing left to watch. Call
     /// [`wait_tree`](Job::wait_tree) *before* `kill_tree` if the caller needs the drain outcome.
     pub fn kill_tree(&self) -> Result<(), Error> {
-        self.0.hard_kill().map_err(|e| Error::Containment {
-            detail: format!("terminate the job's process tree: {e}"),
-        })
+        self.0.hard_kill().map_err(Error::Io)
     }
 
     /// Clear `KILL_ON_JOB_CLOSE`, so that dropping (or having already dropped) this `Job` leaves

--- a/src/containment/job.rs
+++ b/src/containment/job.rs
@@ -9,12 +9,10 @@
 //! [`kill_tree`](Job::kill_tree), [`disarm`](Job::disarm), and the drain
 //! ([`wait_tree`](Job::wait_tree) / [`wait_tree_timeout`](Job::wait_tree_timeout)).
 
-use std::io;
 use std::os::windows::io::{AsRawHandle, BorrowedHandle};
 use std::time::{Duration, Instant};
 
-use windows::Win32::Foundation::{CloseHandle, DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
-use windows::Win32::System::Threading::GetCurrentProcess;
+use windows::Win32::Foundation::CloseHandle;
 
 use crate::containment::windows::{
     assign_to_kill_on_close_job, consumed_job_handle_error, wait_drained_raw, JobHandle,
@@ -117,7 +115,11 @@ impl Job {
         // Duplicated under the lock so a concurrent `kill_tree`/`Drop` cannot close the
         // original between the read and the `DuplicateHandle` call; the wait itself then
         // runs on the duplicate, outside the lock.
-        let Some(dup) = self.0.with_handle(duplicate_job).transpose()? else {
+        let Some(dup) = self
+            .0
+            .with_handle(crate::containment::windows::duplicate_job)
+            .transpose()?
+        else {
             return Err(consumed_job_handle_error());
         };
         let result = wait_drained_raw(dup, deadline, None);
@@ -128,30 +130,6 @@ impl Job {
         }
         result
     }
-}
-
-/// `DuplicateHandle` a live handle into a second, independent reference to the same kernel
-/// object — used so [`Job::wait_tree_deadline`] never holds the original handle value across a
-/// (possibly long) wait.
-/// `pub(crate)`: `JobHandle::wait_drained` needs the same duplicate-then-wait shape, so
-/// there is one implementation rather than two.
-pub(crate) fn duplicate_job(handle: HANDLE) -> Result<HANDLE, Error> {
-    let mut dup = HANDLE::default();
-    // SAFETY: `handle` is live for the duration of this call (borrowed from `self.0`, which
-    // outlives this function call); `dup` is an out-parameter DuplicateHandle initializes.
-    unsafe {
-        DuplicateHandle(
-            GetCurrentProcess(),
-            handle,
-            GetCurrentProcess(),
-            &mut dup,
-            0,
-            false,
-            DUPLICATE_SAME_ACCESS,
-        )
-    }
-    .map_err(io::Error::from)?;
-    Ok(dup)
 }
 
 #[cfg(test)]

--- a/src/containment/job.rs
+++ b/src/containment/job.rs
@@ -1,0 +1,154 @@
+//! The public Job Object primitive, for a caller that must construct the child process itself
+//! and cannot go through [`crate::Command`] — e.g. a ConPTY host, which needs
+//! `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` on its own `CreateProcessW` call. See
+//! [cosca#131](https://github.com/bindreams/cosca/issues/131).
+//!
+//! [`Job`] is a thin wrapper over the exact same [`crate::containment::windows::JobHandle`] that
+//! backs [`Command::contain()`](crate::Command::contain) — there is exactly one Job Object
+//! implementation in this crate, reused by both paths. It exposes only what teardown needs:
+//! [`kill_tree`](Job::kill_tree), [`disarm`](Job::disarm), and the drain
+//! ([`wait_tree`](Job::wait_tree) / [`wait_tree_timeout`](Job::wait_tree_timeout)).
+
+use std::io;
+use std::os::windows::io::{AsRawHandle, BorrowedHandle};
+use std::time::{Duration, Instant};
+
+use windows::Win32::Foundation::{CloseHandle, DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
+use windows::Win32::System::Threading::GetCurrentProcess;
+
+use crate::containment::windows::{
+    assign_to_kill_on_close_job, consumed_job_handle_error, wait_drained_raw, JobHandle,
+};
+use crate::containment::TreeDrain;
+use crate::error::Error;
+
+/// An owned Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set, holding exactly
+/// one assigned process tree.
+///
+/// # The mandatory sequence
+///
+/// A member must be inside the job before it executes any instruction of its own, or a
+/// fast-forking grandchild can spawn and escape before assignment completes. There is exactly
+/// one way to close that race, and it is on the caller:
+///
+/// 1. Create the process **suspended** (`CREATE_SUSPENDED` on `CreateProcessW`).
+/// 2. Call [`Job::assign`] with its process handle.
+/// 3. Only now resume the process's main thread (e.g. `ResumeThread`).
+///
+/// Resuming before step 2 completes is a race: any instruction the process executes before it
+/// is a job member — including forking a child of its own — can escape containment permanently.
+/// This crate cannot enforce the ordering across an FFI boundary it does not own; get it right by
+/// literally not calling anything that could resume the thread until [`Job::assign`] has
+/// returned `Ok`.
+///
+/// # Dropping a `Job`
+///
+/// Dropping a live `Job` closes the underlying job handle, which — because
+/// `KILL_ON_JOB_CLOSE` is set — **terminates every process still in it**, exactly like
+/// [`kill_tree`](Job::kill_tree). Call [`disarm`](Job::disarm) first to opt out.
+#[derive(Debug)]
+pub struct Job(JobHandle);
+
+impl Job {
+    /// Assign `process` to a freshly created `KILL_ON_JOB_CLOSE` job.
+    ///
+    /// `process` is **borrowed**, not owned: `Job` does not close it, wait on it, or resume it.
+    /// It must have been created suspended and must not yet have been resumed — see the
+    /// [type-level sequence](Job#the-mandatory-sequence). The handle must carry the
+    /// `PROCESS_SET_QUOTA` and `PROCESS_TERMINATE` access rights (a handle fresh out of
+    /// `CreateProcessW` always does).
+    ///
+    /// # On error
+    ///
+    /// If this returns `Err`, `process` was never assigned to any job. It is still suspended:
+    /// **do not resume it** — an uncontained resume defeats the reason this call exists. Tear it
+    /// down instead (e.g. `TerminateProcess`) and propagate the error.
+    #[must_use = "dropping the returned `Job` immediately kills the whole tree just assigned to \
+                  it, unless `disarm()` is called first"]
+    pub fn assign(process: BorrowedHandle<'_>) -> Result<Job, Error> {
+        Ok(Job(assign_to_kill_on_close_job(process.as_raw_handle())?))
+    }
+
+    /// Terminate every process still in the job, then close the handle.
+    ///
+    /// Idempotent: calling this (or dropping the `Job`) again is a no-op. A subsequent
+    /// [`wait_tree`](Job::wait_tree) call cannot confirm the tree has actually finished exiting —
+    /// `TerminateJobObject`/`CloseHandle` are not documented as synchronous with member process
+    /// teardown, and once this closes the handle there is nothing left to watch. Call
+    /// [`wait_tree`](Job::wait_tree) *before* `kill_tree` if the caller needs the drain outcome.
+    pub fn kill_tree(&self) -> Result<(), Error> {
+        self.0.hard_kill();
+        Ok(())
+    }
+
+    /// Clear `KILL_ON_JOB_CLOSE`, so that dropping (or having already dropped) this `Job` leaves
+    /// its tree running.
+    ///
+    /// This is the "session ended normally, leave background processes alone" teardown path —
+    /// the opposite of [`kill_tree`](Job::kill_tree)'s "peer disconnected, reap everything".
+    /// Best-effort: a failure here is logged (`log::warn!`) rather than returned, since the
+    /// backstop for a caller that never sees the log is [`kill_tree`](Job::kill_tree), which
+    /// needs no special disarmed state to work.
+    pub fn disarm(&self) {
+        self.0.disarm();
+    }
+
+    /// Block until every member of the tree has exited, or forever if none ever does.
+    pub fn wait_tree(&self) -> Result<TreeDrain, Error> {
+        self.wait_tree_deadline(None)
+    }
+
+    /// Like [`wait_tree`](Job::wait_tree), but give up and report
+    /// [`TreeDrain::MembersRemain`](crate::containment::TreeDrain::MembersRemain) once `timeout`
+    /// elapses.
+    pub fn wait_tree_timeout(&self, timeout: Duration) -> Result<TreeDrain, Error> {
+        self.wait_tree_deadline(crate::wait::deadline_from(timeout))
+    }
+
+    /// Shared body of `wait_tree`/`wait_tree_timeout`. Waits on a **duplicate** of the job
+    /// handle rather than the live one directly: this call can block for the whole `deadline`,
+    /// and `kill_tree`/`disarm`/`Drop` running concurrently on `&self` from another thread must
+    /// not be able to invalidate the handle value out from under an in-flight wait (a closed
+    /// Windows handle's numeric value can be recycled onto an unrelated kernel object).
+    /// `DuplicateHandle` pins a second, independent reference to the SAME job for the duration
+    /// of this call; closing the original elsewhere cannot touch it.
+    fn wait_tree_deadline(&self, deadline: Option<Option<Instant>>) -> Result<TreeDrain, Error> {
+        let Some(job) = self.0.as_handle() else {
+            return Err(consumed_job_handle_error());
+        };
+        let dup = duplicate(job)?;
+        let result = wait_drained_raw(dup, deadline, None);
+        // SAFETY: `dup` is a handle this function alone created and holds; nothing else
+        // references it.
+        unsafe {
+            let _ = CloseHandle(dup);
+        }
+        result
+    }
+}
+
+/// `DuplicateHandle` a live handle into a second, independent reference to the same kernel
+/// object — used so [`Job::wait_tree_deadline`] never holds the original handle value across a
+/// (possibly long) wait.
+fn duplicate(handle: HANDLE) -> Result<HANDLE, Error> {
+    let mut dup = HANDLE::default();
+    // SAFETY: `handle` is live for the duration of this call (borrowed from `self.0`, which
+    // outlives this function call); `dup` is an out-parameter DuplicateHandle initializes.
+    unsafe {
+        DuplicateHandle(
+            GetCurrentProcess(),
+            handle,
+            GetCurrentProcess(),
+            &mut dup,
+            0,
+            false,
+            DUPLICATE_SAME_ACCESS,
+        )
+    }
+    .map_err(io::Error::from)?;
+    Ok(dup)
+}
+
+#[cfg(test)]
+#[path = "job_tests.rs"]
+mod job_tests;

--- a/src/containment/job.rs
+++ b/src/containment/job.rs
@@ -77,8 +77,9 @@ impl Job {
     /// teardown, and once this closes the handle there is nothing left to watch. Call
     /// [`wait_tree`](Job::wait_tree) *before* `kill_tree` if the caller needs the drain outcome.
     pub fn kill_tree(&self) -> Result<(), Error> {
-        self.0.hard_kill();
-        Ok(())
+        self.0.hard_kill().map_err(|e| Error::Containment {
+            detail: format!("terminate the job's process tree: {e}"),
+        })
     }
 
     /// Clear `KILL_ON_JOB_CLOSE`, so that dropping (or having already dropped) this `Job` leaves
@@ -113,10 +114,12 @@ impl Job {
     /// `DuplicateHandle` pins a second, independent reference to the SAME job for the duration
     /// of this call; closing the original elsewhere cannot touch it.
     fn wait_tree_deadline(&self, deadline: Option<Option<Instant>>) -> Result<TreeDrain, Error> {
-        let Some(job) = self.0.as_handle() else {
+        // Duplicated under the lock so a concurrent `kill_tree`/`Drop` cannot close the
+        // original between the read and the `DuplicateHandle` call; the wait itself then
+        // runs on the duplicate, outside the lock.
+        let Some(dup) = self.0.with_handle(duplicate_job).transpose()? else {
             return Err(consumed_job_handle_error());
         };
-        let dup = duplicate(job)?;
         let result = wait_drained_raw(dup, deadline, None);
         // SAFETY: `dup` is a handle this function alone created and holds; nothing else
         // references it.
@@ -130,7 +133,9 @@ impl Job {
 /// `DuplicateHandle` a live handle into a second, independent reference to the same kernel
 /// object — used so [`Job::wait_tree_deadline`] never holds the original handle value across a
 /// (possibly long) wait.
-fn duplicate(handle: HANDLE) -> Result<HANDLE, Error> {
+/// `pub(crate)`: `JobHandle::wait_drained` needs the same duplicate-then-wait shape, so
+/// there is one implementation rather than two.
+pub(crate) fn duplicate_job(handle: HANDLE) -> Result<HANDLE, Error> {
     let mut dup = HANDLE::default();
     // SAFETY: `handle` is live for the duration of this call (borrowed from `self.0`, which
     // outlives this function call); `dup` is an out-parameter DuplicateHandle initializes.

--- a/src/containment/job_tests.rs
+++ b/src/containment/job_tests.rs
@@ -1,0 +1,150 @@
+//! Unit tests for the public `Job` wrapper: delegation to `JobHandle`, not the suspend/resume
+//! contract (that needs a genuine `CREATE_SUSPENDED` process and lives in the integration suite,
+//! `tests/windows_job_object.rs`). These use a plain, already-running `cmd /C more` — mirroring
+//! `windows_tests.rs`'s `wait_drained_raw_tracks_a_real_member_through_exit`.
+
+use std::mem::size_of;
+use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle};
+
+use windows::Win32::System::JobObjects::{
+    JobObjectExtendedLimitInformation, QueryInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+};
+
+use super::Job;
+
+/// `cmd /C more`: blocks reading its stdin until EOF, then exits. No new external dependency —
+/// this is the OS shell, exactly like `windows_tests.rs`'s fixture.
+fn spawn_blocker() -> std::process::Child {
+    std::process::Command::new("cmd")
+        .args(["/C", "more"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn cmd /C more")
+}
+
+#[test]
+fn assign_then_kill_tree_terminates_the_process() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives this borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    job.kill_tree().expect("kill_tree");
+
+    let status = child.wait().expect("wait for the killed child");
+    assert!(
+        !status.success(),
+        "a job-killed process must not report success: {status:?}"
+    );
+}
+
+#[test]
+fn disarm_clears_kill_on_job_close() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives this borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+    let handle = job.0.as_handle().expect("freshly assigned job handle must be live");
+
+    job.disarm();
+
+    let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    let mut returned = 0u32;
+    // SAFETY: `handle` is live; `info` is sized for the class being queried.
+    unsafe {
+        QueryInformationJobObject(
+            Some(handle),
+            JobObjectExtendedLimitInformation,
+            std::ptr::addr_of_mut!(info).cast(),
+            size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            Some(&mut returned),
+        )
+    }
+    .expect("QueryInformationJobObject after disarm");
+    assert_eq!(
+        info.BasicLimitInformation.LimitFlags.0, 0,
+        "disarm() must clear every limit flag, including KILL_ON_JOB_CLOSE"
+    );
+
+    // Cleanup: disarm() means dropping `job` will NOT kill this real process.
+    drop(job);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn wait_tree_reports_members_remain_then_all_exited() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives this borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    // An already-elapsed deadline reads as `Duration::ZERO` without blocking (see
+    // `crate::wait::remaining`) — a live member reports `MembersRemain` instantly.
+    let past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+    // `wait_tree_deadline` is private to `job`, but `job_tests` is its child module, so it's
+    // reachable directly — no need for a test-only public wrapper.
+    let verdict = job
+        .wait_tree_deadline(Some(Some(past)))
+        .expect("wait_tree (elapsed deadline)");
+    assert_eq!(verdict, crate::containment::TreeDrain::MembersRemain);
+
+    // Let the child exit on its own terms (EOF on stdin) — a real synchronization point.
+    drop(child.stdin.take());
+    child.wait().expect("wait for cmd /C more to exit");
+
+    let verdict = job.wait_tree().expect("wait_tree (no deadline, already drained)");
+    assert_eq!(verdict, crate::containment::TreeDrain::AllMembersExited);
+}
+
+#[test]
+fn wait_tree_after_kill_tree_is_unassessable() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives this borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    job.kill_tree().expect("kill_tree");
+    let _ = child.wait();
+
+    let err = job
+        .wait_tree()
+        .expect_err("wait_tree after kill_tree must not guess a drain verdict");
+    assert!(
+        matches!(err, crate::error::Error::Unassessable { .. }),
+        "expected Unassessable, got {err:?}"
+    );
+}
+
+#[test]
+fn assign_to_an_invalid_handle_is_an_error() {
+    // A real, valid, open handle — just not a process handle. `BorrowedHandle::borrow_raw`
+    // requires a genuinely live handle (never null / INVALID_HANDLE_VALUE), which a plain
+    // file satisfies; `AssignProcessToJobObject` still rejects it deterministically, since the
+    // kernel object behind it isn't a process.
+    let file = std::fs::File::open(std::env::current_exe().expect("current_exe")).expect("open self as a plain file");
+    assert!(
+        Job::assign(file.as_handle()).is_err(),
+        "assigning a non-process handle must fail, not succeed"
+    );
+}
+
+#[test]
+fn job_debug_differs_before_and_after_kill_tree() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives this borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    let live = format!("{job:?}");
+    job.kill_tree().expect("kill_tree");
+    let killed = format!("{job:?}");
+
+    assert_ne!(
+        live, killed,
+        "Debug must reflect the handle being consumed by kill_tree, not print the same thing regardless"
+    );
+    let _ = child.wait();
+}

--- a/src/containment/job_tests.rs
+++ b/src/containment/job_tests.rs
@@ -148,3 +148,40 @@ fn job_debug_differs_before_and_after_kill_tree() {
     );
     let _ = child.wait();
 }
+
+/// `Job` is shared across threads by callers, which is exactly what makes its `&self` methods
+/// racy if the handle is not locked. Pinning the bound here means a future change that makes
+/// `Job` thread-hostile fails at compile time rather than silently narrowing what callers may
+/// do — the same assertion `Process` carries.
+#[test]
+fn job_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Job>();
+}
+
+/// `disarm` and `kill_tree` racing on one `Job` from two threads must not fault or corrupt.
+///
+/// This is the case the lock exists for: both take `&self`, both use the handle, and one of
+/// them closes it. Before the handle was locked, `disarm` could write to a handle `kill_tree`
+/// had already closed — and Windows recycles a closed handle's value onto unrelated kernel
+/// objects, so that write could clear `KILL_ON_JOB_CLOSE` on someone else's job.
+///
+/// Either interleaving is a valid outcome; the assertion is that both calls complete and the
+/// job ends up consumed. Run repeatedly to widen the window rather than timed, so it cannot
+/// flake on a slow runner.
+#[test]
+fn disarm_racing_kill_tree_is_safe() {
+    for _ in 0..64 {
+        let mut child = spawn_blocker();
+        let raw = child.as_raw_handle();
+        // SAFETY: `child` outlives the borrow.
+        let job = std::sync::Arc::new(Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job"));
+
+        let a = std::sync::Arc::clone(&job);
+        let t = std::thread::spawn(move || a.disarm());
+        job.kill_tree().expect("kill_tree");
+        t.join().expect("the disarming thread must not panic");
+
+        let _ = child.wait();
+    }
+}

--- a/src/containment/job_tests.rs
+++ b/src/containment/job_tests.rs
@@ -159,18 +159,16 @@ fn job_is_send_and_sync() {
     assert_send_sync::<Job>();
 }
 
-/// `disarm` and `kill_tree` racing on one `Job` from two threads must not fault or corrupt.
+/// Both orderings of `disarm` and `kill_tree` on a shared `Job` complete without faulting.
 ///
-/// This is the case the lock exists for: both take `&self`, both use the handle, and one of
-/// them closes it. Before the handle was locked, `disarm` could write to a handle `kill_tree`
-/// had already closed — and Windows recycles a closed handle's value onto unrelated kernel
-/// objects, so that write could clear `KILL_ON_JOB_CLOSE` on someone else's job.
-///
-/// Either interleaving is a valid outcome; the assertion is that both calls complete and the
-/// job ends up consumed. Run repeatedly to widen the window rather than timed, so it cannot
-/// flake on a slow runner.
+/// Honest about what this is: a smoke test, not a regression guard. It does NOT fail against
+/// the pre-lock code — provoking a real handle-close-then-recycle interleaving is not portably
+/// possible, because it needs the OS to hand the recycled value to this same process inside a
+/// window measured in instructions. What actually holds the invariant is structural: the lock
+/// makes load-then-use indivisible, and `job_is_send_and_sync` pins the bound that makes the
+/// sharing legal in the first place.
 #[test]
-fn disarm_racing_kill_tree_is_safe() {
+fn disarm_and_kill_tree_from_two_threads_complete() {
     for _ in 0..64 {
         let mut child = spawn_blocker();
         let raw = child.as_raw_handle();
@@ -184,4 +182,49 @@ fn disarm_racing_kill_tree_is_safe() {
 
         let _ = child.wait();
     }
+}
+
+/// Once `kill_tree` has consumed the handle, `disarm` must observe that and do nothing.
+///
+/// This is the deterministic half of the concurrency story above, and it is the state the lock
+/// exists to make observable: without it, a `disarm` arriving after the close would read a
+/// stale value and write to whatever kernel object had inherited it.
+#[test]
+fn disarm_after_kill_tree_does_nothing() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives the borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    job.kill_tree().expect("kill_tree");
+    let consumed = format!("{job:?}");
+    job.disarm(); // must be a no-op, not a write through a dangling value
+    assert_eq!(
+        consumed,
+        format!("{job:?}"),
+        "disarm on a consumed job must leave it consumed, not resurrect or mutate it"
+    );
+
+    let _ = child.wait();
+}
+
+/// A zero timeout on a live tree reports `MembersRemain` rather than blocking or guessing.
+#[test]
+fn wait_tree_timeout_zero_reports_members_remain() {
+    let mut child = spawn_blocker();
+    let raw = child.as_raw_handle();
+    // SAFETY: `child` outlives the borrow.
+    let job = Job::assign(unsafe { BorrowedHandle::borrow_raw(raw) }).expect("assign to job");
+
+    let drain = job
+        .wait_tree_timeout(std::time::Duration::ZERO)
+        .expect("a zero-timeout drain query must succeed");
+    assert_eq!(
+        drain,
+        crate::containment::TreeDrain::MembersRemain,
+        "a live member must be reported as remaining"
+    );
+
+    job.kill_tree().expect("kill_tree");
+    let _ = child.wait();
 }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -27,7 +27,8 @@ use windows::Win32::System::JobObjects::{
 };
 use windows::Win32::System::Threading::{
     GetProcessId, OpenProcess, OpenThread, ResumeThread, WaitForMultipleObjects, WaitForSingleObject,
-    CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, INFINITE, PROCESS_SYNCHRONIZE, THREAD_SUSPEND_RESUME,
+    CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, INFINITE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+    THREAD_SUSPEND_RESUME,
 };
 
 /// Sentinel: a null pointer means the handle has been consumed or is invalid.
@@ -189,7 +190,12 @@ impl Drop for JobHandle {
         if let Some(job) = self.take() {
             // SAFETY: job is a valid handle we own.
             unsafe {
-                let _ = CloseHandle(job);
+                if let Err(e) = CloseHandle(job) {
+                    // The close IS the teardown here: with KILL_ON_JOB_CLOSE still set, a
+                    // failed close means the tree was never reaped and the handle leaked.
+                    // Drop cannot report that, so it must at least be visible.
+                    log::warn!("closing the job handle failed ({e}); the tree may still be running");
+                }
             }
         }
     }
@@ -734,11 +740,6 @@ pub(crate) fn consumed_job_handle_error() -> crate::error::Error {
     }
 }
 
-/// The loop body of [`JobHandle::wait_drained`], taking the already-resolved raw handle rather
-/// than borrowing `&JobHandle` — the async wrapper (`tokio::wait`) copies the handle value out
-/// before handing it to `spawn_blocking`, since a `'static` blocking closure cannot capture a
-/// borrow. Sound because the async caller holds `&JobHandle` (transitively, `&Child`) across the
-/// whole `spawn_blocking` `.await`, so the job handle cannot be closed while this runs.
 /// Duplicate a job handle. One implementation for all three duplicate-then-wait sites (the
 /// sync wait, the async wait, and `Job::wait_tree`); it lives here, next to `JobHandle`,
 /// rather than in `job.rs`, because the public wrapper depends on this module and not the
@@ -746,6 +747,8 @@ pub(crate) fn consumed_job_handle_error() -> crate::error::Error {
 ///
 /// Call it as the closure passed to [`JobHandle::with_handle`], never on a handle returned
 /// out of one: the point is that the lock is still held while `DuplicateHandle` reads it.
+/// Returning the handle first and duplicating after is the same load-then-use gap with extra
+/// steps — and reads as correct, which is why it is called out here.
 pub(crate) fn duplicate_job(handle: HANDLE) -> Result<HANDLE, crate::error::Error> {
     use windows::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS};
     use windows::Win32::System::Threading::GetCurrentProcess;
@@ -768,6 +771,12 @@ pub(crate) fn duplicate_job(handle: HANDLE) -> Result<HANDLE, crate::error::Erro
     Ok(dup)
 }
 
+/// The loop body of [`JobHandle::wait_drained`], taking an already-resolved raw handle rather
+/// than borrowing `&JobHandle`.
+///
+/// Every caller now hands in an owned duplicate taken under the lock, not the live handle, so
+/// this can run for an unbounded deadline without holding off `hard_kill`/`Drop` and without
+/// the handle being closed underneath it.
 pub(crate) fn wait_drained_raw(
     job: HANDLE,
     deadline: Option<Option<std::time::Instant>>,
@@ -810,7 +819,13 @@ pub(crate) fn wait_drained_raw(
         let mut denied: Option<io::Error> = None;
         for pid in pids.iter().take(budget) {
             // SAFETY: standard Win32 call; the handle is closed below on every path.
-            match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, *pid) } {
+            // `PROCESS_QUERY_LIMITED_INFORMATION` is required by `IsProcessInJob` below and is
+            // NOT implied by `PROCESS_SYNCHRONIZE`; without it every membership check fails
+            // ACCESS_DENIED, `handles` stays empty forever, and this loop spins instead of
+            // ever reaching `WaitForMultipleObjects`. (`job_contains_pid` opens for the same
+            // reason.) `LIMITED` rather than full query: it is the least right that works and
+            // is grantable across integrity levels.
+            match unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, false, *pid) } {
                 // A pid enumerated a moment ago can have exited and had its number reused by
                 // the time it is opened, so membership is re-confirmed against the job rather
                 // than assumed. Waiting on a bystander would either hang the drain (it outlives
@@ -820,12 +835,23 @@ pub(crate) fn wait_drained_raw(
                     let mut in_job = windows::core::BOOL(0);
                     // SAFETY: both handles are valid for the duration of the call.
                     let confirmed = unsafe { IsProcessInJob(h, Some(job), &mut in_job) };
-                    if confirmed.is_ok() && in_job.as_bool() {
-                        handles.push(h);
-                    } else {
-                        // SAFETY: opened just above and not stored anywhere.
-                        unsafe {
+                    match confirmed {
+                        // A member: wait on it.
+                        Ok(()) if in_job.as_bool() => handles.push(h),
+                        // Openable but not in this job — the pid was recycled between the
+                        // enumeration and the open. Filtering it out is the point.
+                        Ok(()) => unsafe {
                             let _ = CloseHandle(h);
+                        },
+                        // The query itself failed, so membership is unknown. Recorded like any
+                        // other actionable failure rather than silently dropped: if it holds
+                        // for every member it would otherwise be invisible.
+                        Err(e) => {
+                            denied = Some(io::Error::from(e));
+                            // SAFETY: opened just above and not stored anywhere.
+                            unsafe {
+                                let _ = CloseHandle(h);
+                            }
                         }
                     }
                 }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -13,7 +13,7 @@
 use std::ffi::c_void;
 use std::io;
 use std::mem::size_of;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::RwLock;
 
 use windows::Win32::Foundation::{
     CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, WAIT_FAILED, WAIT_OBJECT_0,
@@ -38,12 +38,19 @@ fn null_ptr() -> *mut c_void {
 /// Owns the Job Object handle. `KILL_ON_JOB_CLOSE` means the whole process tree
 /// is terminated when this handle is closed (dropped or explicitly killed).
 ///
-/// Interior mutability via `AtomicPtr` allows `hard_kill` and `disarm` to be
-/// called via `&self` (required because `Child::kill_tree` takes `&self`).
+/// Interior mutability allows `hard_kill` and `disarm` to be called via `&self`
+/// (required because `Child::kill_tree` takes `&self`).
+///
+/// The lock is load-bearing, not incidental. Every use is "read the handle, then call
+/// Win32 with it", and an atomic makes only the read indivisible — leaving a window in
+/// which a concurrent `hard_kill`/`Drop` closes the handle before the call lands. Windows
+/// recycles closed handle values onto unrelated kernel objects, so that call would then
+/// operate on someone else's object: `disarm` writing a cleared `KILL_ON_JOB_CLOSE` to an
+/// unrelated job silently leaves *its* tree to outlive its owner. Holding the lock across
+/// the call is what makes load-then-use a single step.
 pub(crate) struct JobHandle {
-    /// The raw HANDLE value stored as an atomic `*mut c_void`.
-    /// Null means the handle has been consumed (taken/killed).
-    raw: AtomicPtr<c_void>,
+    /// The raw HANDLE value. Null means the handle has been consumed (taken/killed).
+    raw: RwLock<*mut c_void>,
 }
 
 // A Windows job-object HANDLE is a process-wide kernel handle; using it
@@ -52,11 +59,15 @@ pub(crate) struct JobHandle {
 // `!Send`, which would prevent this type from crossing thread boundaries.
 unsafe impl Send for JobHandle {}
 
+// SAFETY: the pointer is only ever read or replaced under `raw`'s lock, which is what makes
+// load-then-use indivisible; the job operations themselves are serialised by the kernel. This
+// is required rather than incidental: `Job` is public, its methods take `&self`, and callers
+// may share it across threads.
+unsafe impl Sync for JobHandle {}
+
 impl std::fmt::Debug for JobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("JobHandle")
-            .field("raw", &self.raw.load(Ordering::Relaxed))
-            .finish()
+        f.debug_struct("JobHandle").field("raw", &self.peek()).finish()
     }
 }
 
@@ -64,24 +75,33 @@ impl JobHandle {
     fn new(handle: HANDLE) -> Self {
         debug_assert!(!handle.0.is_null(), "job handle must not be null");
         JobHandle {
-            raw: AtomicPtr::new(handle.0),
+            raw: RwLock::new(handle.0),
         }
     }
 
-    /// The raw job handle, or `None` once consumed. Backs the test-only
-    /// membership probe (`job_contains_pid`).
-    pub(crate) fn as_handle(&self) -> Option<HANDLE> {
-        let p = self.raw.load(Ordering::Relaxed);
-        if p.is_null() {
+    /// The raw value, for diagnostics only — never to call Win32 with. Use [`with_handle`].
+    fn peek(&self) -> *mut c_void {
+        *self.raw.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Run `f` with the live job handle, holding the lock so it cannot be closed and its
+    /// value recycled underneath the call. `None` once consumed.
+    ///
+    /// Keep `f` short and non-blocking: it holds off `hard_kill` and `Drop` for its duration.
+    /// A long wait must duplicate the handle inside `f` and then wait on the duplicate.
+    pub(crate) fn with_handle<R>(&self, f: impl FnOnce(HANDLE) -> R) -> Option<R> {
+        let guard = self.raw.read().unwrap_or_else(|e| e.into_inner());
+        if guard.is_null() {
             None
         } else {
-            Some(HANDLE(p))
+            Some(f(HANDLE(*guard)))
         }
     }
 
-    /// Atomically take the raw handle, leaving null. Returns `None` if already consumed.
+    /// Take the raw handle, leaving null. Returns `None` if already consumed.
     fn take(&self) -> Option<HANDLE> {
-        let p = self.raw.swap(null_ptr(), Ordering::AcqRel);
+        let mut guard = self.raw.write().unwrap_or_else(|e| e.into_inner());
+        let p = std::mem::replace(&mut *guard, null_ptr());
         if p.is_null() {
             None
         } else {
@@ -90,15 +110,19 @@ impl JobHandle {
     }
 
     /// Terminate every process in the job, then close the handle.
-    pub(crate) fn hard_kill(&self) {
-        if let Some(job) = self.take() {
-            // SAFETY: job is a valid handle we own; Win32 calls are safe.
-            unsafe {
-                if let Err(e) = TerminateJobObject(job, 1) {
-                    log::warn!("TerminateJobObject failed ({e}); the tree may still be running");
-                }
-                let _ = CloseHandle(job);
+    ///
+    /// Returns the `TerminateJobObject` failure rather than only logging it: a caller that is
+    /// told teardown succeeded while the tree is still running has no way to notice, and the
+    /// other containment mechanisms already report this.
+    pub(crate) fn hard_kill(&self) -> io::Result<()> {
+        let Some(job) = self.take() else { return Ok(()) };
+        // SAFETY: job is a valid handle we own; Win32 calls are safe.
+        unsafe {
+            let terminated = TerminateJobObject(job, 1).map_err(io::Error::from);
+            if let Err(e) = CloseHandle(job) {
+                log::warn!("CloseHandle on the job failed ({e}); the handle is leaked");
             }
+            terminated
         }
     }
 
@@ -106,34 +130,46 @@ impl JobHandle {
     /// Called by `Child::detach()` before the handle is released: otherwise
     /// dropping the job handle terminates the tree the caller intended to keep alive.
     pub(crate) fn disarm(&self) {
-        let p = self.raw.load(Ordering::Relaxed);
-        if p.is_null() {
-            return;
-        }
-        let job = HANDLE(p);
-        // A zeroed JOBOBJECT_EXTENDED_LIMIT_INFORMATION has LimitFlags == 0, which
-        // clears KILL_ON_JOB_CLOSE. Best-effort: if this call fails the handle close
-        // in Drop will still fire the kill — but that's an unlikely kernel failure.
-        let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-        // SAFETY: job is a valid handle; info is fully initialised (zeroed by default()).
-        unsafe {
-            if let Err(e) = SetInformationJobObject(
-                job,
-                JobObjectExtendedLimitInformation,
-                std::ptr::addr_of!(info).cast(),
-                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-            ) {
-                log::warn!(
-                    "SetInformationJobObject(disarm) failed ({e}); KILL_ON_JOB_CLOSE is still set, so \
-                     closing this handle will still kill the tree"
-                );
+        // Held across the call: this WRITES to the handle, so landing on a recycled value
+        // would clear KILL_ON_JOB_CLOSE on an unrelated job and quietly let its tree
+        // outlive its owner.
+        self.with_handle(|job| {
+            // A zeroed JOBOBJECT_EXTENDED_LIMIT_INFORMATION has LimitFlags == 0, which
+            // clears KILL_ON_JOB_CLOSE.
+            let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            // SAFETY: job is a valid handle; info is fully initialised (zeroed by default()).
+            unsafe {
+                if let Err(e) = SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    std::ptr::addr_of!(info).cast(),
+                    size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                ) {
+                    log::warn!(
+                        "SetInformationJobObject(disarm) failed ({e}); KILL_ON_JOB_CLOSE is still set, so \
+                         closing this handle will still kill the tree"
+                    );
+                }
             }
-        }
+        });
     }
 }
 
 #[cfg(all(windows, test))]
 impl JobHandle {
+    /// Test-only: read the handle without holding the lock across its use.
+    ///
+    /// Reintroduces the load-then-use gap that [`with_handle`](JobHandle::with_handle) exists
+    /// to close, so it is confined to tests, which do not race their own teardown.
+    pub(crate) fn as_handle(&self) -> Option<HANDLE> {
+        let p = self.peek();
+        if p.is_null() {
+            None
+        } else {
+            Some(HANDLE(p))
+        }
+    }
+
     /// Test-only: a real but empty job object (no process assigned). Cheap to create and
     /// cleanly closed on `Drop`; for variant-level assertions like
     /// `Attached::JobObject(_).is_actionable()`.
@@ -662,13 +698,22 @@ impl JobHandle {
         deadline: Option<Option<std::time::Instant>>,
         cancel: Option<HANDLE>,
     ) -> Result<crate::containment::TreeDrain, crate::error::Error> {
-        let Some(job) = self.as_handle() else {
+        // Duplicate under the lock, then wait on the duplicate. The wait can block for the
+        // whole deadline, and holding the lock for that long would stall `hard_kill`/`Drop`
+        // (and, with an unbounded deadline, forever). The duplicate is an independent
+        // reference to the same job, so closing the original elsewhere cannot invalidate it.
+        let Some(dup) = self.with_handle(crate::containment::job::duplicate_job).transpose()? else {
             // The job was already consumed — `hard_kill()` or `Drop` already ran, nulling `raw`
             // and closing the underlying handle. See `consumed_job_handle_error`'s own doc for
             // why that is reported as `Unassessable` rather than a guessed `AllMembersExited`.
             return Err(consumed_job_handle_error());
         };
-        wait_drained_raw(job, deadline, cancel)
+        let result = wait_drained_raw(dup, deadline, cancel);
+        // SAFETY: `dup` is ours alone and no longer in use.
+        unsafe {
+            let _ = CloseHandle(dup);
+        }
+        result
     }
 }
 
@@ -976,9 +1021,6 @@ pub(crate) fn job_contains_pid(attached: &crate::containment::Attached, pid: u32
     let crate::containment::Attached::JobObject(job) = attached else {
         return false;
     };
-    let Some(job_handle) = job.as_handle() else {
-        return false;
-    };
 
     // Open the child process by PID; the backend doesn't expose its handle.
     // SAFETY: standard Win32 call; the handle is closed below.
@@ -990,13 +1032,17 @@ pub(crate) fn job_contains_pid(attached: &crate::containment::Attached, pid: u32
     };
 
     let mut in_job = windows::core::BOOL(0);
-    // SAFETY: both handles are valid for the duration of the call.
-    let ok = unsafe { IsProcessInJob(process_handle, Some(job_handle), &mut in_job) };
+    // Lock held across the query so the job handle cannot be closed and its value recycled
+    // between the read and the call.
+    let queried = job.with_handle(|job_handle| {
+        // SAFETY: both handles are valid for the duration of the call.
+        unsafe { IsProcessInJob(process_handle, Some(job_handle), &mut in_job) }
+    });
     // SAFETY: `process_handle` was opened above and must be closed.
     unsafe {
         let _ = CloseHandle(process_handle);
     }
-    ok.is_ok() && in_job.as_bool()
+    matches!(queried, Some(Ok(()))) && in_job.as_bool()
 }
 
 #[cfg(test)]

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -992,8 +992,10 @@ pub(crate) fn attach_job(proc_handle: std::os::windows::io::RawHandle) -> io::Re
     // Resume REGARDLESS of job assignment result. A frozen child cannot be left running.
     if let Err(resume_err) = resume_initial_threads(proc_handle) {
         if let Ok(job) = job_result {
-            // Kill via the job first (catches any threads the walk may have missed).
-            job.hard_kill();
+            // Kill via the job first (catches any threads the walk may have missed). The
+            // resume failure is what gets reported; a kill failure on top of it is logged
+            // by `hard_kill` and cannot change the outcome here.
+            let _ = job.hard_kill();
         }
         return Err(resume_err);
     }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -94,7 +94,9 @@ impl JobHandle {
         if let Some(job) = self.take() {
             // SAFETY: job is a valid handle we own; Win32 calls are safe.
             unsafe {
-                let _ = TerminateJobObject(job, 1);
+                if let Err(e) = TerminateJobObject(job, 1) {
+                    log::warn!("TerminateJobObject failed ({e}); the tree may still be running");
+                }
                 let _ = CloseHandle(job);
             }
         }
@@ -115,12 +117,17 @@ impl JobHandle {
         let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
         // SAFETY: job is a valid handle; info is fully initialised (zeroed by default()).
         unsafe {
-            let _ = SetInformationJobObject(
+            if let Err(e) = SetInformationJobObject(
                 job,
                 JobObjectExtendedLimitInformation,
                 std::ptr::addr_of!(info).cast(),
                 size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-            );
+            ) {
+                log::warn!(
+                    "SetInformationJobObject(disarm) failed ({e}); KILL_ON_JOB_CLOSE is still set, so \
+                     closing this handle will still kill the tree"
+                );
+            }
         }
     }
 }
@@ -500,7 +507,11 @@ pub(crate) mod fault {
 }
 
 /// Create a `KILL_ON_JOB_CLOSE` job and assign the process at `proc_handle` to it.
-fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> io::Result<JobHandle> {
+///
+/// `pub(crate)`: also the sole constructor behind the public [`crate::containment::job::Job`]
+/// primitive — reused verbatim rather than duplicated, so `Command::contain()` and `Job::assign`
+/// share exactly one implementation.
+pub(crate) fn assign_to_kill_on_close_job(proc_handle: std::os::windows::io::RawHandle) -> io::Result<JobHandle> {
     // A Windows `RawHandle` is a `*mut c_void`.
     let raw_handle = HANDLE(proc_handle.cast());
     // SAFETY: all calls are standard Win32; owned handles are closed on every error path.
@@ -662,17 +673,17 @@ impl JobHandle {
 }
 
 /// The [`Error::Unassessable`](crate::error::Error::Unassessable) reported when a drain check
-/// finds the job handle already closed (`kill_tree()`/`hard_kill()`, or the `Child` was
-/// dropped): `TerminateJobObject`/`CloseHandle` are not documented as synchronous with member
+/// finds the job handle already closed (`kill_tree()`/`hard_kill()`, or the owning `Child`/`Job`
+/// was dropped): `TerminateJobObject`/`CloseHandle` are not documented as synchronous with member
 /// process teardown, so once the handle is gone there is no way left to ask whether every member
 /// has actually finished exiting — reporting `AllMembersExited` here would be a guess, not a
-/// live-checked verdict. Shared verbatim by `JobHandle::wait_drained`'s own early return and its
-/// tokio twin, `job_wait_tree_drained`.
+/// live-checked verdict. Shared verbatim by `JobHandle::wait_drained`'s own early return, its
+/// tokio twin `job_wait_tree_drained`, and the public [`crate::containment::job::Job`] wrapper.
 pub(crate) fn consumed_job_handle_error() -> crate::error::Error {
     crate::error::Error::Unassessable {
-        detail: "the job handle was already closed (kill_tree()/hard_kill(), or the Child was \
-                 dropped) before this drain check ran; whether every member has actually \
-                 finished exiting can no longer be observed"
+        detail: "the job handle was already closed (kill_tree()/hard_kill(), or the owning \
+                 Child/Job was dropped) before this drain check ran; whether every member has \
+                 actually finished exiting can no longer be observed"
             .into(),
         source: None,
     }

--- a/src/containment/windows.rs
+++ b/src/containment/windows.rs
@@ -702,7 +702,7 @@ impl JobHandle {
         // whole deadline, and holding the lock for that long would stall `hard_kill`/`Drop`
         // (and, with an unbounded deadline, forever). The duplicate is an independent
         // reference to the same job, so closing the original elsewhere cannot invalidate it.
-        let Some(dup) = self.with_handle(crate::containment::job::duplicate_job).transpose()? else {
+        let Some(dup) = self.with_handle(duplicate_job).transpose()? else {
             // The job was already consumed — `hard_kill()` or `Drop` already ran, nulling `raw`
             // and closing the underlying handle. See `consumed_job_handle_error`'s own doc for
             // why that is reported as `Unassessable` rather than a guessed `AllMembersExited`.
@@ -739,6 +739,35 @@ pub(crate) fn consumed_job_handle_error() -> crate::error::Error {
 /// before handing it to `spawn_blocking`, since a `'static` blocking closure cannot capture a
 /// borrow. Sound because the async caller holds `&JobHandle` (transitively, `&Child`) across the
 /// whole `spawn_blocking` `.await`, so the job handle cannot be closed while this runs.
+/// Duplicate a job handle. One implementation for all three duplicate-then-wait sites (the
+/// sync wait, the async wait, and `Job::wait_tree`); it lives here, next to `JobHandle`,
+/// rather than in `job.rs`, because the public wrapper depends on this module and not the
+/// other way round.
+///
+/// Call it as the closure passed to [`JobHandle::with_handle`], never on a handle returned
+/// out of one: the point is that the lock is still held while `DuplicateHandle` reads it.
+pub(crate) fn duplicate_job(handle: HANDLE) -> Result<HANDLE, crate::error::Error> {
+    use windows::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS};
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    let mut dup = HANDLE::default();
+    // SAFETY: `handle` is live for the duration of this call (borrowed from `self.0`, which
+    // outlives this function call); `dup` is an out-parameter DuplicateHandle initializes.
+    unsafe {
+        DuplicateHandle(
+            GetCurrentProcess(),
+            handle,
+            GetCurrentProcess(),
+            &mut dup,
+            0,
+            false,
+            DUPLICATE_SAME_ACCESS,
+        )
+    }
+    .map_err(io::Error::from)?;
+    Ok(dup)
+}
+
 pub(crate) fn wait_drained_raw(
     job: HANDLE,
     deadline: Option<Option<std::time::Instant>>,
@@ -782,7 +811,24 @@ pub(crate) fn wait_drained_raw(
         for pid in pids.iter().take(budget) {
             // SAFETY: standard Win32 call; the handle is closed below on every path.
             match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, *pid) } {
-                Ok(h) => handles.push(h),
+                // A pid enumerated a moment ago can have exited and had its number reused by
+                // the time it is opened, so membership is re-confirmed against the job rather
+                // than assumed. Waiting on a bystander would either hang the drain (it outlives
+                // the tree) or, if it exits first, report the tree drained while members run.
+                Ok(h) => {
+                    use windows::Win32::System::JobObjects::IsProcessInJob;
+                    let mut in_job = windows::core::BOOL(0);
+                    // SAFETY: both handles are valid for the duration of the call.
+                    let confirmed = unsafe { IsProcessInJob(h, Some(job), &mut in_job) };
+                    if confirmed.is_ok() && in_job.as_bool() {
+                        handles.push(h);
+                    } else {
+                        // SAFETY: opened just above and not stored anywhere.
+                        unsafe {
+                            let _ = CloseHandle(h);
+                        }
+                    }
+                }
                 // ERROR_INVALID_PARAMETER: the pid no longer names a process — it exited in
                 // the race between the enumeration above and this open. That is real
                 // progress (this round's tree is shrinking), not a failure: loop back to
@@ -993,9 +1039,11 @@ pub(crate) fn attach_job(proc_handle: std::os::windows::io::RawHandle) -> io::Re
     if let Err(resume_err) = resume_initial_threads(proc_handle) {
         if let Ok(job) = job_result {
             // Kill via the job first (catches any threads the walk may have missed). The
-            // resume failure is what gets reported; a kill failure on top of it is logged
-            // by `hard_kill` and cannot change the outcome here.
-            let _ = job.hard_kill();
+            // resume failure is what gets reported; a kill failure on top of it cannot change
+            // that outcome, so it is logged here rather than swallowed.
+            if let Err(e) = job.hard_kill() {
+                log::warn!("job kill after a failed resume also failed ({e}); the tree may still be running");
+            }
         }
         return Err(resume_err);
     }

--- a/src/containment/windows_tests.rs
+++ b/src/containment/windows_tests.rs
@@ -11,7 +11,7 @@ fn job_handle_debug_does_not_panic() {
     // a `JobHandle`.
     use super::JobHandle;
     let h = JobHandle::create_empty_for_test();
-    h.hard_kill();
+    h.hard_kill().expect("hard_kill on a live job");
     let s = format!("{h:?}");
     assert!(s.contains("JobHandle"), "debug output: {s}");
 }
@@ -24,7 +24,7 @@ fn job_handle_debug_does_not_panic() {
 fn wait_drained_on_a_consumed_handle_is_unassessable() {
     use super::JobHandle;
     let h = JobHandle::create_empty_for_test();
-    h.hard_kill();
+    h.hard_kill().expect("hard_kill on a live job");
     let err = h
         .wait_drained(Some(None), None)
         .expect_err("a consumed job handle must not report a live drain verdict");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod graceful;
 pub mod identity;
 pub mod quote;
 pub mod stdio;
+#[cfg(windows)]
+pub use containment::Job;
 pub use containment::{ContainMode, Containment};
 pub use elevation::{Auth, Backend, ElevatedStdio, ElevatedVia, ElevationReport, EnvSanitizer, Privilege, Secret};
 pub use graceful::GracefulMechanism;

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -435,7 +435,10 @@ async fn job_wait_tree_drained(
     if crate::wait::remaining(deadline) == Some(std::time::Duration::ZERO) {
         return job.wait_drained(deadline, None);
     }
-    let Some(raw_job) = job.as_handle() else {
+    // Read under the lock: the duplicate below must be taken from a handle that cannot be
+    // closed — and its value recycled onto an unrelated object — between the read and the
+    // `DuplicateHandle` call.
+    let Some(raw_job) = job.with_handle(|h| h) else {
         // Mirrors `JobHandle::wait_drained`'s own early return exactly (this function only
         // reaches here once that method's Duration::ZERO delegation above has already been
         // ruled out) — see `consumed_job_handle_error`'s own doc for the full justification.

--- a/src/tokio/wait.rs
+++ b/src/tokio/wait.rs
@@ -427,24 +427,13 @@ async fn job_wait_tree_drained(
     job: &crate::containment::windows::JobHandle,
     deadline: Option<Option<std::time::Instant>>,
 ) -> Result<crate::containment::TreeDrain, Error> {
-    use windows::Win32::Foundation::{CloseHandle, DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
-    use windows::Win32::System::Threading::GetCurrentProcess;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
 
     // Duration::ZERO delegates to the sync one-shot probe — no thread-pool hop needed for a
     // call that cannot block (mirrors grace_wait's identical delegation).
     if crate::wait::remaining(deadline) == Some(std::time::Duration::ZERO) {
         return job.wait_drained(deadline, None);
     }
-    // Read under the lock: the duplicate below must be taken from a handle that cannot be
-    // closed — and its value recycled onto an unrelated object — between the read and the
-    // `DuplicateHandle` call.
-    let Some(raw_job) = job.with_handle(|h| h) else {
-        // Mirrors `JobHandle::wait_drained`'s own early return exactly (this function only
-        // reaches here once that method's Duration::ZERO delegation above has already been
-        // ruled out) — see `consumed_job_handle_error`'s own doc for the full justification.
-        return Err(crate::containment::windows::consumed_job_handle_error());
-    };
-
     /// An independently-owned duplicate of the job handle, held only by the spawned blocking
     /// task and closed by it on every exit path, panic included — see this function's own doc
     /// for why a borrowed handle is not safe to hand across the cancellation boundary here.
@@ -460,23 +449,20 @@ async fn job_wait_tree_drained(
             }
         }
     }
-    let mut dup = HANDLE::default();
-    // SAFETY: `raw_job` was just confirmed live via `job.as_handle()` above. Duplicating
-    // within our own process with `DUPLICATE_SAME_ACCESS` produces an independent handle to
-    // the same job object, valid for the spawned task's full lifetime regardless of what
-    // happens to `job`/`JobHandle` afterward.
-    unsafe {
-        DuplicateHandle(
-            GetCurrentProcess(),
-            raw_job,
-            GetCurrentProcess(),
-            &mut dup,
-            0,
-            false,
-            DUPLICATE_SAME_ACCESS,
-        )
-    }
-    .map_err(|e| Error::Io(std::io::Error::from(e)))?;
+
+    // Duplicate INSIDE the closure, so the lock is still held when `DuplicateHandle` reads the
+    // handle. Returning the handle out of `with_handle` first would release the guard before
+    // the call — leaving the load-then-use gap this is meant to close — and Windows recycles a
+    // closed handle's value onto unrelated kernel objects.
+    let Some(dup) = job
+        .with_handle(crate::containment::windows::duplicate_job)
+        .transpose()?
+    else {
+        // Mirrors `JobHandle::wait_drained`'s own early return exactly (this function only
+        // reaches here once that method's Duration::ZERO delegation above has already been
+        // ruled out) — see `consumed_job_handle_error`'s own doc for the full justification.
+        return Err(crate::containment::windows::consumed_job_handle_error());
+    };
     let job_dup = OwnedJobDup(dup);
 
     /// Signals the cancel event on drop (harmless after completion) so the blocking watcher

--- a/testbin/main.rs
+++ b/testbin/main.rs
@@ -295,6 +295,23 @@ fn main() {
             let mut buf = [0u8; 1];
             let _ = sock.read(&mut buf);
         }
+        "spawn-grandchild-echo" => {
+            // Like spawn-grandchild, but both levels round-trip a byte (`control-echo-pid`)
+            // instead of merely holding the socket open. `control-block`'s EOF-on-death is
+            // proof of death, never proof of life (a still-alive peer produces no EOF either
+            // way); a test that must prove a descendant is POSITIVELY alive — e.g. that
+            // `disarm()` left the tree running rather than merely "hasn't been reaped yet" —
+            // needs the real round trip this mode gives both members.
+            let addr = args[2].clone();
+            let exe = std::env::current_exe().unwrap();
+            #[allow(clippy::zombie_processes)]
+            // intentional: grandchild must outlive us; containment (or not) decides its fate
+            let _gc = std::process::Command::new(exe)
+                .args(["control-echo-pid", &addr, "G"])
+                .spawn()
+                .unwrap();
+            run_control_echo_pid(&addr, "R");
+        }
         #[cfg(unix)]
         "spawn-grandchild-setuid" => {
             // Like spawn-grandchild, but the grandchild is a SEPARATE, pre-provisioned

--- a/tests/windows_job_object.rs
+++ b/tests/windows_job_object.rs
@@ -257,3 +257,22 @@ fn disarm_leaves_every_descendant_running() {
     grand_member.sock.shutdown(std::net::Shutdown::Both).ok();
     drop(root);
 }
+
+/// Dropping a live `Job` reaps the tree, exactly as `kill_tree` does.
+///
+/// This is the path a caller reaches by doing nothing, and it is the one the `#[must_use]` on
+/// `assign` warns about — so it needs coverage of its own rather than being inferred from
+/// `kill_tree`'s. The distinction matters: `kill_tree` terminates explicitly, whereas this
+/// relies on `KILL_ON_JOB_CLOSE` firing when the last handle closes.
+#[test]
+fn dropping_a_live_job_reaps_every_descendant() {
+    let (root, job, mut root_member, mut grand_member) = spawn_contained_tree();
+    root_member.assert_alive("the root, before drop");
+    grand_member.assert_alive("the grandchild, before drop");
+
+    drop(job);
+
+    root_member.assert_dead("the root, after dropping the Job");
+    grand_member.assert_dead("the grandchild, after dropping the Job");
+    drop(root);
+}

--- a/tests/windows_job_object.rs
+++ b/tests/windows_job_object.rs
@@ -21,11 +21,30 @@ use windows::Win32::System::Threading::{
     CreateProcessW, ResumeThread, TerminateProcess, CREATE_SUSPENDED, PROCESS_INFORMATION, STARTUPINFOW,
 };
 
-/// One tree member's control channel: its pid, and the socket that proves it alive or dead.
+/// One tree member's control channel: its pid, the socket that proves it alive or dead, and
+/// an owned handle opened while it was provably alive.
+///
+/// The handle is what makes cleanup safe. Terminating by pid alone races the member's own
+/// exit: Windows recycles a dead process's pid, so a pid read at handshake time can name an
+/// unrelated process by the time a test tears down — and on a shared CI runner that is
+/// someone else's process. An open handle pins the pid for as long as it is held, so the
+/// terminate can only ever land on the intended member.
+///
 /// Mirrors `tests/macos_fdmarker.rs`'s `Member`.
 struct Member {
     pid: u32,
     sock: TcpStream,
+    process: HANDLE,
+}
+
+impl Drop for Member {
+    fn drop(&mut self) {
+        // SAFETY: `process` is this struct's own handle, opened once and closed only here.
+        unsafe {
+            let _ = TerminateProcess(self.process, 1);
+            let _ = CloseHandle(self.process);
+        }
+    }
 }
 
 impl Member {
@@ -174,10 +193,19 @@ fn spawn_contained_tree() -> (Suspended, cosca::Job, Member, Member) {
             .read_line(&mut line)
             .expect("read tag+pid");
         let (tag, pid) = line.trim().split_at(1);
-        let m = Member {
-            pid: pid.parse().expect("member pid"),
-            sock: s,
+        let pid: u32 = pid.parse().expect("member pid");
+        // Opened here, while the handshake proves the member alive — see `Member`'s doc for
+        // why a pid captured now cannot be trusted at teardown.
+        // SAFETY: standard Win32 call; the handle is closed by `Member::drop`.
+        let process = unsafe {
+            windows::Win32::System::Threading::OpenProcess(
+                windows::Win32::System::Threading::PROCESS_TERMINATE,
+                false,
+                pid,
+            )
+            .expect("open the member that just completed its handshake")
         };
+        let m = Member { pid, sock: s, process };
         match tag {
             "R" => root_member = Some(m),
             "G" => grand_member = Some(m),
@@ -222,21 +250,10 @@ fn disarm_leaves_every_descendant_running() {
     root_member.assert_alive("the root, after disarm + drop(Job)");
     grand_member.assert_alive("the grandchild, after disarm + drop(Job)");
 
-    // Cleanup: `Suspended::drop` only reaches the root; the grandchild survives it (a disarmed
-    // job, by design, is no longer this test's tool for reaching it) so it is torn down
-    // directly via its own pid.
+    // Cleanup: `Suspended::drop` only reaches the root; the grandchild survives it, because a
+    // disarmed job is by design no longer this test's tool for reaching it. `Member::drop`
+    // terminates each through its own pinned handle.
     root_member.sock.shutdown(std::net::Shutdown::Both).ok();
     grand_member.sock.shutdown(std::net::Shutdown::Both).ok();
     drop(root);
-    // SAFETY: `grand_member.pid` was just read from the process's own live handshake above.
-    unsafe {
-        if let Ok(h) = windows::Win32::System::Threading::OpenProcess(
-            windows::Win32::System::Threading::PROCESS_TERMINATE,
-            false,
-            grand_member.pid,
-        ) {
-            let _ = TerminateProcess(h, 1);
-            let _ = CloseHandle(h);
-        }
-    }
 }

--- a/tests/windows_job_object.rs
+++ b/tests/windows_job_object.rs
@@ -1,0 +1,242 @@
+//! The public `cosca::Job` primitive, end to end: a caller that spawns its own process via a raw
+//! `CreateProcessW` (never going through `cosca::Command`) follows the mandatory
+//! suspend/assign/resume sequence from `cosca::Job`'s own docs, and the kernel guarantee that
+//! buys must actually hold — every descendant, including a grandchild the root spawns AFTER
+//! being resumed, is genuinely reachable through the job.
+//!
+//! Both required behaviors need a real, provably-alive descendant tree, not merely "hasn't been
+//! reaped yet": `control-block`'s EOF-on-death is proof of death, never proof of life. Both
+//! members here run the testbin's `control-echo-pid` round-trip (via `spawn-grandchild-echo`),
+//! mirroring `tests/macos_fdmarker.rs`'s `Member` (alive = a real write/read round trip; dead =
+//! EOF/reset on a socket the test itself still holds).
+#![cfg(windows)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::windows::io::{BorrowedHandle, RawHandle};
+
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::Threading::{
+    CreateProcessW, ResumeThread, TerminateProcess, CREATE_SUSPENDED, PROCESS_INFORMATION, STARTUPINFOW,
+};
+
+/// One tree member's control channel: its pid, and the socket that proves it alive or dead.
+/// Mirrors `tests/macos_fdmarker.rs`'s `Member`.
+struct Member {
+    pid: u32,
+    sock: TcpStream,
+}
+
+impl Member {
+    /// Alive, proven positively: a byte in, the same byte back. A dead member EOFs instead.
+    fn assert_alive(&mut self, who: &str) {
+        self.sock.write_all(b"x").expect("write to the control socket");
+        let mut b = [0u8; 1];
+        let n = self.sock.read(&mut b).expect("read the control socket");
+        assert_eq!(n, 1, "{who} (pid {}) must still be alive and echoing", self.pid);
+        assert_eq!(&b, b"x", "{who} echoed {b:?} instead of the byte sent");
+    }
+
+    /// Dead, proven by a write failure OR a read failure/EOF on a socket the test still holds.
+    fn assert_dead(&mut self, who: &str) {
+        if self.sock.write_all(b"x").is_err() {
+            return; // the peer already closed its end: dead, as expected
+        }
+        let mut b = [0u8; 1];
+        match self.sock.read(&mut b) {
+            Ok(0) => {} // EOF: dead, as expected
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
+                ) =>
+            {
+                // the kernel resolved the race the other way (RST before FIN): also dead
+            }
+            Ok(n) => panic!("{who} (pid {}) must be dead; it echoed {n} byte(s) instead", self.pid),
+            Err(e) => panic!("{who} (pid {}): unexpected control-socket error: {e}", self.pid),
+        }
+    }
+}
+
+/// A process created `CREATE_SUSPENDED` via a raw `CreateProcessW` call — never through
+/// `cosca::Command` — so the test genuinely exercises the caller sequence `cosca::Job`'s docs
+/// describe: create suspended, assign, only then resume.
+struct Suspended {
+    process: HANDLE,
+    thread: HANDLE,
+    pid: u32,
+}
+
+impl Suspended {
+    /// Spawn `exe` with `args` (argv[1..]), suspended. The command line is built with
+    /// `cosca::quote::windows::join_wide` rather than hand-rolled quoting.
+    fn spawn(exe: &str, args: &[&str]) -> Suspended {
+        let wide_args: Vec<Vec<u16>> = std::iter::once(exe)
+            .chain(args.iter().copied())
+            .map(|a| a.encode_utf16().collect())
+            .collect();
+        let refs: Vec<&[u16]> = wide_args.iter().map(Vec::as_slice).collect();
+        let mut cmdline = cosca::quote::windows::join_wide(&refs);
+        cmdline.push(0); // CreateProcessW requires a NUL-terminated, writable buffer.
+
+        let si = STARTUPINFOW {
+            cb: std::mem::size_of::<STARTUPINFOW>() as u32,
+            ..Default::default()
+        };
+        let mut pi = PROCESS_INFORMATION::default();
+        // Serialized against the crate's own inheritable-handle window, exactly like
+        // `tests/windows_console_identity.rs`'s `probe_raw` — a raw spawn that bypasses
+        // `cosca::Command` entirely still needs to be ordered against it.
+        let created = {
+            let _guard = cosca::test_spawn_lock();
+            // SAFETY: `cmdline` is a NUL-terminated, writable UTF-16 buffer; `si`/`pi` are
+            // valid, correctly-sized in/out params; no handles are inherited.
+            unsafe {
+                CreateProcessW(
+                    None,
+                    Some(PWSTR(cmdline.as_mut_ptr())),
+                    None,
+                    None,
+                    false,
+                    CREATE_SUSPENDED,
+                    None,
+                    None,
+                    &si,
+                    &mut pi,
+                )
+            }
+        };
+        created.expect("CreateProcessW(CREATE_SUSPENDED)");
+        Suspended {
+            process: pi.hProcess,
+            thread: pi.hThread,
+            pid: pi.dwProcessId,
+        }
+    }
+
+    /// Borrow the process handle for [`cosca::Job::assign`]. The borrow does not outlive this
+    /// call; `Suspended` keeps owning (and eventually closing) the real handle.
+    fn borrow_process(&self) -> BorrowedHandle<'_> {
+        let raw: RawHandle = self.process.0;
+        // SAFETY: `self.process` is a live handle owned by `self`, which outlives this borrow.
+        unsafe { BorrowedHandle::borrow_raw(raw) }
+    }
+
+    /// Resume the (single) initial thread. Must only be called after the process has been
+    /// assigned to a job — see `cosca::Job`'s mandatory sequence.
+    fn resume(&mut self) {
+        // SAFETY: `self.thread` is the live, still-suspended main thread from `CreateProcessW`.
+        let prev = unsafe { ResumeThread(self.thread) };
+        assert_eq!(
+            prev, 1,
+            "pid {}: a CREATE_SUSPENDED process's main thread must resume from exactly one suspend",
+            self.pid
+        );
+    }
+}
+
+impl Drop for Suspended {
+    fn drop(&mut self) {
+        // Best-effort cleanup: whether the tree is contained, disarmed, or already dead by the
+        // time a test ends, nothing should be left running past it. `TerminateProcess` on an
+        // already-exited process is a harmless failure.
+        // SAFETY: `self.process`/`self.thread` are live, owned handles.
+        unsafe {
+            let _ = TerminateProcess(self.process, 1);
+            let _ = CloseHandle(self.thread);
+            let _ = CloseHandle(self.process);
+        }
+    }
+}
+
+/// Spawn the testbin's `spawn-grandchild-echo` tree, contained: create the root suspended,
+/// assign it to a fresh `cosca::Job`, resume it, then demux both members' `<tag><pid>\n`
+/// handshakes by tag. The grandchild is spawned by the ROOT after resume — proving the job
+/// reaches a descendant this test process never itself created or assigned.
+fn spawn_contained_tree() -> (Suspended, cosca::Job, Member, Member) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr").to_string();
+
+    let mut root = Suspended::spawn(env!("CARGO_BIN_EXE_cosca_testbin"), &["spawn-grandchild-echo", &addr]);
+    // Step 1 (spawn suspended) already happened above. Step 2: assign, while still frozen.
+    let job = cosca::Job::assign(root.borrow_process()).expect("Job::assign");
+    // Step 3: only now resume.
+    root.resume();
+
+    let mut root_member = None;
+    let mut grand_member = None;
+    for _ in 0..2 {
+        let (s, _) = listener.accept().expect("accept");
+        let mut line = String::new();
+        BufReader::new(s.try_clone().expect("clone"))
+            .read_line(&mut line)
+            .expect("read tag+pid");
+        let (tag, pid) = line.trim().split_at(1);
+        let m = Member {
+            pid: pid.parse().expect("member pid"),
+            sock: s,
+        };
+        match tag {
+            "R" => root_member = Some(m),
+            "G" => grand_member = Some(m),
+            other => panic!("unexpected tree tag {other:?}"),
+        }
+    }
+    (
+        root,
+        job,
+        root_member.expect("root tag"),
+        grand_member.expect("grandchild tag"),
+    )
+}
+
+/// The contract this whole primitive exists for: a caller that spawns its own process
+/// (suspend/assign/resume, never `cosca::Command`) still gets the full kernel guarantee —
+/// `kill_tree()` reaps every descendant, including one the root spawned after being resumed.
+#[test]
+fn kill_tree_reaps_every_descendant() {
+    let (_root, job, mut root_member, mut grand_member) = spawn_contained_tree();
+    root_member.assert_alive("the root, before teardown");
+    grand_member.assert_alive("the grandchild, before teardown");
+
+    job.kill_tree().expect("kill_tree");
+
+    root_member.assert_dead("the root, after kill_tree");
+    grand_member.assert_dead("the grandchild, after kill_tree");
+}
+
+/// The other half of the contract: `disarm()` is "session ended normally, leave background
+/// processes alone" — dropping (or having already dropped) the `Job` afterward must not kill
+/// anything, for the whole tree, not just the root.
+#[test]
+fn disarm_leaves_every_descendant_running() {
+    let (root, job, mut root_member, mut grand_member) = spawn_contained_tree();
+    root_member.assert_alive("the root, before disarm");
+    grand_member.assert_alive("the grandchild, before disarm");
+
+    job.disarm();
+    drop(job);
+
+    root_member.assert_alive("the root, after disarm + drop(Job)");
+    grand_member.assert_alive("the grandchild, after disarm + drop(Job)");
+
+    // Cleanup: `Suspended::drop` only reaches the root; the grandchild survives it (a disarmed
+    // job, by design, is no longer this test's tool for reaching it) so it is torn down
+    // directly via its own pid.
+    root_member.sock.shutdown(std::net::Shutdown::Both).ok();
+    grand_member.sock.shutdown(std::net::Shutdown::Both).ok();
+    drop(root);
+    // SAFETY: `grand_member.pid` was just read from the process's own live handshake above.
+    unsafe {
+        if let Ok(h) = windows::Win32::System::Threading::OpenProcess(
+            windows::Win32::System::Threading::PROCESS_TERMINATE,
+            false,
+            grand_member.pid,
+        ) {
+            let _ = TerminateProcess(h, 1);
+            let _ = CloseHandle(h);
+        }
+    }
+}


### PR DESCRIPTION
Closes #131.

`Containment::JobObject` was only reachable through `Command::contain()`. A caller that needs a proc-thread attribute `Command` cannot model — `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` for a pseudoconsole host being the concrete case — had to create the process itself and got no containment at all.

`Job` exposes the primitive directly: create the process suspended, assign it, resume it.

## Single implementation

`Job::assign` calls the same `assign_to_kill_on_close_job` that `Command::contain()` uses, reused verbatim rather than duplicated, so there is exactly one place that sets `KILL_ON_JOB_CLOSE` and assigns.

## The race is the caller's to close, so the docs say so plainly

A member must be inside the job before executing any instruction, or a fast-forking grandchild escapes. This crate cannot enforce that across an FFI boundary it does not own, so the type-level docs spell out the mandatory sequence, and `assign`'s error path states that on `Err` the process was never assigned and **must not be resumed**.

## API

| | |
|---|---|
| `Job::assign(BorrowedHandle)` | borrows the process handle — does not close, wait on, or resume it |
| `kill_tree` | terminate every member, then close |
| `disarm` | clear `KILL_ON_JOB_CLOSE` so the tree outlives the `Job` |
| `wait_tree` / `wait_tree_timeout` | drain, unbounded or bounded |

`assign` is `#[must_use]` with a message naming the hazard: dropping the returned `Job` immediately kills the tree just assigned to it.

`disarm` is the "session ended normally, leave background processes alone" path, the opposite of `kill_tree`'s "peer disconnected, reap everything" — a consumer needs both to distinguish those cases.

## Two details worth flagging

- **`wait_tree` waits on a `DuplicateHandle` of the job, not the live handle.** The wait can block for the whole deadline, and a concurrent `kill_tree`/`disarm`/`Drop` on `&self` from another thread must not invalidate the handle underneath it — a closed Windows handle's numeric value can be recycled onto an unrelated kernel object.
- **`kill_tree` cannot be followed by a meaningful `wait_tree`.** `TerminateJobObject`/`CloseHandle` are not documented as synchronous with member teardown, and once the handle is closed there is nothing left to watch. Callers needing the drain outcome must wait first. Documented on the method.

Also turns two previously-ignored Win32 failures in `JobHandle` (`TerminateJobObject`, and the `SetInformationJobObject` behind `disarm`) into warnings, since silently failing to disarm means a drop still kills a tree the caller meant to keep.

## Driver

ssh-broker relays a shell from a Windows interactive session. Its EXEC path can use `Command::contain()`; its PTY path spawns into a pseudoconsole and cannot. Without this it keeps a hand-rolled job object — the re-roll this crate exists to absorb (cf. #20).