### PR TITLE
build: publish 0.4.0 to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "cosca"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "command-fds",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosca"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Anna Zhukova"]
 description = "Unified cross-platform subprocess management: spawning, stdio, process trees, stable identity, and elevation."


### PR DESCRIPTION
Closes #133.

Bumps `Cargo.toml` + `Cargo.lock` to 0.4.0. Minor: two additive features since v0.3.0 (#130 `quote::windows::split_wide`, #132 the public `Job` containment primitive), matching the convention used for 0.3.0.

One behaviour change, not an API break: the Job Object mechanism used to swallow `TerminateJobObject` failure and report clean teardown. `Child::kill_tree` now propagates it, as `FdMarker` and `TreeWalk` always did. Callers ignoring the `Err` arm are unaffected; callers handling it may see a failure they were previously told had not happened.

Unblocks bindreams/ssh-broker#5 and #10, which need `Job` and `split_wide` from crates.io rather than a git rev.